### PR TITLE
Deploy Console — first-class admin redesign + reusable admin-console design language

### DIFF
--- a/apps/accounts/templates/deploy.html
+++ b/apps/accounts/templates/deploy.html
@@ -1,9 +1,13 @@
 {% extends "layout.html" %}
 {% load static %}
-{% block meta_title %}{{ WEBSITE_TITLE }} Deploy{% endblock meta_title %}
-{% block meta_description %}God-only deploy controls for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Deploy Console{% endblock meta_title %}
+{% block meta_description %}God-only deploy console for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
 {% block meta_url %}{% url 'deploy' %}#deploy{% endblock meta_url %}
-{% block title %}{{ WEBSITE_TITLE }} Deploy{% endblock title %}
+{% block title %}{{ WEBSITE_TITLE }} Deploy Console{% endblock title %}
+{% block scripts %}let focusTo = 'deploy'{% endblock scripts %}
+{% block includes %}
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
+{% endblock includes %}
 {% block breadcrumbs %}
     <li class="breadcrumb-item h2" title="Portal">
         <a class="icon-link icon-link-hover" href="{% url 'portal' %}#portal">
@@ -23,99 +27,152 @@
     </li>
 {% endblock breadcrumbs %}
 {% block content %}
-<div class="card border-0">
-    <div class="card-body">
-        <h2 class="text-ishar" title="Deploy">
-            <svg class="bi" aria-hidden="true" width="32" height="32">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use>
-            </svg>
-            Deploy
-        </h2>
-        <p class="lead">
-            Rebuild and restart the game stack on the host. This runs
-            <code>deploy.sh</code> on the server &mdash; use with care.
-        </p>
+<div class="ac">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">
+            <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use></svg>
+        </span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Deploy Console</h2>
+            <p class="ac-hero__sub">
+                Rebuild &amp; restart the stack on the host — runs <code>deploy.sh</code> through the deploy agent.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+{% if deploy_configured %}
+            <span class="ac-pill ac-pill--status ac-pill--muted ac-pill--live" id="agentPill" title="Deploy agent status">
+                checking agent…
+            </span>
+{% else %}
+            <span class="ac-pill ac-pill--status ac-pill--muted" id="agentPill" title="Deploy agent status">
+                not configured
+            </span>
+{% endif %}
+        </div>
+    </header>
 
 {% if not deploy_configured %}
-        <div class="alert alert-warning" role="alert">
-            The deploy agent is <strong>not configured</strong>
-            (<code>DEPLOY_AGENT_SECRET</code> is unset). Deploys are disabled.
-        </div>
+    <div class="ac-note ac-note--warn" role="alert">
+        <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#exclamation-triangle"></use></svg>
+        <span><strong>Agent not configured.</strong> <code>DEPLOY_AGENT_SECRET</code> is unset, so deploys are
+        disabled. Set it on the host agent (<code>/etc/ishar/deploy-agent.env</code>) and in this container's
+        environment to enable the console.</span>
+    </div>
 {% endif %}
 
-        <form id="deployForm" onsubmit="return false;">
+    <form id="deployForm" onsubmit="return false;">
 
-            <fieldset class="mb-3">
-                <legend class="h5">Environment</legend>
+        <!-- Environment -->
+        <div class="ac-panel">
+            <div class="ac-panel__h">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#hdd-network"></use></svg>
+                Environment
+            </div>
+            <div class="ac-seg" role="radiogroup" aria-label="Environment">
     {% for env in deploy_envs %}
-                <div class="form-check">
-                    <input class="form-check-input" type="radio" name="env"
-                           id="env-{{ env }}" value="{{ env }}"
-                           {% if env == "prod" %}checked{% endif %}>
-                    <label class="form-check-label" for="env-{{ env }}">{{ env }}</label>
-                </div>
+                <input class="btn-check" type="radio" name="env" id="env-{{ env }}" value="{{ env }}" autocomplete="off"{% if env == "prod" %} checked{% endif %}>
+                <label class="ac-seg__item ac-seg__item--{{ env }}" for="env-{{ env }}">
+                    <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{% if env == 'prod' %}hdd-stack{% else %}cone-striped{% endif %}"></use></svg>
+                    {{ env }}
+                </label>
     {% endfor %}
-            </fieldset>
+            </div>
+        </div>
 
-            <fieldset class="mb-3">
-                <legend class="h5">Services</legend>
-                <p class="text-secondary small mb-2">
-                    Leave all unchecked to deploy every service
-                    (<code>ishar-db</code> is never touched).
-                </p>
+        <!-- Services -->
+        <div class="ac-panel">
+            <div class="ac-panel__h">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#hdd-rack"></use></svg>
+                Services
+            </div>
+            <p class="ac-panel__hint">
+                Select what to (re)deploy. Nothing selected = <strong>all services</strong>.
+                <code>ishar-db</code> is never touched.
+            </p>
+            <div class="ac-grid">
     {% for service in deploy_services %}
