### PR TITLE
Add a living design system + CLAUDE.md, adopt the green-field mandate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,238 @@
+# Ishar Web — Claude Code Project Guide
+
+## Project Identity
+
+`ishar-web` is the web presence and staff-tooling layer for **Ishar MUD** — a
+text-based MUD with a ~30-year history, maintained by a solo developer. This
+repo is **not** the game; the game engine (C + a growing Rust layer) lives in
+`isharmud/ishar-mud`. What lives here:
+
+1. **The public site** — home, FAQ, getting-started, MUD-client links, help
+   files, leaderboards, challenges, seasons, news/patches, player lookups.
+2. **The web telnet client** (`/connect`) — a browser terminal that speaks to
+   the live game over a Channels/Daphne websocket bridge (the "HUD").
+3. **Staff / admin tooling** — the account portal (`/portal`), feedback triage,
+   the **Deploy Console** (`/portal/deploy`, God-gated, drives blue-green
+   deploys of the game from a phone), and process/admin views.
+
+The site **shares the game's MariaDB**. Most models are `managed = False` — they
+map onto tables the C game engine owns; Django reads and occasionally writes
+them but does not own their schema or migrations. Treat the database as a
+contract with the game, not something this repo defines.
+
+The active playerbase is small (~10–11 committed mortals) but deeply invested,
+and several of them (plus the developer) drive the game from phones. **Mobile
+usability is not optional.**
+
+---
+
+## ⭐ The Green-Field Mandate
+
+> **ishar-web is technically brown-field, but the impact zone is small enough
+> that we treat it as green field: no concern with breakage or comms — just
+> optimal, unhandcuffed design.**
+
+This is the governing constraint. In practice:
+
+- **Don't hedge for backward compatibility** where a cleaner design exists. The
+  audience is tiny and known; there is no migration window to protect, no
+  external consumers, no deprecation cycle to run. If a page, template, or
+  convention is better rebuilt than patched, rebuild it.
+- **Reduce entropy, don't preserve it.** The site has accumulated three
+  coexisting visual layers and a lot of copy-pasted markup. The mandate is to
+  *converge*, not to keep old patterns alive out of caution.
+- **Set conventions, then apply them.** Where a decision improves the whole
+  site, make it the standard (record it in `docs/design/decisions.md`) rather
+  than scoping it to one page.
+- **The one thing you still owe:** correctness and taste. "No concern with
+  breakage" means no concern about *changing* things — not a license to ship
+  something broken, ugly, or inaccessible. Verify your work (see below).
+
+This mandate **supersedes** any "keeps the existing identity for
+compatibility"-style hedging still present in older docs. When you find such a
+hedge, treat it as a candidate for a deliberate redesign, not a rule.
+
+---
+
+## Core Development Philosophy
+
+### System Coherence Over Feature Volume
+
+Same north star as the game repo: **every change should reduce entropy.** Before
+adding markup, CSS, or a view, ask:
+
+- Does this consolidate or fragment what exists?
+- Can it reuse or replace an existing pattern (a component, a mixin, a token)?
+- Does it follow the design system (`docs/design/`), or invent a one-off?
+
+### The Solo Developer Constraint
+
+There is no team, no reviewer, no QA. Claude Code is the engineering team this
+project doesn't have. Rigor — verification, adversarial thinking about abuse and
+edge cases, taste in UX — is the only quality gate. Don't hand-wave "this
+probably works"; prove it as far as the environment allows.
+
+---
+
+## Technical Stack
+
+| Layer | Choice |
+|---|---|
+| Framework | **Django 5.2** (`settings.py`, apps under `apps/`) |
+| Server | **Daphne / ASGI** (`asgi.py`), **Channels 4** for the websocket telnet client |
+| Database | **MariaDB**, shared with the game. Custom engine `apps.core.backends`; custom PK `apps.core.models.unsigned.UnsignedAutoField`. Most models are `managed = False`. |
+| Auth | `AUTH_USER_MODEL = accounts.Account` (a `managed = False` game table) |
+| Admin | Django admin, skinned with **django-jazzmin** |
+| Frontend | **Bootstrap 5.3.8** + **Bootstrap Icons 1.13.1**, both self-hosted. **No build step.** Small vanilla JS only. Dark-only (`<html data-bs-theme="dark">`, forced). |
+| Discord | `discord-py-interactions` bot glue (`discord.py`) |
+| Tests | **None.** There is no test suite in this repo today. |
+
+### Frontend rules (non-negotiable)
+
+- **No new frontend libraries.** No CDN dependencies, no web fonts, no
+  framework. Ship Bootstrap + Bootstrap Icons (self-hosted) + vanilla JS.
+- **Icons via the SVG sprite:**
+  `<svg class="bi"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#name"></use></svg>`.
+- **JS updates the DOM via `textContent` / class swaps, never `innerHTML`** for
+  anything derived from data (XSS discipline).
+- **Motion is optional:** wrap every transition/animation in
+  `@media (prefers-reduced-motion: reduce)`. No motion is load-bearing.
+- **Mobile-first.** Every admin tool must be usable at a phone width.
+
+### `static/` is gitignored
+
+`.gitignore` excludes `static/` — it's a collectstatic target
+(`docker-entrypoint.sh` runs `collectstatic` on every container start). Source
+CSS/JS that must be tracked (e.g. `apps/core/static/css/style.css`,
+`admin-console.css`) is **force-added** (`git add -f`). If you add a new tracked
+stylesheet or script, remember it won't stage on its own.
+
+---
+
+## Repository Layout
+
+```
+apps/                 one Django app per game domain (accounts, feedback,
+                      connect, core, leaders, challenges, help, seasons, …)
+  core/               shared plumbing: layout.html, mixins, error/home/auth
+                      views, custom DB backend, static/css/style.css +
+                      admin-console.css, the SVG icon sprite
+  accounts/           Account model, portal, deploy console, password, private
+  connect/            the web telnet client (Channels consumer + hud.css)
+  feedback/           feedback submission + staff triage dashboard
+settings.py           single settings module (settings.example.py is the template)
+asgi.py / wsgi.py     entrypoints (asgi is the real one — Daphne)
+urls.py               root URLconf
+docs/design/          ⭐ the living design system — read before any UI work
+Dockerfile
+docker-entrypoint.sh  collectstatic then exec daphne
+```
+
+There are **no template partials and no `templatetags`** today — repeating
+markup (breadcrumbs, stat tiles, pills, empty states) is copy-pasted. Introducing
+shared partials + a `templatetags` module is a named enabler in the design docs
+(E2); prefer creating the shared piece over pasting a fourth copy.
+
+---
+
+## Conventions & Patterns
+
+### Views: class-based + mixins
+
+New views are class-based. Staff gating uses the mixins in
+`apps/core/views/mixins.py`, which follow a **404-for-everyone-else** convention
+(an unauthorized user gets `Http404`, not a 403 — the page simply doesn't exist
+for them):
+
+- `GodRequiredMixin` — `account.is_god()` (`immortal_level >= 5`).
+- `EternalRequiredMixin` — `account.is_eternal()` (`immortal_level >= 3`;
+  equivalent to `is_staff`).
+- `NeverCacheMixin` — for sensitive/live pages.
+
+**Immortal levels** live on `accounts.Account.immortal_level`
+(`apps/accounts/models/level.py`): None=0, Immortal=1, Artisan=2, Eternal=3,
+Forger=4, **God=5**. Do not confuse `immortal_level` with the character *level*
+(21+ = immortal) — the gates key off `immortal_level`.
+
+### Action views: POST + JsonResponse
+
+Mutating/admin actions are POST-only CBVs returning `JsonResponse`, CSRF via the
+`X-CSRFToken` header (and body field), with an allowlist on inputs. The Deploy
+Console (`apps/accounts/views/deploy.py`) and `SetPrivateView`
+(`apps/accounts/views/private.py`) are the reference implementations. The
+container→host **deploy agent** bridge lives in
+`apps/accounts/utils/deploy_agent.py` (a shared unix socket + shared secret;
+strict env/service allowlist).
+
+### Surfacing a new staff tool
+
+The canonical place is the **Portal dropdown** in
+`apps/core/templates/layout.html` (visible site-wide, grouped by gate), mirrored
+by a card on the portal page (`apps/accounts/templates/portal.html`). A tool
+that only lives at a hand-typed URL is a bug — wire it into the nav.
+
+---
+
+## The Design System — read this before touching any UI
+
+`docs/design/` is the **living source of truth** for how the site looks and why.
+Read [`docs/design/README.md`](docs/design/README.md) first, then:
+
+- [`tokens.md`](docs/design/tokens.md) — the palette: colors, surfaces, text,
+  semantics, radii, motion. Every color on a touched page comes from here.
+- [`components.md`](docs/design/components.md) — the component catalog
+  (canonical markup + status). The **Admin Console** `.ac-*` components
+  (`apps/core/static/css/admin-console.css`) are the reference language for
+  staff tooling; the Deploy Console is the flagship implementation.
+- [`decisions.md`](docs/design/decisions.md) — the append-only ADR log. **When
+  you make a genuine design call, record it here** and update the catalog.
+
+Under the green-field mandate the design system is the plan for facelifting the
+*whole* site coherently, not just admin pages. If a convention should apply site-
+wide, say so in `decisions.md` and start applying it.
+
+---
+
+## Verification (how to prove work without a full run)
+
+The site needs the shared MariaDB **and** the host deploy agent to run
+end-to-end; neither is reachable from most Claude Code environments. So verify
+as far as you can, and **state plainly what was proven vs. left to the owner's
+on-prod test.** Techniques used here:
+
+- **Templates:** compile with Django's template engine via `Template`/
+  `from_string()` under stub settings — catches `{% %}`/block errors without a DB.
+- **`python manage.py check`** when runnable.
+- **`python3 -m py_compile`** on changed Python.
+- **Extracted `<script>` blocks:** `node --check`.
+- **Visual proof:** build a throwaway self-contained `preview.html` that inlines
+  the markup + the CSS layer (and simulates dynamic states), render it with the
+  preinstalled headless Chromium
+  (`/opt/pw-browsers/chromium*/chrome-linux/chrome --headless=new --screenshot`),
+  and send the screenshots. This is how the Deploy Console redesign was
+  eyeballed without a live server.
+- **Shell:** `sh -n`. **Compose:** `docker compose config`.
+
+Do **not** claim a page works end-to-end when you could only compile it. The
+owner tests on production; give them an honest picture of what's verified.
+
+---
+
+## GitHub Issue Tracking
+
+Non-trivial work should be linked to a GitHub issue in the relevant repo
+(**`isharmud/ishar-web`** for site work; cross-cutting infra that spans the game
+is often tracked in `isharmud/ishar-mud`). Reference the issue number in commits
+(`Relates to #NN`) and post a brief completion summary. Trivial changes (typos,
+one-line fixes) don't need an issue — use judgment.
+
+**Do not open a pull request unless explicitly asked.** When you do, mirror any
+PR template in `.github/` and describe only the diff.
+
+## Deploy
+
+The site is deployed like any game service: **`scripts/deploy.sh prod ishar-web`**
+in the `ishar-mud` repo (or the Deploy Console button, which calls the same path
+via the host agent). A deploy runs `collectstatic` on container start, so tracked
+CSS/JS changes land automatically — but only if they were force-added into git
+(see "`static/` is gitignored").

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,124 @@
+# Ishar Web — Design System
+
+This is the living source of truth for how ishar-web looks and why. It exists so
+the site can be faceflifted **incrementally and coherently** — every page we
+touch should pull from the same tokens, components, and principles instead of
+inventing a new look.
+
+Read this first, then:
+
+- **[tokens.md](tokens.md)** — the palette: colors, surfaces, text, semantics,
+  radii, motion. The variables everything keys off.
+- **[components.md](components.md)** — the component catalog: what exists, its
+  canonical markup, and where it's used.
+- **[decisions.md](decisions.md)** — the running log of design decisions (ADR
+  style). Append here whenever a call is made; don't relitigate settled ones.
+
+If you're an agent or a human about to change any visual surface: skim the
+principles below, grab the right tokens/components, and if you introduce or
+change a convention, **record it in `decisions.md` and update the catalog.**
+
+---
+
+## The one-paragraph summary
+
+Ishar is **dark-only**, built on **Bootstrap 5.3.8** + **Bootstrap Icons 1.13.1**
+(both self-hosted), with a **single amber accent** (`#fa7`) on light-grey text
+(`#d6d6d7`). The public site's identity is **black panels outlined in amber**
+(`.border-ishar`). Newer, richer surfaces (the connect HUD, the deploy console)
+use a **layered-grey token system** that reads more like a premium dashboard.
+The direction is to unify these behind one shared token + component layer while
+keeping the amber brand.
+
+---
+
+## Principles
+
+1. **Dark-only, no toggle.** `<html data-bs-theme="dark">` is forced in
+   `layout.html`. Design for dark; don't add a light theme.
+2. **Amber is the accent, used sparingly.** `#fa7` marks brand, focus, primary
+   actions, headers, and "live" state — not large fills. Overusing it flattens
+   the hierarchy.
+3. **Semantic colors are fixed.** ok = green, info = blue, warn = orange,
+   danger = red, immortal = cyan. Same meaning everywhere (see tokens.md). Never
+   repurpose them decoratively.
+4. **Motion is subtle and optional.** Transitions/animations must always be
+   wrapped by `@media (prefers-reduced-motion: reduce)`. No motion is load-bearing.
+5. **Accessible by default.** Real focus styles (`:focus-visible`), `aria-*` on
+   interactive/icon elements, sufficient contrast, and **JS updates the DOM with
+   `textContent`, never `innerHTML`**, for anything derived from data.
+6. **No new frontend libraries; self-host everything.** We ship Bootstrap +
+   Bootstrap Icons and a little vanilla JS. Don't add a framework, a CDN
+   dependency, or a web font without a decision entry.
+7. **Mobile-first.** The playerbase deploys and plays from phones. Every admin
+   tool and page must be usable at a phone width.
+8. **Icons via the SVG sprite.** Prefer
+   `<svg class="bi"><use href="…bootstrap-icons.svg#name"></svg>` over the font
+   classes — it inherits `currentColor` and scales cleanly.
+
+---
+
+## Visual layers (and where each applies)
+
+Three visual layers coexist today. This is deliberate, but they should share
+tokens and converge over time.
+
+| Layer | Where | Look | Source |
+|---|---|---|---|
+| **Classic** | Public site (home, portal, leaders, help, …) | Black panels, amber `.border-ishar` outline, blue links | `apps/core/static/css/style.css` |
+| **HUD** | The web telnet client (`/connect`) | Layered greys, colored vitals bars, gradient banner | `apps/connect/static/css/hud.css` |
+| **Admin Console** | Staff tooling (deploy console; feedback next) | Layered greys + amber accents, terminal panels, status pills | `apps/core/static/css/admin-console.css` |
+
+**Stance:** the **public shell keeps its amber-border identity** (it's
+recognizably Ishar), while **staff/admin tooling uses the Admin Console
+language** (it should feel like a purpose-built console). Both draw from **one
+shared token + semantic vocabulary** (tokens.md). The HUD predates the Admin
+Console layer but uses the same idea; over time its `--hud-*` tokens should be
+expressed in terms of the shared set.
+
+---
+
+## Facelift roadmap
+
+Incremental, page-by-page. Do the two enablers early so later pages are cheap.
+
+### Enablers (do these first)
+- **E1 · Shared token base.** Promote the Admin Console tokens (`--ac-*`) into a
+  small base stylesheet that any page can include (or fold into `style.css`), so
+  colors/surfaces/motion are defined once. Express `--hud-*` in terms of it.
+- **E2 · Shared components.** ishar-web has **no template partials or template
+  tags today** — markup is copy-pasted. Introduce `{% include %}` partials and a
+  `templatetags` module for the repeating pieces (icon, status pill, stat tile,
+  panel header, breadcrumb, empty state) so a component is defined once and
+  restyled once.
+
+### Page adoption order
+Staff surfaces first (highest value, lowest risk — few users, we control them):
+
+| # | Surface | Status |
+|---|---|---|
+| 1 | Deploy console (`/portal/deploy`) | ✅ done — the reference implementation |
+| 2 | Feedback triage (`/feedback`) | next |
+| 3 | Processes / other Django-admin-adjacent staff pages | later |
+| 4 | Portal (`/portal`) + global nav/layout shell | later |
+| 5 | Leaders, Challenges (DataTables pages) | later |
+| 6 | Connect HUD (align tokens) | later |
+| 7 | Home, help, errors, public content | last |
+
+### Recommended near-term addition
+- **A live `/styleguide` page** (staff-only) that renders every token and
+  component from this doc, with copy-paste markup. It becomes the fastest way to
+  build a consistent page and to eyeball regressions. Not built yet — a good
+  next step once E1/E2 land.
+
+---
+
+## How to use this when changing a page
+
+1. Reach for an existing **component** (components.md). If it's close, extend it;
+   don't fork it.
+2. Use **tokens** (tokens.md) for every color/space/radius — no ad-hoc hex.
+3. Respect the **principles** above (dark, sparing amber, fixed semantics,
+   reduced-motion, a11y, no new libs).
+4. If you make a genuinely new decision (a new component, a token change, a
+   deviation), **add a dated entry to decisions.md** and update the catalog.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,6 +18,12 @@ If you're an agent or a human about to change any visual surface: skim the
 principles below, grab the right tokens/components, and if you introduce or
 change a convention, **record it in `decisions.md` and update the catalog.**
 
