### PR TITLE
Add God-gated Deploy link to the navbar Portal dropdown

### DIFF
--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -255,6 +255,16 @@
                                         </svg>
                                     </a>
                                 </li>
+        {% if user.is_god %}
+                                <li class="nav-item" title="Deploy">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'deploy' %}#deploy">
+                                        <svg class="bi" aria-hidden="true">
+                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use>
+                                        </svg>
+                                        Deploy
+                                    </a>
+                                </li>
+        {% endif %}
                                 <li class="nav-item">
                                     <hr class="dropdown-divider">
                                 </li>


### PR DESCRIPTION
## Why

The web deploy page (#1754 in ishar-mud) is God-gated and works, but it was only linked from the portal **card** (`apps/accounts/templates/portal.html`). The navbar **"Portal" dropdown** (`apps/core/templates/layout.html`) — the one visible on every page, where Administration and Feedback Triage live — had **no Deploy entry**, so a God had to type `/portal/deploy` by hand.

## Change

`apps/core/templates/layout.html` — add a `{% if user.is_god %}` Deploy `<li>` (rocket-takeoff icon) inside the existing `{% if user.is_staff %}` admin cluster, right after Administration and before the divider, mirroring the Feedback Triage entry.

Resulting dropdown:
- **God**: Administration → **Deploy** → divider → Challenges → Feedback Triage → …
- **Eternal/Forger** (staff, not God): Administration → divider → … (no Deploy)
- **Mortal**: no admin items

Gating matches the page itself (`GodRequiredMixin` / `is_god()` → `immortal_level >= 5`), so the link only appears for accounts that can actually use it. The portal card already had the link, so it's unchanged.

## Verify

- `layout.html` compiles cleanly via the Django template engine (if/endif + tags balanced).
- Redeploy `ishar-web` to pick it up.

Relates to #1754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01885fxjvTmiRWtPTEG54TSg)_