-                <div class="form-check">
-                    <input class="form-check-input service-check" type="checkbox"
-                           name="services" id="svc-{{ service }}" value="{{ service }}"
-                           {% if service == "ishar-app" %}checked{% endif %}>
-                    <label class="form-check-label" for="svc-{{ service }}">{{ service }}</label>
-                </div>
+                <input class="btn-check service-check" type="checkbox" name="services" id="svc-{{ service }}" value="{{ service }}" autocomplete="off"{% if service == "ishar-app" %} checked{% endif %}>
+                <label class="ac-toggle" for="svc-{{ service }}">
+                    <span class="ac-toggle__icon">
+                        <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{% if service == 'ishar-app' %}controller{% elif service == 'ishar-web' %}globe2{% elif service == 'ishar-feedback-bridge' %}chat-left-dots{% else %}box{% endif %}"></use></svg>
+                    </span>
+                    <span class="ac-toggle__body">
+                        <span class="ac-toggle__name">{{ service }}</span>
+                        <span class="ac-toggle__note">{% if service == 'ishar-app' %}Game server · blue-green, no player drop{% elif service == 'ishar-web' %}Website · restarts this page{% elif service == 'ishar-feedback-bridge' %}Discord → feedback bridge{% else %}Service{% endif %}</span>
+                    </span>
+                    <span class="ac-toggle__check">
+                        <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#check-circle-fill"></use></svg>
+                    </span>
+                </label>
     {% endfor %}
-            </fieldset>
-
-            <div class="alert alert-warning d-none" id="selfDeployWarning" role="alert">
-                <strong>Heads up:</strong> deploying <code>ishar-web</code> restarts the
-                container serving <em>this page</em>. The status panel will freeze
-                mid-deploy &mdash; the host audit log is the source of truth.
             </div>
 
-            <div class="form-check mb-3">
-                <input class="form-check-input" type="checkbox" name="no_pull" id="no_pull" value="1">
-                <label class="form-check-label" for="no_pull">
-                    <code>--no-pull</code> (deploy the current checkout, skip <code>git pull</code>)
+            <div class="ac-note ac-note--warn mt-3 d-none" id="selfDeployWarning" role="alert">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#exclamation-triangle"></use></svg>
+                <span><strong>Heads up —</strong> deploying <code>ishar-web</code> restarts the container serving <em>this page</em>. The console will freeze mid-deploy; the host audit log is the source of truth.</span>
+            </div>
+        </div>
+
+        <!-- Options + confirm -->
+        <div class="ac-panel">
+            <div class="ac-panel__h">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#sliders"></use></svg>
+                Options
+            </div>
+
+            <div class="form-check form-switch ac-switch mb-3">
+                <input class="form-check-input" type="checkbox" role="switch" name="no_pull" id="no_pull" value="1">
+                <label class="form-check-label ac-switch__text" for="no_pull">
+                    <code>--no-pull</code>
+                    <span class="ac-switch__note d-block">Deploy the current checkout, skip <code>git pull</code>.</span>
                 </label>
             </div>
 
-            <div class="mb-3">
-                <label for="password" class="form-label h5">Confirm password</label>
-                <input class="form-control" type="password" name="password" id="password"
+            <label class="ac-panel__h" for="password" style="margin-bottom:.4rem;">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#shield-lock"></use></svg>
+                Confirm password
+            </label>
+            <div class="ac-inputgroup">
+                <span class="ac-inputgroup__icon">
+                    <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#key"></use></svg>
+                </span>
+                <input class="ac-input" type="password" name="password" id="password"
                        autocomplete="current-password" placeholder="Re-enter your account password">
-                <div class="form-text">
-                    Re-authentication is required to trigger a deploy.
-                </div>
             </div>
-
-            <button class="btn btn-danger btn-lg w-100" type="submit" id="deployBtn"
-                    {% if not deploy_configured %}disabled{% endif %}>
-                <svg class="bi" aria-hidden="true">
-                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use>
-                </svg>
-                Deploy
-            </button>
-        </form>
-    </div>
-
-    <div class="card m-1 d-none" id="resultCard">
-        <div class="card-body">
-            <h3 class="h5">
-                Status:
-                <span class="badge bg-secondary" id="statusBadge">idle</span>
-                <span class="text-secondary small" id="deployMeta"></span>
-            </h3>
-            <pre class="bg-black text-light p-2 rounded" id="output"
-                 style="max-height: 24rem; overflow: auto; white-space: pre-wrap;"></pre>
+            <p class="ac-panel__hint mt-2 mb-0">Re-authentication is required on every deploy.</p>
         </div>
-    </div>
+
+        <!-- CTA -->
+        <button class="ac-cta{% if deploy_configured %} ac-cta--ready{% endif %}" type="submit" id="deployBtn"{% if not deploy_configured %} disabled{% endif %}>
+            <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use></svg>
+            Launch deploy
+        </button>
+    </form>
+
+    <!-- Console -->
+    <section class="ac-console d-none" id="resultCard" aria-live="polite">
+        <div class="ac-console__bar">
+            <span class="ac-console__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+            <span class="ac-console__title">deploy.sh</span>
+            <span class="ac-pill ac-pill--status ac-pill--muted" id="statusBadge">idle</span>
+            <span class="ac-console__spacer"></span>
+            <span class="ac-console__timer" id="deployTimer">0:00</span>
+            <button type="button" class="ac-copy" id="copyLog" title="Copy log to clipboard">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#clipboard"></use></svg>
+                <span id="copyLogText">Copy</span>
+            </button>
+        </div>
+        <div class="ac-console__step" id="deployStep" hidden>
+            <span class="ac-spin" id="deploySpin" aria-hidden="true"></span>
+            <span class="ac-console__step-text" id="deployStepText"></span>
+        </div>
+        <div class="ac-console__step" id="deployMetaRow" hidden style="min-height:auto; color: var(--ac-dim); font-size:.8rem;">
+            <span class="ac-console__step-text" id="deployMeta"></span>
+        </div>
+        <pre class="ac-console__body" id="output"></pre>
+    </section>
 </div>
 
 <script>