+> **Green-field mandate.** We design ishar-web as if it were green field — **no
+> concern with breakage or comms, just optimal, unhandcuffed design** (see
+> `decisions.md`, and `../../CLAUDE.md`). Where a cleaner design exists, rebuild
+> rather than patch. The roadmap below covers the whole site, public pages
+> included, not only staff tooling.
+
 ---
 
 ## The one-paragraph summary
@@ -69,12 +75,14 @@ tokens and converge over time.
 | **HUD** | The web telnet client (`/connect`) | Layered greys, colored vitals bars, gradient banner | `apps/connect/static/css/hud.css` |
 | **Admin Console** | Staff tooling (deploy console; feedback next) | Layered greys + amber accents, terminal panels, status pills | `apps/core/static/css/admin-console.css` |
 
-**Stance:** the **public shell keeps its amber-border identity** (it's
-recognizably Ishar), while **staff/admin tooling uses the Admin Console
-language** (it should feel like a purpose-built console). Both draw from **one
-shared token + semantic vocabulary** (tokens.md). The HUD predates the Admin
-Console layer but uses the same idea; over time its `--hud-*` tokens should be
-expressed in terms of the shared set.
+**Stance:** **staff/admin tooling uses the Admin Console language** (it should
+feel like a purpose-built console). The **public shell keeps its amber-border
+look for now** — but under the green-field mandate that's a starting point, not a
+protected identity: public pages are in scope for the same convergence, and the
+amber-border treatment stays only where it's genuinely the best design. All
+layers draw from **one shared token + semantic vocabulary** (tokens.md). The HUD
+predates the Admin Console layer but uses the same idea; over time its `--hud-*`
+tokens should be expressed in terms of the shared set.
 
 ---
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -1,0 +1,194 @@
+# Component Catalog
+
+The building blocks. Two groups: **de-facto** patterns copy-pasted across the
+classic site (formalize these into partials as we go — enabler E2), and the
+**Admin Console** components (`.ac-*`), which are the reference for new staff
+tooling.
+
+For each: what it is, canonical markup, where it's used, and status.
+
+> Icons everywhere use the sprite:
+> `<svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#NAME"></use></svg>`
+
+---
+
+## Admin Console components
+
+Defined in `apps/core/static/css/admin-console.css`; load per page via
+`{% block includes %}`. Reference implementation:
+`apps/accounts/templates/deploy.html`.
+
+### `.ac-hero` — page header banner
+Gradient + 3px amber left edge, circular badge, title, subtitle, optional status
+pill on the right.
+```html
+<header class="ac-hero">
+  <span class="ac-hero__badge">{# icon #}</span>
+  <div class="ac-hero__text">
+    <h2 class="ac-hero__title">Deploy Console</h2>
+    <p class="ac-hero__sub">Short description with <code>code</code>.</p>
+  </div>
+  <div class="ac-hero__status">{# an .ac-pill #}</div>
+</header>
+```
+Status: **formalized.** Use as the top of any admin page.
+
+### `.ac-pill` — status pill
+Uppercase pill; `--muted/--ok/--info/--warn/--danger/--accent` modifiers. Add
+`.ac-pill--status` to get a leading dot (a `::before`, so JS may swap the label
+via `textContent`), and `.ac-pill--live` to make that dot pulse.
+```html
+<span class="ac-pill ac-pill--status ac-pill--ok ac-pill--live">agent online</span>
+```
+Status: **formalized.** This is the site's status-badge going forward
+(supersedes ad-hoc Bootstrap `badge bg-*` on admin surfaces).
+
+### `.ac-panel` + `.ac-panel__h` — section panel
+Bordered panel with an uppercase dim header (optionally an amber icon) and an
+optional `.ac-panel__hint`.
+```html
+<div class="ac-panel">
+  <div class="ac-panel__h">{# icon #} Environment</div>
+  <p class="ac-panel__hint">Helper text.</p>
+  …
+</div>
+```
+Status: **formalized.**
+
+### `.ac-seg` — segmented control
+Pill group of mutually exclusive options over hidden `.btn-check` radios (keeps
+`input[name=…]:checked` working). Intent tints via `--prod`/`--test`-style
+modifiers.
+```html
+<div class="ac-seg" role="radiogroup">
+  <input class="btn-check" type="radio" name="env" id="env-prod" checked>
+  <label class="ac-seg__item ac-seg__item--prod" for="env-prod">{# icon #} prod</label>
+  …
+</div>
+```
+Status: **formalized.**
+
+### `.ac-toggle` — selectable card
+Checkbox styled as a card (icon tile + name + note + check indicator), over a
+hidden `.btn-check`. Selected state uses the amber wash.
+```html
+<input class="btn-check" type="checkbox" name="services" id="svc-x">
+<label class="ac-toggle" for="svc-x">
+  <span class="ac-toggle__icon">{# icon #}</span>
+  <span class="ac-toggle__body">
+    <span class="ac-toggle__name">svc-x</span>
+    <span class="ac-toggle__note">what it is</span>
+  </span>
+  <span class="ac-toggle__check">{# check-circle-fill #}</span>
+</label>
+```
+Lay out in `.ac-grid` (responsive auto-fit). Status: **formalized.**
+
+### `.ac-switch` — labeled switch
+Bootstrap `form-check form-switch` recolored amber. Status: **formalized.**
+
+### `.ac-inputgroup` / `.ac-input` — icon input
+Input with a leading icon cell; focus ring is the amber wash.
+```html
+<div class="ac-inputgroup">
+  <span class="ac-inputgroup__icon">{# key #}</span>
+  <input class="ac-input" type="password" placeholder="…">
+</div>
+```
+Status: **formalized.**
+
+### `.ac-cta` — primary/destructive button
+Gradient button; `.ac-cta--ready` adds a gentle armed glow. Status:
+**formalized** (destructive/red today; add an accent variant when a
+non-destructive primary is needed).
+
+### `.ac-console` — job/log terminal
+Header bar with faux traffic-lights, a title, an `.ac-pill` status, a
+`tabular-nums` timer, and a copy button; an optional `.ac-console__step` row (a
+spinner + a headline parsed from `==>` lines); a monospace `.ac-console__body`
+log. Status: **formalized.** Use for any long-running job with streamed output.
+
+### `.ac-note` — callout
+`--warn`/`--danger` variants; icon + text. Use for inline warnings/heads-ups.
+```html
+<div class="ac-note ac-note--warn" role="alert">{# icon #} <span>…</span></div>
+```
+Status: **formalized.**
+
+---
+
+## Classic / de-facto patterns (formalize into partials)
+
+These are copy-pasted across templates today. Catalogued so we can extract them
+into `{% include %}` partials / template tags (E2) and, later, restyle once.
+
+### Panel (classic)
+`<div class="bg-black border-ishar my-1 p-2 rounded">` — the universal black +
+amber-outline container (`#content`, footer, messages, search form). The classic
+site's card idiom.
+
+### Breadcrumb item
+Every page reimplements:
+```html
+<li class="breadcrumb-item h2" title="…">
+  <a class="icon-link icon-link-hover" href="…">{# icon #} <span>Label</span></a>
+</li>
+```
+Admin/portal pages lead with a Portal crumb. Divider is `•`. **Prime candidate
+for a partial.**
+
+### Count pill
+`<span class="badge bg-dark rounded-pill border border-secondary">{{ n }}</span>`
+— the standard "stat count" chip (events, players-online, essence, upgrades).
+
+### Stat / KPI tile
+The feedback dashboard's clickable tile — big number + uppercase secondary label,
+semantic number color, zero-suppressed emphasis:
+```html
+<a class="text-decoration-none" href="?filter=…">
+  <div class="border bg-black card text-center p-2 h-100">
+    <span class="display-6 {% if n %}text-danger{% endif %}">{{ n }}</span>
+    <span class="text-secondary small text-uppercase">Label</span>
+  </div>
+</a>
+```
+Used in `apps/feedback/templates/feedback_dashboard.html`. **Formalize; the
+Admin Console equivalent should become an `.ac-tile`.**
+
+### Filter bar
+Row of `btn btn-sm btn-outline-*` toggles (active = solid), driven by Django's
+`{% querystring %}` tag, with an inline `role="search"` form. See the feedback
+dashboard. Candidate to standardize as `.ac-filter`.
+
+### Contextual badge
+`<span class="badge text-bg-{{ status_css }}">{{ status_label }}</span>` with the
+color map on the model. On admin surfaces, migrate to `.ac-pill--{ok|info|…}`.
+
+### Empty state
+`<div class="card"><div class="card-body"><p class="card-text fst-italic lead
+text-warning">No … found.</p></div></div>` (leaders/challenges) — or the feedback
+dashboard's `border bg-black card` italic variant. Standardize one.
+
+### DataTable
+`table table-hover table-dark table-flush table-sm table-responsive
+table-striped` with `text-ishar` headers + `table-group-divider`. Used on
+leaders & challenges (needs the DataTables include). Keep, but align header/hover
+colors to tokens.
+
+### `<details>/<summary>` section
+Collapsible with an `.anchor-link` "#" affordance + `h3/h4/h5` + count badge —
+the portal's section pattern.
+
+### Global nav "Portal" dropdown
+`apps/core/templates/layout.html` — the staff/admin menu (Administration,
+Deploy, Feedback Triage, …), gated by `is_staff`/`is_god`/`is_eternal`. The
+canonical place to surface a new staff tool (mirror the existing items).
+
+---
+
+## When adding a component
+
+1. Check this catalog first — extend, don't fork.
+2. Name it `.ac-*`, define it in `admin-console.css`, key it off tokens
+   (tokens.md), and guard any motion with `prefers-reduced-motion`.
+3. Add it here with markup + status, and log the decision in `decisions.md`.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,28 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-11 — Treat ishar-web as green field
+
+**Decision.** Design and refactor as if this were a green-field project: **no
+concern with breakage or comms — optimal, unhandcuffed design.** Where a cleaner
+design exists, rebuild rather than patch; don't preserve a pattern purely for
+backward compatibility. This supersedes prior compatibility hedging, including
+the "public shell keeps the amber-border identity *for recognizability*"
+framing — the amber-border look stays only where it's genuinely the best design,
+not because changing it would break continuity.
+
+**Why.** The audience is ~10–11 known players plus the developer; the impact zone
+is tiny, there are no external consumers, and no migration window to protect.
+Under those conditions, caution about change is pure drag on entropy reduction.
+The mandate is to converge the site's three ad-hoc visual layers into one
+coherent system, page by page, without hedging.
+
+**Notes.** "No concern with breakage" means no concern about *changing* things —
+not a license to ship broken, ugly, or inaccessible UI. Correctness, taste, and
+the verification bar (see `CLAUDE.md`) still hold. The facelift roadmap in
+`README.md` now covers the whole site, public pages included, not just staff
+tooling.
+
 ## 2026-07-11 — Establish the design system + Admin Console language
 
 **Decision.** Stand up `docs/design/` as the living source of truth (this doc,
@@ -20,9 +42,11 @@ implementation.
 **Why.** The site had grown three ad-hoc visual layers and no written
 conventions; a facelift needs a shared vocabulary or it fragments further.
 
-**Notes.** Public shell keeps the amber-border identity; staff tooling gets the
-richer layered-grey console look; both share one token/semantic set. Roadmap and
-enablers in `README.md`.
+**Notes.** Staff tooling gets the richer layered-grey console look; the public
+shell currently keeps the amber-border look. Both share one token/semantic set.
+Per the green-field decision above, the amber-border identity is kept only where
+it's the best design — public pages are in scope for the same convergence.
+Roadmap and enablers in `README.md`.
 
 ## 2026-07-11 — Dark-only, forced
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1,0 +1,82 @@
+# Design Decisions Log
+
+An append-only record of design decisions, newest first. Lightweight ADR: what
+we decided, and why. When you make a real design call — a new component, a token
+change, a deliberate deviation — add an entry. Don't relitigate settled ones;
+supersede with a new dated entry if something genuinely changes.
+
+Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Notes**.
+
+---
+
+## 2026-07-11 — Establish the design system + Admin Console language
+
+**Decision.** Stand up `docs/design/` as the living source of truth (this doc,
+`tokens.md`, `components.md`, `README.md`), and adopt the **Admin Console**
+visual language (`apps/core/static/css/admin-console.css`) as the reference for
+staff/admin tooling. The deploy console (`/portal/deploy`) is its first
+implementation.
+
+**Why.** The site had grown three ad-hoc visual layers and no written
+conventions; a facelift needs a shared vocabulary or it fragments further.
+
+**Notes.** Public shell keeps the amber-border identity; staff tooling gets the
+richer layered-grey console look; both share one token/semantic set. Roadmap and
+enablers in `README.md`.
+
+## 2026-07-11 — Dark-only, forced
+
+**Decision.** The site is dark-only (`<html data-bs-theme="dark">`); no light
+theme, no toggle. **Why.** It's the established identity and the game's own
+aesthetic; a second theme doubles the surface area for no clear benefit.
+
+## 2026-07-11 — Single amber accent, used sparingly
+
+**Decision.** `#fa7` (`--ishar-color` / `--ac-accent`) is the only brand accent.
+Reserve it for brand, focus, primary/live state, and headers — not large fills.
+**Why.** One disciplined accent keeps hierarchy legible; spreading amber
+everywhere flattens it.
+
+## 2026-07-11 — Fixed semantic color meanings
+
+**Decision.** ok=green `#4cbb17`, info=blue `#4a86cf`, warn=orange `#f80`,
+danger=red (`#d64b4b` console / `#d02b2b` classic), immortal=cyan `#00b7eb`.
+Same meaning on every surface; never decorative. **Why.** Predictable status
+reading across the whole app.
+
+## 2026-07-11 — Bootstrap Icons via the SVG sprite
+
+**Decision.** Prefer `<svg class="bi"><use href="…bootstrap-icons.svg#name">`
+over the icon-font classes. **Why.** Inherits `currentColor`, scales cleanly,
+and matches the dominant existing pattern.
+
+## 2026-07-11 — No new frontend libraries; self-host
+
+**Decision.** Ship only Bootstrap 5.3.8 + Bootstrap Icons 1.13.1 (self-hosted)
+plus small vanilla JS. No new framework, CDN dependency, or web font without a
+decision entry. **Why.** Keeps the site fast, offline-buildable, and simple for
+a solo maintainer.
+
+## 2026-07-11 — Motion is optional; reduced-motion always honored
+
+**Decision.** Every transition/animation is wrapped by
+`@media (prefers-reduced-motion: reduce)`; no motion is load-bearing. **Why.**
+Accessibility and taste — the UI must be fully usable and calm without motion.
+
+## 2026-07-11 — JS updates via textContent, not innerHTML
+
+**Decision.** Data-derived DOM updates use `textContent` (and class swaps), never
+`innerHTML`. Status pills carry their dot as a `::before` so labels can be
+swapped safely. **Why.** Removes an XSS foot-gun class and keeps updates cheap.
+
+---
+
+## Open decisions / to record when made
+
+- **E1 — shared token base:** where the canonical tokens live (fold `--ac-*` into
+  `style.css` vs a new `tokens.css` base include). Record when chosen.
+- **E2 — shared components:** the partial/templatetag structure for repeating
+  markup (icon, pill, tile, panel header, breadcrumb, empty state).
+- **Contextual badges:** migration path from Bootstrap `text-bg-*` to `.ac-pill`
+  on admin surfaces (and whether public pages follow).
+- **Live styleguide page:** whether to build a staff-only `/styleguide`.

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -1,0 +1,143 @@
+# Design Tokens
+
+The canonical palette and scales. Every color, surface, and radius on a
+faceflifted page should come from here — no ad-hoc hex.
+
+Two token sets exist today and are **cohesive by design** (same amber, same body
+text). The **Admin Console set (`--ac-*`) is the go-forward vocabulary**; the
+classic site currently hard-codes most of these values inline in `style.css`.
+The target (enabler E1) is one shared base that both express in terms of.
+
+Sources of truth:
+- `apps/core/static/css/admin-console.css` — the `--ac-*` tokens (defined as
+  `:root` custom properties; reference implementation).
+- `apps/core/static/css/style.css` — the classic values (only `--ishar-color` is
+  a variable today; the rest are literal).
+- `apps/connect/static/css/hud.css` — the HUD's `--hud-*` set (same idea, to be
+  aligned).
+
+---
+
+## Brand
+
+| Token | Value | Meaning |
+|---|---|---|
+| `--ac-accent` / `--ishar-color` | `#fa7` | The Ishar amber. Brand, focus, primary/live accents. Use sparingly. |
+| `--ac-accent-2` | `#ffd7b0` | Lighter amber for text/marks on amber washes (contrast). |
+
+The full hex of the brand amber is `#ffaa77` (that's what the `theme-color` /
+tile meta use); `#fa7` is the shorthand used in CSS.
+
+---
+
+## Surfaces (dark, layered)
+
+Surfaces step **up in lightness** as they come forward. Classic panels are pure
+black with an amber outline; Admin Console panels use the layered greys.
+
+| Token | Value | Use |
+|---|---|---|
+| `--ac-bg` | `#0c0c0d` | Deepest surface — page/console background, inset wells. |
+| `--ac-panel` | `#131316` | Panel / card surface. |
+| `--ac-elev` | `#1c1c22` | Raised / hover surface, chips, icon tiles. |
+| `--ac-border` | `#2a2a30` | Default hairline border. |
+| `--ac-border-2` | `#3a3a44` | Stronger border (hover/active/inputs). |
+| — (classic) | `#000` | Classic public panels (`.card`, `.navbar`, `.list-group`). |
+| — (classic) | `#323639` | Classic page background (`body`); also classic button/select bg. |
+
+The HUD equivalents: `--hud-bg #0c0c0d`, `--hud-panel #131316`, `--hud-border
+#2a2a30`, elevated `#1c1c22` — i.e. already the same values as `--ac-*`.
+
+---
+
+## Text
+
+| Token | Value | Use |
+|---|---|---|
+| `--ac-text` | `#d6d6d7` | Body text. The canonical foreground everywhere. |
+| `--ac-dim` | `#8a8a92` | Muted text: labels, hints, secondary meta. |
+| — | `#c7c7c9` | Console/log body text (slightly dimmer than body). |
+
+Headings, `<label>`, `<strong>`, `<th>`, `.card-header`, `.card-title`, and
+`.text-ishar` render in **amber** (`--ishar-color`) on the classic site — that's
+the site's "highlighted text" convention.
+
+---
+
+## Links (classic site)
+
+| State | Value |
+|---|---|
+| link | `#09f` (bright blue) |
+| active / visited | `#6082b6` (muted blue) |
+| hover | `#d6d6d7` (body text) |
+
+Admin Console surfaces generally avoid raw links in favor of buttons/pills; when
+a link is needed there, prefer `--ac-accent` on hover.
+
+---
+
+## Semantic colors (fixed meanings)
+
+Do not repurpose these. They mean the same thing on every surface.
+
+| Token | Value | Meaning |
+|---|---|---|
+| `--ac-ok` | `#4cbb17` | Success, healthy, safe, "moves" (HUD). Also `.message-success`, active season. |
+| `--ac-info` | `#4a86cf` | Informational, in-progress, "mana" (HUD). |
+| `--ac-warn` | `#f80` | Caution / heads-up. Also `.message-warn`/`.message-warning`. |
+| `--ac-danger` | `#d64b4b` | Destructive / error (Admin Console). |
+| — (classic danger) | `#d02b2b` | `.message-error`, dead/survival/hardcore players. |
+| — (immortal) | `#00b7eb` | Immortal accounts (god/forger/eternal/artisan/immortal/consort). Cyan. |
+| — (HUD gold) | `#cdcd00` | XP / currency in the HUD. |
+
+**Player-status vocabulary** (from `style.css`, used by `player_css`):
+- Immortals (`.god-player` … `.consort-player`): `#00b7eb`, with emoji affix
+  (`😇` god, `👼` other immortals).
+- Dead / survival / hardcore (`.dead-player`, …): `#d02b2b`; visited `#fa8072`;
+  hover `#f00`; affix `☠️`.
+
+**Status → color maps** (data-driven) live on the models, e.g. feedback's
+`status_css` (`apps/feedback/models/feedback.py`) emits Bootstrap contextual
+names (`success`/`danger`/`info`/`primary`/`warning`/`secondary`). Keep those in
+the model, render with Bootstrap `text-bg-*` or an `.ac-pill--*` modifier.
+
+---
+
+## Translucent washes
+
+Subtle tints for selected/active states and hero banners.
+
+| Token | Value |
+|---|---|
+| `--ac-wash` | `rgba(255,170,119,.12)` (amber) |
+| `--ac-ok-wash` | `rgba(76,187,23,.12)` |
+| `--ac-info-wash` | `rgba(74,134,207,.14)` |
+| `--ac-danger-wash` | `rgba(214,75,75,.14)` |
+
+---
+
+## Radii & motion
+
+| Token | Value | Use |
+|---|---|---|
+| `--ac-radius` | `.6rem` | Panels, hero, console. |
+| `--ac-radius-sm` | `.4rem` | Inputs, toggles, buttons, chips. |
+| pill radius | `999px` | Status pills, segmented control. |
+
+Motion: transitions are ~`.15s`; the few keyframes (`ac-pulse`, `ac-rotate`,
+`ac-glow`) live in `admin-console.css`. **All motion is disabled under**
+`@media (prefers-reduced-motion: reduce)` — match that whenever you add any.
+
+---
+
+## Typography
+
+- **No custom web fonts.** Body uses the Bootstrap system stack.
+- **Monospace** (`var(--bs-font-monospace, monospace)`) for logs, terminals,
+  service names, and code — anywhere "machine" text belongs.
+- **Section labels** are the dashboard signature: `UPPERCASE`, `font-weight:700`,
+  `letter-spacing:~.09em`, in `--ac-dim` (see `.ac-panel__h`). Use them for panel
+  headers on admin surfaces.
+- Numeric readouts that tick (timers, counts) use
+  `font-variant-numeric: tabular-nums` so they don't jitter.