@@ -126,11 +183,61 @@
     const statusBadge = document.getElementById("statusBadge");
     const outputEl = document.getElementById("output");
     const metaEl = document.getElementById("deployMeta");
+    const metaRow = document.getElementById("deployMetaRow");
     const warning = document.getElementById("selfDeployWarning");
+    const agentPill = document.getElementById("agentPill");
+    const timerEl = document.getElementById("deployTimer");
+    const stepRow = document.getElementById("deployStep");
+    const stepText = document.getElementById("deployStepText");
+    const spin = document.getElementById("deploySpin");
+    const copyBtn = document.getElementById("copyLog");
+    const copyText = document.getElementById("copyLogText");
     const csrftoken = "{{ csrf_token }}";
+    const deployConfigured = {% if deploy_configured %}true{% else %}false{% endif %};
     let polling = null;
+    let timer = null;
+    let startedAt = 0;
 
-    // Show the self-deploy caveat when ishar-web is selected.
+    // ---- helpers ---------------------------------------------------------
+    // Set a status pill's label + intent without innerHTML (dot is ::before).
+    function setPill(el, text, kind, live) {
+        el.textContent = text;
+        el.className = "ac-pill ac-pill--status ac-pill--" + kind + (live ? " ac-pill--live" : "");
+    }
+    function setBadge(text, kind, live) { setPill(statusBadge, text, kind, live); }
+
+    function fmtElapsed(ms) {
+        const s = Math.floor(ms / 1000);
+        return Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0");
+    }
+    function startTimer() {
+        startedAt = Date.now();
+        timerEl.textContent = "0:00";
+        clearInterval(timer);
+        timer = setInterval(function () {
+            timerEl.textContent = fmtElapsed(Date.now() - startedAt);
+        }, 1000);
+    }
+    function stopTimer() { clearInterval(timer); timer = null; }
+
+    // Surface the most recent `==>` step line from deploy.sh as a headline.
+    function updateStep(output, running) {
+        const lines = (output || "").split("\n");
+        let last = "";
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const m = lines[i].match(/^\s*==>\s*(.+?)\s*$/);
+            if (m) { last = m[1]; break; }
+        }
+        if (last) {
+            stepRow.hidden = false;
+            stepText.textContent = last;
+            spin.style.display = running ? "" : "none";
+        } else {
+            stepRow.hidden = true;
+        }
+    }
+
+    // ---- self-deploy caveat ---------------------------------------------
     function refreshWarning() {
         const web = document.getElementById("svc-ishar-web");
         warning.classList.toggle("d-none", !(web && web.checked));
@@ -140,11 +247,32 @@
     });
     refreshWarning();
 
-    function setBadge(text, cls) {
-        statusBadge.textContent = text;
-        statusBadge.className = "badge " + cls;
+    // ---- live agent health (hero pill) ----------------------------------
+    if (deployConfigured) {
+        post("{% url 'deploy_ping' %}", {})
+            .then(function (r) {
+                if (r.status === 200 && (r.data.ok === undefined || r.data.ok)) {
+                    setPill(agentPill, "agent online", "ok", true);
+                } else {
+                    setPill(agentPill, "agent unreachable", "danger", false);
+                }
+            })
+            .catch(function () { setPill(agentPill, "agent unreachable", "danger", false); });
     }
 
+    // ---- copy log --------------------------------------------------------
+    copyBtn.addEventListener("click", function () {
+        const text = outputEl.textContent || "";
+        const done = function () {
+            copyText.textContent = "Copied";
+            setTimeout(function () { copyText.textContent = "Copy"; }, 1500);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done, function () {});
+        }
+    });
+
+    // ---- POST helper -----------------------------------------------------
     function post(url, params) {
         const body = new URLSearchParams(params);
         body.append("csrfmiddlewaretoken", csrftoken);
@@ -162,54 +290,64 @@
         });
     }
 
+    // ---- render a status payload ----------------------------------------
     function renderStatus(data) {
+        const running = data.status === "running";
         outputEl.textContent = data.output || "";
         outputEl.scrollTop = outputEl.scrollHeight;
+
         const parts = [];
         if (data.env) { parts.push("env=" + data.env); }
         if (data.services) { parts.push("services=" + data.services.join(",")); }
         if (data.exit_code !== null && data.exit_code !== undefined) {
             parts.push("exit=" + data.exit_code);
         }
-        metaEl.textContent = parts.join("  ");
+        if (parts.length) { metaRow.hidden = false; metaEl.textContent = parts.join("   ·   "); }
+
+        updateStep(data.output, running);
+
         if (data.status === "success") {
-            setBadge("success", "bg-success");
+            setBadge("success", "ok", false);
         } else if (data.status === "failed") {
-            setBadge("failed", "bg-danger");
+            setBadge("failed", "danger", false);
         } else {
-            setBadge("running…", "bg-warning text-dark");
+            setBadge("running", "warn", true);
         }
     }
 
+    function finish() { stopTimer(); btn.disabled = !deployConfigured; spin.style.display = "none"; }
+
+    // ---- poll ------------------------------------------------------------
     function poll(deployId) {
         post("{% url 'deploy_status' %}", { deploy_id: deployId })
             .then(function (r) {
                 if (r.status !== 200) {
-                    setBadge("lost", "bg-danger");
+                    setBadge("lost", "danger", false);
                     outputEl.textContent += "\n[status unavailable: " +
                         (r.data.message || r.status) + "]";
                     clearInterval(polling);
-                    btn.disabled = false;
+                    finish();
                     return;
                 }
                 renderStatus(r.data);
                 if (r.data.status !== "running") {
                     clearInterval(polling);
-                    btn.disabled = false;
+                    finish();
                 }
             })
             .catch(function () {
-                // A self-deploy of ishar-web drops this container; polling will
-                // fail. Say so rather than spinning forever.
+                // A self-deploy of ishar-web drops this container; polling fails.
                 outputEl.textContent += "\n[lost connection to the site — " +
                     "if you deployed ishar-web this is expected; " +
                     "check the host audit log]";
-                setBadge("disconnected", "bg-secondary");
+                setBadge("disconnected", "muted", false);
+                stepRow.hidden = true;
                 clearInterval(polling);
-                btn.disabled = false;
+                finish();
             });
     }
 
+    // ---- submit ----------------------------------------------------------
     form.addEventListener("submit", function () {
         const env = (form.querySelector("input[name=env]:checked") || {}).value;
         const services = Array.from(
@@ -229,9 +367,12 @@
 
         btn.disabled = true;
         resultCard.classList.remove("d-none");
-        setBadge("starting…", "bg-warning text-dark");
+        setBadge("starting", "warn", true);
         outputEl.textContent = "";
         metaEl.textContent = "";
+        metaRow.hidden = true;
+        stepRow.hidden = true;
+        startTimer();
 
         // URLSearchParams needs repeated keys for the service list.
         const body = new URLSearchParams();
@@ -260,16 +401,16 @@
                 polling = setInterval(function () { poll(r.data.deploy_id); }, 2000);
                 poll(r.data.deploy_id);
             } else {
-                setBadge("rejected", "bg-danger");
+                setBadge("rejected", "danger", false);
                 const msg = r.data.message || r.data.detail || r.data.error ||
                     ("HTTP " + r.status);
                 outputEl.textContent = msg;
-                btn.disabled = false;
+                finish();
             }
         }).catch(function (err) {
-            setBadge("error", "bg-danger");
+            setBadge("error", "danger", false);
             outputEl.textContent = "Request failed: " + err;
-            btn.disabled = false;
+            finish();
         });
     });
 })();

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from .views.deploy import DeployActionView, DeployStatusView, DeployView
+from .views.deploy import (
+    DeployActionView,
+    DeployPingView,
+    DeployStatusView,
+    DeployView,
+)
 from .views.password import PasswordView
 from .views.portal import PortalView
 from .views.private import SetPrivateView
@@ -14,4 +19,5 @@ urlpatterns = [
     path("deploy/", DeployView.as_view(), name="deploy"),
     path("deploy/run/", DeployActionView.as_view(), name="deploy_run"),
     path("deploy/status/", DeployStatusView.as_view(), name="deploy_status"),
+    path("deploy/ping/", DeployPingView.as_view(), name="deploy_ping"),
 ]

--- a/apps/accounts/views/deploy.py
+++ b/apps/accounts/views/deploy.py
@@ -11,7 +11,7 @@ from django.views.generic.base import TemplateView, View
 
 from apps.core.views.mixins import GodRequiredMixin, NeverCacheMixin
 
-from ..utils.deploy_agent import DeployAgentError, deploy_status, start_deploy
+from ..utils.deploy_agent import DeployAgentError, deploy_status, ping, start_deploy
 
 
 class DeployView(GodRequiredMixin, NeverCacheMixin, TemplateView):
@@ -65,6 +65,27 @@ class DeployActionView(GodRequiredMixin, NeverCacheMixin, View):
         # sees the real accepted/rejected outcome (busy, cooldown, invalid, ...).
         status = int(result.get("http_status", 200 if result.get("ok") else 400))
         return JsonResponse(result, status=status)