--- a/readme.md
+++ b/readme.md
@@ -31,5 +31,11 @@ the getting started guide, or even by downloading a MUD client!
 The website is using a combination of Python, Django, MariaDB, nginx, and daphne
 among other things.
 
+### Design
+
+Visual/UI work follows the living design system in
+[`docs/design/`](docs/design/README.md) — tokens, components, principles, and a
+running decisions log. Read it before changing any page's look.
+
 The MUD itself is written in C,
 while relying upon "[Mocha](https://old.isharmud.com/mocha/)".


### PR DESCRIPTION
Stands up the source of truth for ishar-web's look, so the whole site can be faceflifted **incrementally and coherently** rather than as one-offs. The deploy console + `admin-console.css` proved out a real design language; this captures it (and the current state, decisions, and roadmap) as living docs future work keeps updating. A second commit adds a project **`CLAUDE.md`** and encodes the **green-field mandate**.

ishar-web had **three ad-hoc visual layers** (classic amber-border, connect HUD, the new admin-console) and **no written conventions** and **no `docs/` dir** — so this establishes the system fresh.

## New `docs/design/`
- **`README.md`** — index + guiding **principles** (dark-only; amber used sparingly; fixed semantic colors; reduced-motion always; a11y incl. `textContent`-not-`innerHTML`; no new frontend libs; mobile-first; sprite icons), the **layer stance**, and a **page-by-page facelift roadmap** with two enablers (a shared token base; shared Django partials/templatetags — neither exists today).
- **`tokens.md`** — the canonical palette with exact hex: brand amber (`#fa7`), layered-grey surfaces, text, fixed semantics (ok/info/warn/danger + immortal cyan + player-status vocabulary), washes, radii, motion, typography — cross-referenced to `style.css` / `hud.css` / `admin-console.css`.
- **`components.md`** — catalog of the admin-console components (`.ac-hero/-pill/-panel/-seg/-toggle/-switch/-inputgroup/-cta/-console/-note`, reference impl = the deploy console) **plus** the classic de-facto patterns to formalize into partials.
- **`decisions.md`** — an append-only ADR log, seeded with the decisions already made.

Root `readme.md` now points to it.

## `CLAUDE.md` + green-field mandate (2nd commit)
- New **`CLAUDE.md`** — project guide: identity (public site + `/connect` telnet client + staff tooling over the game's *shared* MariaDB, mostly `managed = False`), stack, conventions (CBV + 404-for-everyone gating mixins with `immortal_level` gates, POST/`JsonResponse` action views, the deploy-agent bridge), the `static/`-is-gitignored gotcha, the design-system pointer, and the verification playbook for when the site can't run end-to-end.
- **Green-field mandate** recorded in `decisions.md` and surfaced in `README.md`: design as if green field — *no concern with breakage or comms, just optimal unhandcuffed design* — which **supersedes** the earlier "keeps the amber-border identity for compatibility" hedging. Public pages are now in scope for the same convergence; the amber-border look is kept only where it's genuinely the best design, not as a protected identity. (Correctness/taste/verification still hold.)

## Notes
- **Documentation only** — no CSS or template changes. It defines the plan the later facelift executes.
- The docs reference `apps/core/static/css/admin-console.css`, which lands in the deploy-console PR (#63) — expected, since both are in-flight.
- Verified: internal links resolve; every classic hex cited matches `style.css`.

Relates to #1754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)