+
+
+class DeployPingView(GodRequiredMixin, NeverCacheMixin, View):
+    """POST-only liveness probe for the host agent. Powers the console's live
+    agent-health pill. Read-only (no re-auth); God gate + CSRF still apply."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            result = ping()
+        except DeployAgentError as exc:
+            return JsonResponse(
+                {"ok": False, "message": f"Deploy agent unavailable: {exc}"},
+                status=503,
+            )
+        # Normalize: guarantee an `ok` flag for the pill regardless of the
+        # agent's own shape.
+        if "ok" not in result:
+            result = {"ok": True, **result}
+        return JsonResponse(result)
 
 
 class DeployStatusView(GodRequiredMixin, NeverCacheMixin, View):

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -1,0 +1,514 @@
+/* ==========================================================================
+   admin-console.css — Ishar "Admin Console" design language
+   --------------------------------------------------------------------------
+   A reusable token + component layer for first-class staff/admin tooling
+   (deploy console first; feedback triage & future admin surfaces next).
+
+   Built ON TOP of the site brand: the single amber accent (--ishar-color: #fa7)
+   and body text (#d6d6d7) carry over, but surfaces use the richer layered-grey
+   system pioneered by the connect HUD (hud.css) instead of flat black+amber.
+
+   Conventions (adopt these anywhere admin tooling is built):
+     - Surfaces step up in lightness: --ac-bg < --ac-panel < --ac-elev.
+     - Accent (amber) is used sparingly: headers, focus, primary/live state.
+     - Semantic colors are fixed: ok=green, info=blue, warn=orange, danger=red.
+     - Section headers are UPPERCASE, letter-spaced, dim (.ac-panel__h).
+     - Status is a .ac-pill; a live pill gets a pulsing dot.
+     - Selectable options are .btn-check inputs styled via sibling labels
+       (.ac-seg__item / .ac-toggle) so they stay accessible + keyboard-friendly.
+     - Motion is subtle and ALWAYS disabled under prefers-reduced-motion.
+   Load per-page via {% block includes %}, not globally.
+   ========================================================================== */
+
+:root {
+    --ac-accent:      #fa7;                      /* brand amber */
+    --ac-accent-2:    #ffd7b0;                   /* lighter amber for text-on-accent gradients */
+    --ac-bg:          #0c0c0d;                   /* deepest surface */
+    --ac-panel:       #131316;                   /* panel surface */
+    --ac-elev:        #1c1c22;                   /* raised / hover surface */
+    --ac-border:      #2a2a30;                   /* hairline border */
+    --ac-border-2:    #3a3a44;                   /* stronger border (hover/active) */
+    --ac-text:        #d6d6d7;                   /* body text */
+    --ac-dim:         #8a8a92;                   /* muted / labels */
+    --ac-ok:          #4cbb17;                   /* success / safe */
+    --ac-info:        #4a86cf;                   /* informational */
+    --ac-warn:        #f80;                      /* caution */
+    --ac-danger:      #d64b4b;                   /* destructive / error */
+    --ac-wash:        rgba(255, 170, 119, .12);  /* translucent amber wash */
+    --ac-ok-wash:     rgba(76, 187, 23, .12);
+    --ac-info-wash:   rgba(74, 134, 207, .14);
+    --ac-danger-wash: rgba(214, 75, 75, .14);
+    --ac-radius:      .6rem;
+    --ac-radius-sm:   .4rem;
+}
+
+/* Outer container so the console reads as one cohesive surface. */
+.ac {
+    color: var(--ac-text);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 60rem;
+}
+
+/* ------------------------------------------------------------------ hero -- */
+.ac-hero {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.15rem 1.35rem;
+    border: 1px solid var(--ac-border);
+    border-left: 3px solid var(--ac-accent);
+    border-radius: var(--ac-radius);
+    background:
+        radial-gradient(120% 140% at 0% 0%, var(--ac-wash) 0%, transparent 55%),
+        linear-gradient(100deg, #1a1509 0%, var(--ac-panel) 42%, var(--ac-bg) 100%);
+    overflow: hidden;
+}
+.ac-hero__badge {
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 50%;
+    color: var(--ac-accent);
+    background: var(--ac-wash);
+    box-shadow: inset 0 0 0 1px rgba(255, 170, 119, .25);
+}
+.ac-hero__badge .bi { width: 1.6rem; height: 1.6rem; }
+.ac-hero__text { min-width: 0; flex: 1 1 auto; }
+.ac-hero__title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: .01em;
+    color: var(--ac-accent);
+    line-height: 1.1;
+}
+.ac-hero__sub {
+    margin: .2rem 0 0;
+    color: var(--ac-dim);
+    font-size: .9rem;
+}
+.ac-hero__sub code {
+    color: var(--ac-accent-2);
+    background: rgba(255, 170, 119, .1);
+    padding: .05rem .3rem;
+    border-radius: .25rem;
+}
+.ac-hero__status { flex: 0 0 auto; align-self: flex-start; }
+
+/* --------------------------------------------------------------- pills --- */
+.ac-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .28rem .6rem;
+    border-radius: 999px;
+    font-size: .72rem;
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--ac-dim);
+    background: var(--ac-elev);
+    border: 1px solid var(--ac-border);
+    transition: background .15s, border-color .15s, color .15s;
+}
+.ac-pill__dot {
+    width: .5rem;
+    height: .5rem;
+    border-radius: 50%;
+    background: currentColor;
+    flex: 0 0 auto;
+}
+.ac-pill--muted   { color: var(--ac-dim);    border-color: var(--ac-border); }
+.ac-pill--ok      { color: var(--ac-ok);     border-color: rgba(76,187,23,.4);  background: var(--ac-ok-wash); }
+.ac-pill--info    { color: var(--ac-info);   border-color: rgba(74,134,207,.4); background: var(--ac-info-wash); }
+.ac-pill--warn    { color: var(--ac-warn);   border-color: rgba(255,136,0,.4);  background: rgba(255,136,0,.12); }
+.ac-pill--danger  { color: var(--ac-danger); border-color: rgba(214,75,75,.45); background: var(--ac-danger-wash); }
+.ac-pill--accent  { color: var(--ac-accent); border-color: rgba(255,170,119,.45); background: var(--ac-wash); }
+/* Status pills carry a leading dot as a pseudo-element so JS may replace the
+   label via textContent (no innerHTML) without wiping the dot. */
+.ac-pill--status::before {
+    content: "";
+    width: .5rem; height: .5rem; border-radius: 50%;
+    background: currentColor; flex: 0 0 auto;
+}
+/* A live pill's dot breathes. */
+.ac-pill--live .ac-pill__dot,
+.ac-pill--status.ac-pill--live::before { animation: ac-pulse 1.4s ease-in-out infinite; }
+
+/* -------------------------------------------------------------- panels --- */
+.ac-panel {
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius);
+    background: var(--ac-panel);
+    padding: 1.1rem 1.25rem;
+}
+.ac-panel__h {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    margin: 0 0 .2rem;
+    font-size: .72rem;
+    font-weight: 700;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    color: var(--ac-dim);
+}
+.ac-panel__h .bi { width: .95rem; height: .95rem; color: var(--ac-accent); }
+.ac-panel__hint {
+    margin: 0 0 .85rem;
+    color: var(--ac-dim);
+    font-size: .85rem;
+}
+.ac-panel__hint code {
+    color: var(--ac-accent-2);
+    background: rgba(255,170,119,.1);
+    padding: .03rem .28rem;
+    border-radius: .25rem;
+}
+
+/* --------------------------------------------------- segmented control --- */
+.ac-seg {
+    display: inline-flex;
+    padding: .28rem;
+    gap: .28rem;
+    border-radius: 999px;
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+}
+.ac-seg__item {
+    cursor: pointer;
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: .45rem;
+    padding: .4rem 1.1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--ac-dim);
+    border: 1px solid transparent;
+    transition: background .15s, color .15s, border-color .15s;
+    user-select: none;
+}
+.ac-seg__item .bi { width: 1rem; height: 1rem; }
+.ac-seg__item:hover { color: var(--ac-text); background: var(--ac-elev); }
+.btn-check:checked + .ac-seg__item {
+    color: var(--ac-text);
+    background: var(--ac-elev);
+    border-color: var(--ac-border-2);
+}
+/* Environment intent tints when selected. */
+.btn-check:checked + .ac-seg__item--prod {
+    color: #ffb3b3;
+    background: var(--ac-danger-wash);
+    border-color: rgba(214,75,75,.5);
+}
+.btn-check:checked + .ac-seg__item--test {
+    color: #bcd8ff;
+    background: var(--ac-info-wash);
+    border-color: rgba(74,134,207,.5);
+}
+.btn-check:focus-visible + .ac-seg__item {
+    outline: 2px solid var(--ac-accent);
+    outline-offset: 2px;
+}
+
+/* ------------------------------------------------------- toggle cards --- */
+.ac-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    gap: .6rem;
+}
+.ac-toggle {
+    cursor: pointer;
+    margin: 0;
+    display: flex;
+    align-items: flex-start;
+    gap: .7rem;
+    padding: .8rem .9rem;
+    border-radius: var(--ac-radius-sm);
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+    transition: background .15s, border-color .15s, box-shadow .15s, transform .1s;
+}
+.ac-toggle:hover { border-color: var(--ac-border-2); background: var(--ac-elev); }
+.ac-toggle:active { transform: translateY(1px); }
+.ac-toggle__icon {
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: var(--ac-radius-sm);
+    color: var(--ac-dim);
+    background: var(--ac-elev);
+    border: 1px solid var(--ac-border);
+    transition: color .15s, background .15s, border-color .15s;
+}
+.ac-toggle__icon .bi { width: 1.15rem; height: 1.15rem; }
+.ac-toggle__body { min-width: 0; }
+.ac-toggle__name {
+    font-weight: 600;
+    color: var(--ac-text);
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: .92rem;
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+}
+.ac-toggle__note { color: var(--ac-dim); font-size: .78rem; margin-top: .1rem; }
+.ac-toggle__check {
+    margin-left: auto;
+    flex: 0 0 auto;
+    align-self: center;
+    color: var(--ac-border-2);
+    transition: color .15s, transform .15s;
+}
+.ac-toggle__check .bi { width: 1.25rem; height: 1.25rem; }
+/* Selected state. */
+.btn-check:checked + .ac-toggle {
+    border-color: rgba(255,170,119,.55);
+    background: var(--ac-wash);
+    box-shadow: inset 0 0 0 1px rgba(255,170,119,.25);
+}
+.btn-check:checked + .ac-toggle .ac-toggle__icon {
+    color: var(--ac-accent);
+    background: rgba(255,170,119,.14);
+    border-color: rgba(255,170,119,.4);
+}
+.btn-check:checked + .ac-toggle .ac-toggle__check { color: var(--ac-accent-2); transform: scale(1.05); }
+.btn-check:focus-visible + .ac-toggle { outline: 2px solid var(--ac-accent); outline-offset: 2px; }
+
+/* -------------------------------------------------------- callouts --- */
+.ac-note {
+    display: flex;
+    align-items: flex-start;
+    gap: .6rem;
+    padding: .75rem .9rem;
+    border-radius: var(--ac-radius-sm);
+    border: 1px solid var(--ac-border);
+    background: var(--ac-elev);
+    color: var(--ac-text);
+    font-size: .88rem;
+    line-height: 1.5;
+}
+.ac-note .bi { width: 1.15rem; height: 1.15rem; flex: 0 0 auto; margin-top: .12rem; }
+.ac-note code {
+    color: var(--ac-accent-2);
+    background: rgba(255,170,119,.1);
+    padding: .03rem .28rem; border-radius: .25rem;
+}
+.ac-note--warn   { border-color: rgba(255,136,0,.4);  background: rgba(255,136,0,.09); }
+.ac-note--warn   .bi { color: var(--ac-warn); }
+.ac-note--danger { border-color: rgba(214,75,75,.4);  background: var(--ac-danger-wash); }
+.ac-note--danger .bi { color: var(--ac-danger); }
+
+/* --------------------------------------------------------- form bits --- */
+/* Uses Bootstrap's native .form-switch shape; we only recolor + resize it. */
+.ac-switch .form-check-input {
+    width: 2.6em;
+    height: 1.3em;
+    margin-top: .1em;
+    background-color: var(--ac-bg);
+    border-color: var(--ac-border-2);
+    cursor: pointer;
+}
+.ac-switch .form-check-input:checked {
+    background-color: var(--ac-accent);
+    border-color: var(--ac-accent);
+}
+.ac-switch .form-check-input:focus {
+    border-color: var(--ac-accent);
+    box-shadow: 0 0 0 .2rem var(--ac-wash);
+}
+.ac-switch .form-check-label { color: var(--ac-text); cursor: pointer; }
+.ac-switch__text code {
+    color: var(--ac-accent-2);
+    background: rgba(255,170,119,.1);
+    padding: .03rem .28rem; border-radius: .25rem;
+}
+.ac-switch__note { color: var(--ac-dim); font-size: .8rem; }
+
+.ac-inputgroup {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius-sm);
+    background: var(--ac-bg);
+    overflow: hidden;
+    transition: border-color .15s, box-shadow .15s;
+}
+.ac-inputgroup:focus-within {
+    border-color: var(--ac-accent);
+    box-shadow: 0 0 0 .2rem var(--ac-wash);
+}
+.ac-inputgroup__icon {
+    display: grid; place-items: center;
+    padding: 0 .8rem;
+    color: var(--ac-dim);
+    background: var(--ac-elev);
+    border-right: 1px solid var(--ac-border);
+}
+.ac-inputgroup__icon .bi { width: 1.05rem; height: 1.05rem; }
+.ac-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    background: transparent;
+    border: 0;
+    color: var(--ac-text);
+    padding: .6rem .8rem;
+    font-size: 1rem;
+}
+.ac-input:focus { outline: none; }
+.ac-input::placeholder { color: #5b5b63; }
+
+/* ------------------------------------------------------------- CTA --- */
+.ac-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .6rem;
+    width: 100%;
+    padding: .85rem 1rem;
+    border-radius: var(--ac-radius-sm);
+    border: 1px solid rgba(214,75,75,.6);
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: .02em;
+    color: #fff;
+    background: linear-gradient(180deg, #b23b3b 0%, #8f2b2b 100%);
+    cursor: pointer;
+    transition: filter .15s, box-shadow .15s, transform .1s, opacity .15s;
+}
+.ac-cta .bi { width: 1.2rem; height: 1.2rem; }
+.ac-cta:hover:not(:disabled) { filter: brightness(1.12); box-shadow: 0 0 0 .2rem var(--ac-danger-wash); }
+.ac-cta:active:not(:disabled) { transform: translateY(1px); }
+.ac-cta:disabled { opacity: .5; cursor: not-allowed; filter: grayscale(.4); }
+/* Gentle "armed" glow when ready to fire. */
+.ac-cta--ready:not(:disabled) { animation: ac-glow 2.4s ease-in-out infinite; }
+
+/* -------------------------------------------------------- console --- */
+.ac-console {
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius);
+    background: var(--ac-bg);
+    overflow: hidden;
+}
+.ac-console__bar {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    padding: .55rem .85rem;
+    background: var(--ac-panel);
+    border-bottom: 1px solid var(--ac-border);
+}
+.ac-console__dots { display: inline-flex; gap: .4rem; flex: 0 0 auto; }
+.ac-console__dots i {
+    width: .7rem; height: .7rem; border-radius: 50%;
+    background: #3a3a44; display: inline-block;
+}
+.ac-console__dots i:nth-child(1) { background: #e05c5c; }
+.ac-console__dots i:nth-child(2) { background: #e0b23c; }
+.ac-console__dots i:nth-child(3) { background: #4cbb17; }
+.ac-console__title {
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: .8rem;
+    color: var(--ac-dim);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ac-console__spacer { flex: 1 1 auto; }
+.ac-console__timer {
+    font-family: var(--bs-font-monospace, monospace);
+    font-variant-numeric: tabular-nums;
+    font-size: .8rem;
+    color: var(--ac-dim);
+}
+.ac-copy {
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .2rem .5rem;
+    border-radius: .3rem;
+    font-size: .72rem;
+    color: var(--ac-dim);
+    background: var(--ac-elev);
+    border: 1px solid var(--ac-border);
+    cursor: pointer;
+    transition: color .15s, border-color .15s, background .15s;
+}
+.ac-copy .bi { width: .85rem; height: .85rem; }
+.ac-copy:hover { color: var(--ac-accent); border-color: rgba(255,170,119,.4); }
+.ac-console__step {
+    display: flex;
+    align-items: center;
+    gap: .55rem;
+    padding: .55rem .85rem;
+    background: var(--ac-panel);
+    border-bottom: 1px solid var(--ac-border);
+    color: var(--ac-text);
+    font-size: .9rem;
+    min-height: 2.4rem;
+}
+.ac-console__step .ac-spin { flex: 0 0 auto; color: var(--ac-accent); }
+.ac-console__step-text {
+    font-family: var(--bs-font-monospace, monospace);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.ac-console__body {
+    margin: 0;
+    padding: .85rem 1rem;
+    max-height: 26rem;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: .82rem;
+    line-height: 1.5;
+    color: #c7c7c9;
+    background: var(--ac-bg);
+}
+.ac-console__body::-webkit-scrollbar { width: .6rem; }
+.ac-console__body::-webkit-scrollbar-thumb { background: var(--ac-border-2); border-radius: 999px; }
+
+/* Spinner used in the step readout. */
+.ac-spin {
+    display: inline-block;
+    width: 1rem; height: 1rem;
+    border: 2px solid var(--ac-border-2);
+    border-top-color: var(--ac-accent);
+    border-radius: 50%;
+    animation: ac-rotate .7s linear infinite;
+}
+
+/* ---------------------------------------------------------- motion --- */
+@keyframes ac-pulse {
+    0%, 100% { opacity: 1;   transform: scale(1); }
+    50%      { opacity: .35; transform: scale(.7); }
+}
+@keyframes ac-rotate { to { transform: rotate(360deg); } }
+@keyframes ac-glow {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(214,75,75,0); }
+    50%      { box-shadow: 0 0 0 .25rem var(--ac-danger-wash); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ac-pill--live .ac-pill__dot,
+    .ac-pill--status.ac-pill--live::before,
+    .ac-cta--ready:not(:disabled),
+    .ac-spin { animation: none !important; }
+    .ac-spin { border-top-color: var(--ac-accent); }
+    * { transition: none !important; }
+}
+
+/* ----------------------------------------------------- responsive --- */
+@media (max-width: 575.98px) {
+    .ac-hero { flex-wrap: wrap; }
+    .ac-hero__status { align-self: stretch; }
+    .ac-seg { width: 100%; }
+    .ac-seg__item { flex: 1 1 0; justify-content: center; padding: .5rem .5rem; }
+}


### PR DESCRIPTION
Turns the God-gated deploy page from a plain Bootstrap form into a purpose-built **Deploy Console**, and — the durable part — introduces a reusable **admin-console** design language that future staff surfaces (feedback triage, etc.) can adopt. Feedback dashboard was the quality bar.

## New design language — `apps/core/static/css/admin-console.css`
A proper token + component layer built *on top of* the brand (`--ishar-color: #fa7`), borrowing the connect HUD's premium layered-grey surfaces so admin tooling reads richer than flat black+amber:
- **Tokens**: `--ac-bg/--ac-panel/--ac-elev/--ac-border`, `--ac-text/--ac-dim`, fixed semantics `--ac-ok/info/warn/danger`, amber wash.
- **Components** (documented, BEM-ish): `.ac-hero` (gradient + accent edge), `.ac-pill` status pills (a `--live` pill's dot pulses; the dot is a `::before` so JS `textContent` swaps never wipe it), `.ac-panel` + uppercase `.ac-panel__h`, `.ac-seg` segmented control, `.ac-toggle` selectable cards, `.ac-switch`, `.ac-inputgroup`, `.ac-cta` gradient button, `.ac-console` terminal, `.ac-note` callouts.
- First `@keyframes` in the repo — all disabled under `prefers-reduced-motion`.
- Loaded per-page via layout's existing `{% block includes %}` (opt-in, reusable, no global weight).

## Deploy page — `apps/accounts/templates/deploy.html` (rewrite)
- **Hero** with rocket badge + a **live agent-health pill** (online / unreachable / not-configured).
- **Environment** as a segmented control (prod tinted danger, test info); **Services** as selectable cards with role notes ("blue-green, no player drop" / "restarts this page" / "Discord bridge"); `--no-pull` switch; lock/key re-auth input-group; gradient **Launch deploy** CTA.
- **Terminal console**: traffic-lights, status pill, **live elapsed timer**, a **current-step headline** parsed from `deploy.sh`'s `==>` lines with a spinner while running, a **copy-log** button, and the streamed monospace output.

Every existing JS hook and the request/response contract are preserved verbatim — element ids/names/classes, CSRF header+body, the 2s status poll, the immediate password clear, `textContent`-only DOM updates, and the `#svc-ishar-web` self-deploy caveat.

## Backend — live agent health (small)
`DeployPingView` (God-gated, POST, CSRF) → `deploy_agent.ping()`; route `deploy/ping/` (`deploy_ping`). Reuses the existing `ping()`; no new agent protocol. Powers the hero pill.

## Verification
- `deploy.html` compiles via the Django template engine; `views/deploy.py` + `urls.py` `py_compile`; the extracted `<script>` passes `node --check`.
- Rendered self-contained previews (idle / running / success / self-deploy-warning) with headless Chromium and iterated on the look. Screenshots shared with the owner.
- The live end-to-end deploy needs the host agent, so that's owner-tested on the box. **Redeploy `ishar-web` to pick this up.**

Scope: deploy page only; the CSS layer is intentionally reusable for feedback + other admin pages next.

Relates to #1754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01885fxjvTmiRWtPTEG54TSg)_