### PR TITLE
Land design-system enablers E1+E2; rebuild Feedback Triage as an Admin Console

### DIFF
--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -18,29 +18,11 @@
        (.ac-seg__item / .ac-toggle) so they stay accessible + keyboard-friendly.
      - Motion is subtle and ALWAYS disabled under prefers-reduced-motion.
    Load per-page via {% block includes %}, not globally.
-   ========================================================================== */
 
-:root {
-    --ac-accent:      #fa7;                      /* brand amber */
-    --ac-accent-2:    #ffd7b0;                   /* lighter amber for text-on-accent gradients */
-    --ac-bg:          #0c0c0d;                   /* deepest surface */
-    --ac-panel:       #131316;                   /* panel surface */
-    --ac-elev:        #1c1c22;                   /* raised / hover surface */
-    --ac-border:      #2a2a30;                   /* hairline border */
-    --ac-border-2:    #3a3a44;                   /* stronger border (hover/active) */
-    --ac-text:        #d6d6d7;                   /* body text */
-    --ac-dim:         #8a8a92;                   /* muted / labels */
-    --ac-ok:          #4cbb17;                   /* success / safe */
-    --ac-info:        #4a86cf;                   /* informational */
-    --ac-warn:        #f80;                      /* caution */
-    --ac-danger:      #d64b4b;                   /* destructive / error */
-    --ac-wash:        rgba(255, 170, 119, .12);  /* translucent amber wash */
-    --ac-ok-wash:     rgba(76, 187, 23, .12);
-    --ac-info-wash:   rgba(74, 134, 207, .14);
-    --ac-danger-wash: rgba(214, 75, 75, .14);
-    --ac-radius:      .6rem;
-    --ac-radius-sm:   .4rem;
-}
+   TOKENS LIVE IN style.css (enabler E1): the --ac-* custom properties are
+   defined once in the global stylesheet's :root, so this file is purely the
+   component layer and may be loaded on any page without redefining them.
+   ========================================================================== */
 
 /* Outer container so the console reads as one cohesive surface. */
 .ac {
@@ -50,6 +32,8 @@
     gap: 1rem;
     max-width: 60rem;
 }
+/* Wider variant for list/table-heavy consoles (triage dashboards). */
+.ac--wide { max-width: 72rem; }
 
 /* ------------------------------------------------------------------ hero -- */
 .ac-hero {
@@ -303,6 +287,8 @@
     background: rgba(255,170,119,.1);
     padding: .03rem .28rem; border-radius: .25rem;
 }
+.ac-note--ok     { border-color: rgba(76,187,23,.4);  background: var(--ac-ok-wash); }
+.ac-note--ok     .bi { color: var(--ac-ok); }
 .ac-note--warn   { border-color: rgba(255,136,0,.4);  background: rgba(255,136,0,.09); }
 .ac-note--warn   .bi { color: var(--ac-warn); }
 .ac-note--danger { border-color: rgba(214,75,75,.4);  background: var(--ac-danger-wash); }
@@ -484,6 +470,340 @@
     border-radius: 50%;
     animation: ac-rotate .7s linear infinite;
 }
+
+/* ------------------------------------------------------ stat tiles --- */
+/* Clickable KPI tiles (counts that filter a list). Semantic number color
+   comes from a modifier; pass --muted when the count is zero so only live
+   numbers draw the eye. --active marks the currently-applied filter. */
+.ac-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+    gap: .6rem;
+}
+.ac-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: .2rem;
+    padding: .9rem .6rem;
+    border-radius: var(--ac-radius);
+    background: var(--ac-panel);
+    border: 1px solid var(--ac-border);
+    text-decoration: none;
+    transition: background .15s, border-color .15s, transform .1s;
+}
+a.ac-tile:hover { background: var(--ac-elev); border-color: var(--ac-border-2); transform: translateY(-1px); }
+.ac-tile__n {
+    font-size: 1.9rem;
+    font-weight: 700;
+    line-height: 1.05;
+    color: var(--ac-text);
+    font-variant-numeric: tabular-nums;
+}
+.ac-tile__label {
+    font-size: .7rem;
+    font-weight: 700;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    color: var(--ac-dim);
+    text-align: center;
+}
+.ac-tile--ok     .ac-tile__n { color: var(--ac-ok); }
+.ac-tile--info   .ac-tile__n { color: var(--ac-info); }
+.ac-tile--warn   .ac-tile__n { color: var(--ac-warn); }
+.ac-tile--danger .ac-tile__n { color: var(--ac-danger); }
+.ac-tile--accent .ac-tile__n { color: var(--ac-accent); }
+.ac-tile--muted  .ac-tile__n { color: var(--ac-dim); }
+.ac-tile--active {
+    border-color: rgba(255, 170, 119, .55);
+    background: var(--ac-wash);
+    box-shadow: inset 0 0 0 1px rgba(255, 170, 119, .25);
+}
+
+/* ------------------------------------------------------ filter bar --- */
+/* Rows of mutually exclusive chip links (active = amber wash), grouped per
+   dimension; compose with an inline role=search form for text/sort. */
+.ac-filter {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .35rem;
+}
+.ac-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    padding: .28rem .7rem;
+    border-radius: 999px;
+    font-size: .8rem;
+    font-weight: 600;
+    text-decoration: none;
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+    transition: background .15s, border-color .15s, color .15s;
+}
+/* a.-qualified color rules: the global `a:link` rule outspecifies a bare
+   class, so chips/tiles/rows must pin their own link colors. */
+.ac-chip, a.ac-chip:link, a.ac-chip:visited { color: var(--ac-dim); }
+.ac-chip:hover, a.ac-chip:hover { color: var(--ac-text); background: var(--ac-elev); }
+.ac-chip--active,
+a.ac-chip--active:link, a.ac-chip--active:visited {
+    color: var(--ac-accent);
+    border-color: rgba(255, 170, 119, .45);
+    background: var(--ac-wash);
+}
+a.ac-chip--active:hover { color: var(--ac-accent-2); background: var(--ac-wash); }
+.ac-filter__sep {
+    width: 1px;
+    align-self: stretch;
+    background: var(--ac-border);
+    margin: .15rem .3rem;
+}
+
+/* --------------------------------------------------------- buttons --- */
+/* Small secondary action buttons (the .ac-cta stays the page's one primary).
+   Semantic variants color text/border; hover fills the matching wash. */
+.ac-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .35rem;
+    padding: .38rem .75rem;
+    border-radius: var(--ac-radius-sm);
+    font-size: .8rem;
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--ac-text);
+    background: var(--ac-elev);
+    border: 1px solid var(--ac-border-2);
+    cursor: pointer;
+    transition: background .15s, border-color .15s, color .15s, transform .1s;
+}
+.ac-btn .bi { width: .95rem; height: .95rem; }
+a.ac-btn:link, a.ac-btn:visited { color: var(--ac-text); }
+.ac-btn:hover:not(:disabled), a.ac-btn:hover { color: var(--ac-accent); border-color: rgba(255, 170, 119, .45); }
+.ac-btn:active:not(:disabled) { transform: translateY(1px); }
+.ac-btn:disabled { opacity: .5; cursor: not-allowed; }
+.ac-btn:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: 2px; }
+.ac-btn--ok     { color: var(--ac-ok);     border-color: rgba(76, 187, 23, .45); }
+.ac-btn--ok:hover:not(:disabled)     { color: var(--ac-ok);     border-color: var(--ac-ok);     background: var(--ac-ok-wash); }
+.ac-btn--info   { color: var(--ac-info);   border-color: rgba(74, 134, 207, .45); }
+.ac-btn--info:hover:not(:disabled)   { color: var(--ac-info);   border-color: var(--ac-info);   background: var(--ac-info-wash); }
+.ac-btn--warn   { color: var(--ac-warn);   border-color: rgba(255, 136, 0, .45); }
+.ac-btn--warn:hover:not(:disabled)   { color: var(--ac-warn);   border-color: var(--ac-warn);   background: var(--ac-warn-wash); }
+.ac-btn--danger { color: var(--ac-danger); border-color: rgba(214, 75, 75, .5); }
+.ac-btn--danger:hover:not(:disabled) { color: var(--ac-danger); border-color: var(--ac-danger); background: var(--ac-danger-wash); }
+.ac-btn--accent { color: var(--ac-accent); border-color: rgba(255, 170, 119, .45); }
+.ac-btn--accent:hover:not(:disabled) { color: var(--ac-accent); background: var(--ac-wash); }
+
+/* ---------------------------------------------------------- fields --- */
+/* Bare input/textarea/select on console surfaces (the icon-cell variant is
+   .ac-inputgroup). Class rules out-rank the classic element styles. */
+.ac-field {
+    display: block;
+    width: 100%;
+    padding: .5rem .7rem;
+    font-size: .9rem;
+    color: var(--ac-text);
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius-sm);
+    transition: border-color .15s, box-shadow .15s;
+}
+.ac-field:focus {
+    outline: none;
+    border-color: var(--ac-accent);
+    box-shadow: 0 0 0 .2rem var(--ac-wash);
+}
+.ac-field::placeholder { color: #5b5b63; }
+.ac-field--inline { display: inline-block; width: auto; }
+select.ac-field { cursor: pointer; }
+.ac-label {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    margin: 0 0 .3rem;
+    font-size: .7rem;
+    font-weight: 700;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    color: var(--ac-dim);
+}
+
+/* ---------------------------------------------------------- row list --- */
+/* The console's list-of-records surface (mobile-first replacement for the
+   data table): one bordered stack, each record a wrapping flex row. */
+.ac-rows {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius);
+    background: var(--ac-panel);
+    overflow: hidden;
+}
+.ac-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .35rem .75rem;
+    padding: .65rem .85rem;
+    border-bottom: 1px solid var(--ac-border);
+    transition: background .15s;
+}
+.ac-row:last-child { border-bottom: 0; }
+.ac-row:hover { background: var(--ac-elev); }
+.ac-row__icon {
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--ac-radius-sm);
+    color: var(--ac-dim);
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+}
+.ac-row__icon .bi { width: 1rem; height: 1rem; }
+.ac-row__main { flex: 1 1 14rem; min-width: 0; }
+.ac-row__title {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .35rem;
+    font-size: .95rem;
+}
+a.ac-row__link:link, a.ac-row__link:visited { color: var(--ac-text); text-decoration: none; }
+a.ac-row__link:hover { color: var(--ac-accent); }
+.ac-row__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .1rem .8rem;
+    margin-top: .1rem;
+    font-size: .78rem;
+    color: var(--ac-dim);
+}
+.ac-row__meta .mono { font-family: var(--bs-font-monospace, monospace); }
+.ac-row__side {
+    margin-left: auto;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+}
+
+/* ------------------------------------------------------ empty state --- */
+.ac-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .5rem;
+    padding: 2.2rem 1rem;
+    border: 1px dashed var(--ac-border-2);
+    border-radius: var(--ac-radius);
+    background: var(--ac-bg);
+    color: var(--ac-dim);
+    text-align: center;
+    font-size: .9rem;
+}
+.ac-empty .bi { width: 1.6rem; height: 1.6rem; opacity: .7; }
+
+/* ----------------------------------------------------------- pager --- */
+.ac-pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: .6rem;
+}
+.ac-pager__info {
+    color: var(--ac-dim);
+    font-size: .8rem;
+    font-variant-numeric: tabular-nums;
+}
+
+/* -------------------------------------------------------- timeline --- */
+/* Comment/audit trail. System entries recede (dashed, dim, italic) so human
+   conversation stays foreground. */
+.ac-timeline { display: flex; flex-direction: column; gap: .55rem; }
+.ac-tl {
+    display: flex;
+    gap: .7rem;
+    padding: .7rem .85rem;
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius-sm);
+    background: var(--ac-panel);
+}
+.ac-tl__icon {
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    width: 1.9rem;
+    height: 1.9rem;
+    border-radius: 50%;
+    color: var(--ac-dim);
+    background: var(--ac-elev);
+    border: 1px solid var(--ac-border);
+}
+.ac-tl__icon .bi { width: .95rem; height: .95rem; }
+.ac-tl__body { flex: 1 1 auto; min-width: 0; }
+.ac-tl__head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: .2rem .6rem;
+    font-size: .78rem;
+    color: var(--ac-dim);
+}
+.ac-tl__author { font-weight: 600; color: var(--ac-text); }
+.ac-tl__author--staff { color: var(--ac-info); }
+.ac-tl__time { margin-left: auto; white-space: nowrap; }
+.ac-tl__text {
+    margin-top: .25rem;
+    font-size: .9rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.ac-tl--system { background: var(--ac-bg); border-style: dashed; }
+.ac-tl--system .ac-tl__text { color: var(--ac-dim); font-style: italic; font-size: .82rem; }
+
+/* ------------------------------------------------------- quote body --- */
+/* Verbatim player/machine text (report bodies, pasted output): monospace on
+   the deepest surface, like a captured terminal excerpt. */
+.ac-quote {
+    margin: 0;
+    padding: .85rem 1rem;
+    border: 1px solid var(--ac-border);
+    border-left: 3px solid var(--ac-border-2);
+    border-radius: var(--ac-radius-sm);
+    background: var(--ac-bg);
+    color: var(--ac-text);
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: .88rem;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+/* --------------------------------------------- key/value definition --- */
+.ac-kv {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: .4rem 1rem;
+    font-size: .88rem;
+}
+.ac-kv dt { color: var(--ac-dim); font-weight: 500; }
+.ac-kv dd { margin: 0; text-align: right; min-width: 0; overflow-wrap: anywhere; }
+
+/* ----------------------------------------------------- CTA variants --- */
+/* Amber "go" primary for non-destructive consoles (the red default stays
+   for destructive actions like deploys). */
+.ac-cta--accent {
+    border-color: rgba(255, 170, 119, .6);
+    background: linear-gradient(180deg, #ffb385 0%, #dd8a52 100%);
+    color: #231005;
+}
+.ac-cta--accent:hover:not(:disabled) { box-shadow: 0 0 0 .2rem var(--ac-wash); }
 
 /* ---------------------------------------------------------- motion --- */
 @keyframes ac-pulse {

--- a/apps/core/static/css/style.css
+++ b/apps/core/static/css/style.css
@@ -1,6 +1,52 @@
-:root {--ishar-color: #fa7; }
+/* ==========================================================================
+   style.css — Ishar global stylesheet + shared design tokens
+   --------------------------------------------------------------------------
+   The :root block below is the site-wide token base (design-system enabler
+   E1 — see docs/design/tokens.md). It is loaded on every page via layout.html,
+   so any stylesheet (admin-console.css, hud.css, per-page CSS) may reference
+   the --ac-* / --ishar-* custom properties without redefining them.
+   ========================================================================== */
+:root {
+    /* Brand */
+    --ishar-color:    #fa7;                      /* the Ishar amber (alias of --ac-accent) */
+    --ac-accent:      #fa7;                      /* brand amber */
+    --ac-accent-2:    #ffd7b0;                   /* lighter amber for text/marks on amber washes */
+
+    /* Surfaces (dark, layered — step up in lightness as they come forward) */
+    --ac-bg:          #0c0c0d;                   /* deepest surface */
+    --ac-panel:       #131316;                   /* panel surface */
+    --ac-elev:        #1c1c22;                   /* raised / hover surface */
+    --ac-border:      #2a2a30;                   /* hairline border */
+    --ac-border-2:    #3a3a44;                   /* stronger border (hover/active) */
+
+    /* Text */
+    --ac-text:        #d6d6d7;                   /* body text */
+    --ac-dim:         #8a8a92;                   /* muted / labels */
+
+    /* Semantics (fixed meanings — never decorative) */
+    --ac-ok:          #4cbb17;                   /* success / safe */
+    --ac-info:        #4a86cf;                   /* informational */
+    --ac-warn:        #f80;                      /* caution */
+    --ac-danger:      #d64b4b;                   /* destructive / error */
+
+    /* Translucent washes */
+    --ac-wash:        rgba(255, 170, 119, .12);  /* amber */
+    --ac-ok-wash:     rgba(76, 187, 23, .12);
+    --ac-info-wash:   rgba(74, 134, 207, .14);
+    --ac-warn-wash:   rgba(255, 136, 0, .12);
+    --ac-danger-wash: rgba(214, 75, 75, .14);
+
+    /* Radii */
+    --ac-radius:      .6rem;
+    --ac-radius-sm:   .4rem;
+}
 
 .border-ishar { border: 0.1rem solid var(--ishar-color); }
+
+/* Sprite icons ({% bi %}) default to text-size; explicit width/height
+   attributes (e.g. the connect HUD) still win via :not([width]). */
+svg.bi:not([width]) { width: 1em; height: 1em; }
+.bi { vertical-align: -.125em; fill: currentColor; }
 
 .navbar, .navbar-expand-lg .navbar-nav .nav-link, .list-group, .list-group-item, .card { background-color: #000; }
 
@@ -32,9 +78,9 @@ a[target="_blank"] {
     }
 }
 
-body { background-color: #323639; color: #d6d6d7; }
+body { background-color: #323639; color: var(--ac-text); }
 .card-header, .card-title { color: var(--ishar-color); }
-.card, .card-text, .card-footer { color: #d6d6d7; }
+.card, .card-text, .card-footer { color: var(--ac-text); }
 button, textarea, select {
     border: 0.1rem solid var(--ishar-color);
     background-color: #323639;
@@ -84,7 +130,7 @@ summary h5 {
 
 a:link { color: #09f; text-decoration: none; }
 a:active, a:visited { color: #6082b6; }
-a:hover { color: #d6d6d7; }
+a:hover { color: var(--ac-text); }
 
 a img:hover{ opacity: 0.8; }
 
@@ -129,8 +175,8 @@ a.hardcore-player:hover {
 .dead-player::after { content: ' ☠️'; }
 
 .message-info { color: #09f; }
-.message-success, .active-season td { color: #4cbb17; }
-.message-warn, .message-warning  { color: #f80; }
+.message-success, .active-season td { color: var(--ac-ok); }
+.message-warn, .message-warning  { color: var(--ac-warn); }
 
 .two-col { column-count: 2; }
 .challenge-completed {

--- a/apps/core/templates/partials/crumb.html
+++ b/apps/core/templates/partials/crumb.html
@@ -1,0 +1,14 @@
+{% load ishar %}
+<li class="breadcrumb-item{% if active %} active{% endif %} h2"{% if active %} aria-current="page"{% endif %} title="{{ label }}">
+{% if href %}
+    <a class="icon-link icon-link-hover" href="{{ href }}">
+        {% bi icon %}
+        <span{% if anchor %} id="{{ anchor }}"{% endif %}>{{ label }}</span>
+    </a>
+{% else %}
+    <span class="icon-link">
+        {% bi icon %}
+        <span{% if anchor %} id="{{ anchor }}"{% endif %}>{{ label }}</span>
+    </span>
+{% endif %}
+</li>

--- a/apps/core/templatetags/ishar.py
+++ b/apps/core/templatetags/ishar.py
@@ -1,0 +1,61 @@
+"""
+Shared template tags for the Ishar design system (enabler E2).
+
+`{% load ishar %}` then:
+
+    {% bi "rocket-takeoff" %}                        icon via the SVG sprite
+    {% bi "lock-fill" css="text-warning" label="Private" %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Deploy" "rocket-takeoff" urlname="deploy" anchor="deploy" active=True %}
+
+Keep these tags tiny and presentation-only; anything data-driven (status maps,
+labels) belongs on the model. See docs/design/components.md.
+"""
+from django import template
+from django.templatetags.static import static
+from django.urls import reverse
+from django.utils.html import format_html
+
+register = template.Library()
+
+
+@register.simple_tag
+def bi(name, css="", label=""):
+    """A Bootstrap Icons sprite icon.
+
+    Decorative by default (aria-hidden); pass `label` to make it meaningful
+    (role=img + aria-label). `css` appends classes to the standard `bi`.
+    """
+    classes = f"bi {css}".strip()
+    href = f"{static('bootstrap-icons/bootstrap-icons.svg')}#{name}"
+    if label:
+        return format_html(
+            '<svg class="{}" role="img" aria-label="{}"><use xlink:href="{}"></use></svg>',
+            classes, label, href,
+        )
+    return format_html(
+        '<svg class="{}" aria-hidden="true"><use xlink:href="{}"></use></svg>',
+        classes, href,
+    )
+
+
+@register.inclusion_tag("partials/crumb.html")
+def crumb(label, icon, urlname="", anchor="", active=False):
+    """One breadcrumb item, the site-wide pattern.
+
+    `urlname` is reversed to an href (with `#anchor` appended when given);
+    omit it for a plain, unlinked crumb. `anchor` also becomes the id of the
+    label span so `focusTo` deep-linking keeps working.
+    """
+    href = ""
+    if urlname:
+        href = reverse(urlname)
+        if anchor:
+            href = f"{href}#{anchor}"
+    return {
+        "label": label,
+        "icon": icon,
+        "href": href,
+        "anchor": anchor,
+        "active": active,
+    }

--- a/apps/feedback/models/feedback.py
+++ b/apps/feedback/models/feedback.py
@@ -314,3 +314,18 @@ class Feedback(models.Model):
         if self.resolution == FeedbackResolution.DUPLICATE:
             return "warning"
         return "secondary"
+
+    @property
+    def status_pill(self) -> str:
+        """Admin Console pill modifier (.ac-pill--*) for the status."""
+        if self.is_open():
+            return "ok" if self.is_acknowledged() else "danger"
+        if self.is_in_progress():
+            return "info"
+        if self.resolution == FeedbackResolution.FIXED:
+            return "accent"
+        if self.resolution == FeedbackResolution.WONTFIX:
+            return "danger"
+        if self.resolution == FeedbackResolution.DUPLICATE:
+            return "warn"
+        return "muted"

--- a/apps/feedback/templates/feedback_dashboard.html
+++ b/apps/feedback/templates/feedback_dashboard.html
@@ -1,184 +1,178 @@
 {% extends "layout.html" %}
 {% load humanize %}
+{% load ishar %}
 {% load static %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Feedback Triage{% endblock meta_title %}
 {% block meta_description %}Staff feedback triage for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
 {% block meta_url %}{% url 'feedback' %}#feedback{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Feedback Triage{% endblock title %}
 {% block scripts %}let focusTo = 'feedback'{% endblock scripts %}
+{% block includes %}
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
+{% endblock includes %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item h2" title="Portal">
-        <a class="icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-            </svg>
-            <span id="portal">Portal</span>
-        </a>
-    </li>
-    <li class="breadcrumb-item active h2" aria-current="page" title="Feedback Triage">
-        <a class="icon-link icon-link-hover" href="{% url 'feedback' %}#feedback">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#flag"></use>
-            </svg>
-            <span id="feedback">Feedback Triage</span>
-        </a>
-    </li>
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Feedback Triage" "flag" urlname="feedback" anchor="feedback" active=True %}
 {% endblock breadcrumbs %}
 {% block content %}
+<div class="ac ac--wide">
 
-{# ---- Summary tiles ------------------------------------------------------ #}
-<div class="row g-2 mb-3">
-    <div class="col-6 col-lg-3">
-        <a class="text-decoration-none" href="{% url 'feedback' %}?show=active">
-            <div class="border bg-black card text-center p-2 h-100">
-                <span class="display-6">{{ counts.active }}</span>
-                <span class="text-secondary small text-uppercase">Active</span>
-            </div>
-        </a>
-    </div>
-    <div class="col-6 col-lg-3">
-        <a class="text-decoration-none" href="{% url 'feedback' %}?flag=unacked">
-            <div class="border border-danger-subtle bg-black card text-center p-2 h-100">
-                <span class="display-6 {% if counts.unacked %}text-danger{% endif %}">{{ counts.unacked }}</span>
-                <span class="text-secondary small text-uppercase">Unacknowledged</span>
-            </div>
-        </a>
-    </div>
-    <div class="col-6 col-lg-3">
-        <a class="text-decoration-none" href="{% url 'feedback' %}?show=in_progress">
-            <div class="border bg-black card text-center p-2 h-100">
-                <span class="display-6 text-info">{{ counts.in_progress }}</span>
-                <span class="text-secondary small text-uppercase">In Progress</span>
-            </div>
-        </a>
-    </div>
-    <div class="col-6 col-lg-3">
-        <a class="text-decoration-none" href="{% url 'feedback' %}?flag=bountied">
-            <div class="border bg-black card text-center p-2 h-100">
-                <span class="display-6 text-warning">{{ counts.bountied }}</span>
-                <span class="text-secondary small text-uppercase">Bountied</span>
-            </div>
-        </a>
-    </div>
-</div>
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "flag" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Feedback Triage</h2>
+            <p class="ac-hero__sub">
+                Player <code>bug</code> / <code>typo</code> / <code>idea</code> reports from the game and Discord.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+{% if counts.unacked %}
+            <span class="ac-pill ac-pill--status ac-pill--danger ac-pill--live" title="Open reports no staff member has claimed yet">
+                {{ counts.unacked }} unacknowledged
+            </span>
+{% else %}
+            <span class="ac-pill ac-pill--status ac-pill--ok" title="Every open report has been claimed">
+                inbox clear
+            </span>
+{% endif %}
+        </div>
+    </header>
 
-{# ---- Filter bar --------------------------------------------------------- #}
-<div class="border bg-black card p-2 mb-3">
-    <div class="d-flex flex-wrap gap-1 mb-2" role="group" aria-label="State filter">
-        {% for key, label in show_filters %}
-        <a class="btn btn-sm {% if current.show == key %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
-           href="{% querystring show=key page=None %}">{{ label }}</a>
-        {% endfor %}
+    <!-- Stat tiles -->
+    <div class="ac-tiles">
+        <a class="ac-tile ac-tile--accent{% if current.show == 'active' and not current.flag %} ac-tile--active{% endif %}"
+           href="{% url 'feedback' %}?show=active">
+            <span class="ac-tile__n">{{ counts.active }}</span>
+            <span class="ac-tile__label">Active</span>
+        </a>
+        <a class="ac-tile {% if counts.unacked %}ac-tile--danger{% else %}ac-tile--muted{% endif %}{% if current.flag == 'unacked' %} ac-tile--active{% endif %}"
+           href="{% url 'feedback' %}?flag=unacked">
+            <span class="ac-tile__n">{{ counts.unacked }}</span>
+            <span class="ac-tile__label">Unacknowledged</span>
+        </a>
+        <a class="ac-tile {% if counts.in_progress %}ac-tile--info{% else %}ac-tile--muted{% endif %}{% if current.show == 'in_progress' and not current.flag %} ac-tile--active{% endif %}"
+           href="{% url 'feedback' %}?show=in_progress">
+            <span class="ac-tile__n">{{ counts.in_progress }}</span>
+            <span class="ac-tile__label">In Progress</span>
+        </a>
+        <a class="ac-tile {% if counts.bountied %}ac-tile--warn{% else %}ac-tile--muted{% endif %}{% if current.flag == 'bountied' %} ac-tile--active{% endif %}"
+           href="{% url 'feedback' %}?flag=bountied">
+            <span class="ac-tile__n">{{ counts.bountied }}</span>
+            <span class="ac-tile__label">Bountied</span>
+        </a>
     </div>
-    <div class="d-flex flex-wrap gap-1 mb-2" role="group" aria-label="Type filter">
-        <a class="btn btn-sm {% if not current.type %}btn-primary{% else %}btn-outline-primary{% endif %}"
-           href="{% querystring type=None page=None %}">All types</a>
-        {% for value, label in feedback_types %}
-        <a class="btn btn-sm {% if current.type == value %}btn-primary{% else %}btn-outline-primary{% endif %}"
-           href="{% querystring type=value page=None %}">{{ label }}</a>
-        {% endfor %}
-    </div>
-    <div class="d-flex flex-wrap gap-1 align-items-center">
-        {% for f in flag_filters %}
-        <a class="btn btn-sm {% if current.flag == f %}btn-warning{% else %}btn-outline-warning{% endif %} text-capitalize"
-           href="{% querystring flag=f page=None %}">{{ f }}</a>
-        {% endfor %}
-        {% if current.flag %}
-        <a class="btn btn-sm btn-outline-light" href="{% querystring flag=None page=None %}">clear</a>
-        {% endif %}
-        <form class="d-flex ms-auto gap-1" method="get" role="search">
+
+    <!-- Filters -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "funnel" %} Filters</div>
+        <div class="ac-filter mb-2" role="group" aria-label="State filter">
+{% for key, label in show_filters %}
+            <a class="ac-chip{% if current.show == key %} ac-chip--active{% endif %}"
+               href="{% querystring show=key page=None %}">{{ label }}</a>
+{% endfor %}
+        </div>
+        <div class="ac-filter mb-2" role="group" aria-label="Type filter">
+            <a class="ac-chip{% if not current.type %} ac-chip--active{% endif %}"
+               href="{% querystring type=None page=None %}">All types</a>
+{% for value, label in feedback_types %}
+            <a class="ac-chip{% if current.type == value %} ac-chip--active{% endif %}"
+               href="{% querystring type=value page=None %}">{{ label }}</a>
+{% endfor %}
+            <span class="ac-filter__sep" aria-hidden="true"></span>
+{% for f in flag_filters %}
+            <a class="ac-chip text-capitalize{% if current.flag == f %} ac-chip--active{% endif %}"
+               href="{% querystring flag=f page=None %}">{{ f }}</a>
+{% endfor %}
+{% if current.flag %}
+            <a class="ac-chip" href="{% querystring flag=None page=None %}" title="Clear the flag filter">
+                {% bi "x-lg" %} clear
+            </a>
+{% endif %}
+        </div>
+        <form class="d-flex flex-wrap gap-2 align-items-center" method="get" role="search">
             <input type="hidden" name="show" value="{{ current.show }}">
-            {% if current.type %}<input type="hidden" name="type" value="{{ current.type }}">{% endif %}
-            {% if current.flag %}<input type="hidden" name="flag" value="{{ current.flag }}">{% endif %}
-            <input class="form-control form-control-sm bg-dark text-light border-secondary" type="search"
+{% if current.type %}
+            <input type="hidden" name="type" value="{{ current.type }}">
+{% endif %}
+{% if current.flag %}
+            <input type="hidden" name="flag" value="{{ current.flag }}">
+{% endif %}
+            <input class="ac-field ac-field--inline flex-grow-1" style="min-width: 12rem;" type="search"
                    name="q" value="{{ current.q }}" placeholder="Search text, name, #id" aria-label="Search">
-            <select class="form-select form-select-sm bg-dark text-light border-secondary w-auto" name="sort" onchange="this.form.submit()" aria-label="Sort">
+            <select class="ac-field ac-field--inline" name="sort" onchange="this.form.submit()" aria-label="Sort">
                 <option value="newest" {% if current.sort == "newest" %}selected{% endif %}>Newest</option>
                 <option value="oldest" {% if current.sort == "oldest" %}selected{% endif %}>Oldest</option>
                 <option value="level" {% if current.sort == "level" %}selected{% endif %}>Level</option>
             </select>
-            <button class="btn btn-sm btn-outline-light" type="submit">Go</button>
+            <button class="ac-btn" type="submit">{% bi "search" %} Search</button>
         </form>
     </div>
-</div>
 
-{# ---- Reports table ------------------------------------------------------ #}
+    <!-- Reports -->
 {% if reports %}
-<div class="table-responsive">
-    <table class="table table-dark table-hover table-sm align-middle border">
-        <thead>
-            <tr class="text-secondary small text-uppercase">
-                <th scope="col">#</th>
-                <th scope="col">Type</th>
-                <th scope="col">Status</th>
-                <th scope="col">Summary</th>
-                <th scope="col">Reporter</th>
-                <th scope="col">Src</th>
-                <th scope="col">Age</th>
-                <th scope="col" class="text-end">Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for report in reports %}
-            <tr id="row-{{ report.pk }}">
-                <td class="text-secondary">{{ report.pk }}</td>
-                <td title="{{ report.get_feedback_type_display }}">
-                    <svg class="bi" aria-hidden="true" width="16" height="16">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{{ report.type_icon }}"></use>
-                    </svg>
-                </td>
-                <td>
-                    <span class="badge text-bg-{{ report.status_css }}" data-role="status">{{ report.status_label }}</span>
-                </td>
-                <td>
-                    <a class="link-light text-decoration-none" href="{% url 'feedback_detail' report.pk %}">
-                        {{ report.summary }}
-                    </a>
-                    {% if report.is_private %}<svg class="bi text-warning" title="Private" aria-label="Private" width="14" height="14"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#lock-fill"></use></svg>{% endif %}
-                    {% if report.bountied %}<svg class="bi text-warning" title="Bountied" aria-label="Bountied" width="14" height="14"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#coin"></use></svg>{% endif %}
-                    {% if report.github_issue_url %}<a href="{{ report.github_issue_url }}" target="_blank" rel="noopener" title="GitHub issue"><svg class="bi text-info" aria-label="GitHub issue" width="14" height="14"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#github"></use></svg></a>{% endif %}
-                    {% if report.num_comments %}<span class="badge rounded-pill text-bg-dark border border-secondary" title="{{ report.num_comments }} comment{{ report.num_comments|pluralize }}">{{ report.num_comments }}</span>{% endif %}
-                </td>
-                <td class="small">
-                    {{ report.player_name|default:"—" }}{% if report.player_level %} <span class="text-secondary">({{ report.player_level }})</span>{% endif %}
-                </td>
-                <td class="small text-secondary text-capitalize">{{ report.source }}</td>
-                <td class="small text-secondary" title="{{ report.created_at }}">{{ report.created_at|naturaltime|default:"—" }}</td>
-                <td class="text-end text-nowrap">
-                    {% if report.is_unacknowledged %}
-                    <button class="btn btn-sm btn-outline-success fb-action" data-id="{{ report.pk }}" data-action="ack" title="Acknowledge">Ack</button>
-                    {% elif report.acknowledged_by %}
-                    <span class="text-secondary small" title="Acknowledged by {{ report.acknowledged_by }}">✓ {{ report.acknowledged_by }}</span>
-                    {% endif %}
-                    <a class="btn btn-sm btn-outline-light" href="{% url 'feedback_detail' report.pk %}">Open</a>
-                </td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-</div>
+    <div class="ac-rows">
+{% for report in reports %}
+        <div class="ac-row" id="row-{{ report.pk }}">
+            <span class="ac-row__icon" title="{{ report.get_feedback_type_display }}">
+                {% bi report.type_icon label=report.get_feedback_type_display %}
+            </span>
+            <div class="ac-row__main">
+                <div class="ac-row__title">
+                    <a class="ac-row__link" href="{% url 'feedback_detail' report.pk %}">{{ report.summary }}</a>
+{% if report.is_private %}
+                    {% bi "lock-fill" css="text-warning" label="Private" %}
+{% endif %}
+{% if report.bountied %}
+                    {% bi "coin" css="text-warning" label="Bountied" %}
+{% endif %}
+{% if report.github_issue_url %}
+                    <a href="{{ report.github_issue_url }}" target="_blank" rel="noopener" title="GitHub issue">{% bi "github" css="text-info" label="GitHub issue" %}</a>
+{% endif %}
+                </div>
+                <div class="ac-row__meta">
+                    <span class="mono">#{{ report.pk }}</span>
+                    <span>{{ report.player_name|default:"—" }}{% if report.player_level %} ({{ report.player_level }}){% endif %}</span>
+                    <span class="text-capitalize">{{ report.source }}</span>
+                    <span title="{{ report.created_at }}">{{ report.created_at|naturaltime|default:"—" }}</span>
+{% if report.num_comments %}
+                    <span title="{{ report.num_comments }} comment{{ report.num_comments|pluralize }}">{% bi "chat-left-text" %} {{ report.num_comments }}</span>
+{% endif %}
+                </div>
+            </div>
+            <div class="ac-row__side">
+                <span class="ac-pill ac-pill--status ac-pill--{{ report.status_pill }}" data-role="status">{{ report.status_label }}</span>
+{% if report.is_unacknowledged %}
+                <button class="ac-btn ac-btn--ok fb-action" data-id="{{ report.pk }}" data-action="ack" title="Claim this report">Ack</button>
+{% elif report.acknowledged_by %}
+                <span class="ac-row__meta" title="Acknowledged by {{ report.acknowledged_by }}">✓ {{ report.acknowledged_by }}</span>
+{% endif %}
+                <a class="ac-btn" href="{% url 'feedback_detail' report.pk %}">Open</a>
+            </div>
+        </div>
+{% endfor %}
+    </div>
 
 {% if is_paginated %}
-<nav aria-label="Feedback pages">
-    <ul class="pagination pagination-sm justify-content-center">
-        {% if page_obj.has_previous %}
-        <li class="page-item"><a class="page-link bg-dark text-light border-secondary" href="{% querystring page=page_obj.previous_page_number %}">Prev</a></li>
-        {% endif %}
-        <li class="page-item disabled"><span class="page-link bg-black text-secondary border-secondary">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span></li>
-        {% if page_obj.has_next %}
-        <li class="page-item"><a class="page-link bg-dark text-light border-secondary" href="{% querystring page=page_obj.next_page_number %}">Next</a></li>
-        {% endif %}
-    </ul>
-</nav>
+    <nav class="ac-pager" aria-label="Feedback pages">
+{% if page_obj.has_previous %}
+        <a class="ac-btn" href="{% querystring page=page_obj.previous_page_number %}">{% bi "chevron-left" %} Prev</a>
+{% endif %}
+        <span class="ac-pager__info">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+{% if page_obj.has_next %}
+        <a class="ac-btn" href="{% querystring page=page_obj.next_page_number %}">Next {% bi "chevron-right" %}</a>
+{% endif %}
+    </nav>
 {% endif %}
 
 {% else %}
-<div class="card bg-black border">
-    <div class="card-body">
-        <p class="card-text fst-italic">No feedback reports match the current filter.</p>
+    <div class="ac-empty">
+        {% bi "inbox" %}
+        <span>No feedback reports match the current filter.</span>
     </div>
-</div>
 {% endif %}
+
+</div>
 
 <script>
     // Inline acknowledge from the triage list.
@@ -193,13 +187,14 @@
         const data = await resp.json().catch(() => ({ok: false, message: "Error"}))
         if (data.ok) {
             const row = document.getElementById(`row-${id}`)
-            const badge = row.querySelector('[data-role="status"]')
-            if (badge && data.status_label) {
-                badge.textContent = data.status_label
-                badge.className = `badge text-bg-${data.status_css}`
+            const pill = row.querySelector('[data-role="status"]')
+            if (pill && data.status_label) {
+                // Label via textContent (dot is a ::before, so it survives).
+                pill.textContent = data.status_label
+                pill.className = `ac-pill ac-pill--status ac-pill--${data.status_pill || "muted"}`
             }
             const done = document.createElement("span")
-            done.className = "text-secondary small"
+            done.className = "ac-row__meta"
             done.textContent = `✓ ${data.acknowledged_by || ""}`  // textContent: no HTML injection
             button.replaceWith(done)
         } else {

--- a/apps/feedback/templates/feedback_detail.html
+++ b/apps/feedback/templates/feedback_detail.html
@@ -1,135 +1,177 @@
 {% extends "layout.html" %}
 {% load humanize %}
+{% load ishar %}
 {% load static %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Feedback #{{ report.pk }}{% endblock meta_title %}
 {% block meta_description %}Feedback report #{{ report.pk }}.{% endblock meta_description %}
 {% block meta_url %}{% url 'feedback_detail' report.pk %}{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Feedback #{{ report.pk }}{% endblock title %}
 {% block scripts %}let focusTo = 'report'{% endblock scripts %}
+{% block includes %}
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
+{% endblock includes %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item h2" title="Portal">
-        <a class="icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-            <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use></svg>
-            Portal
-        </a>
-    </li>
-    <li class="breadcrumb-item h2" title="Feedback Triage">
-        <a class="icon-link icon-link-hover" href="{% url 'feedback' %}#feedback">
-            <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#flag"></use></svg>
-            Feedback
-        </a>
-    </li>
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Feedback" "flag" urlname="feedback" anchor="feedback" %}
     <li class="breadcrumb-item active h2" aria-current="page" title="Report #{{ report.pk }}">
         <span id="report">#{{ report.pk }}</span>
     </li>
 {% endblock breadcrumbs %}
 {% block content %}
+<div class="ac ac--wide">
 
-<div class="row g-3">
-
-    {# ---- Left: report + timeline ------------------------------------- #}
-    <div class="col-lg-8">
-        <div class="border bg-black card mb-3">
-            <div class="card-header d-flex align-items-center flex-wrap gap-2">
-                <svg class="bi" aria-hidden="true" width="20" height="20"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{{ report.type_icon }}"></use></svg>
-                <strong class="h5 m-0">#{{ report.pk }} · {{ report.get_feedback_type_display }}</strong>
-                <span class="badge text-bg-{{ report.status_css }}" id="status-badge">{{ report.status_label }}</span>
-                {% if report.is_private %}<span class="badge text-bg-warning"><svg class="bi" width="12" height="12" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#lock-fill"></use></svg> Private</span>{% endif %}
-                {% if report.bountied %}<span class="badge text-bg-warning">Bounty · {{ report.bountied_by }}</span>{% endif %}
-                {% if report.github_issue_url %}<a class="badge text-bg-info text-decoration-none" href="{{ report.github_issue_url }}" target="_blank" rel="noopener">GitHub issue ↗</a>{% endif %}
-            </div>
-            <div class="card-body">
-                <pre class="text-light bg-dark border border-secondary rounded p-3" style="white-space:pre-wrap;word-break:break-word;">{{ report.body }}</pre>
-            </div>
-            <div class="card-footer small text-secondary">
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi report.type_icon %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">#{{ report.pk }} · {{ report.get_feedback_type_display }}</h2>
+            <p class="ac-hero__sub">
                 Filed {{ report.created_at|naturaltime|default:"—" }}
-                {% if report.acknowledged_by %} · acknowledged by {{ report.acknowledged_by }}{% endif %}
-                {% if report.closed_by %} · closed by {{ report.closed_by }}{% if report.resolution_note %} — {{ report.resolution_note }}{% endif %}{% endif %}
+                {% if report.player_name %}by <code>{{ report.player_name }}</code>{% if report.player_level %} (level {{ report.player_level }}){% endif %}{% endif %}
+                · <span class="text-capitalize">{{ report.source }}</span>
+            </p>
+        </div>
+        <div class="ac-hero__status d-flex flex-wrap gap-1 justify-content-end">
+            <span class="ac-pill ac-pill--status ac-pill--{{ report.status_pill }}" id="status-badge">{{ report.status_label }}</span>
+{% if report.is_private %}
+            <span class="ac-pill ac-pill--warn" title="Never reaches Discord; not promotable to GitHub">{% bi "lock-fill" %} private</span>
+{% endif %}
+{% if report.bountied %}
+            <span class="ac-pill ac-pill--warn" title="Bounty awarded by {{ report.bountied_by }}">{% bi "coin" %} bounty</span>
+{% endif %}
+{% if report.github_issue_url %}
+            <a class="ac-pill ac-pill--info text-decoration-none" href="{{ report.github_issue_url }}" target="_blank" rel="noopener">{% bi "github" %} issue</a>
+{% endif %}
+        </div>
+    </header>
+
+    <div class="row g-3">
+
+        {# ---- Left: report + timeline ------------------------------------- #}
+        <div class="col-lg-8 d-flex flex-column gap-3">
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "file-earmark-text" %} Report</div>
+                <pre class="ac-quote">{{ report.body }}</pre>
+            </div>
+
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "chat-left-text" %} Timeline</div>
+                <div class="ac-timeline">
+{% for comment in comments %}
+                    <div class="ac-tl{% if comment.is_system %} ac-tl--system{% endif %}">
+                        <span class="ac-tl__icon" title="{{ comment.source }}">
+                            {% bi comment.source_icon label=comment.source %}
+                        </span>
+                        <div class="ac-tl__body">
+                            <div class="ac-tl__head">
+                                <span class="ac-tl__author{% if comment.is_staff %} ac-tl__author--staff{% endif %}">{{ comment.author }}</span>
+{% if comment.is_staff and not comment.is_system %}
+                                <span class="ac-pill ac-pill--info">staff</span>
+{% endif %}
+                                <span class="ac-tl__time" title="{{ comment.created_at }}">{{ comment.created_at|naturaltime }}</span>
+                            </div>
+                            <div class="ac-tl__text">{{ comment.body }}</div>
+                        </div>
+                    </div>
+{% empty %}
+                    <div class="ac-empty">
+                        {% bi "chat-left" %}
+                        <span>No comments yet.</span>
+                    </div>
+{% endfor %}
+                </div>
             </div>
         </div>
 
-        <h2 class="h5">Timeline</h2>
-        <div class="list-group mb-3">
-        {% for comment in comments %}
-            <div class="list-group-item bg-black text-light border-secondary {% if comment.is_system %}border-start border-4 border-secondary{% endif %}">
-                <div class="d-flex justify-content-between small text-secondary">
-                    <span>
-                        <svg class="bi" aria-hidden="true" width="14" height="14"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{{ comment.source_icon }}"></use></svg>
-                        <strong class="{% if comment.is_staff %}text-info{% endif %}">{{ comment.author }}</strong>
-                        {% if comment.is_staff and not comment.is_system %}<span class="badge text-bg-secondary">staff</span>{% endif %}
-                    </span>
-                    <span title="{{ comment.created_at }}">{{ comment.created_at|naturaltime }}</span>
-                </div>
-                <div class="{% if comment.is_system %}fst-italic text-secondary{% endif %} mt-1" style="white-space:pre-wrap;word-break:break-word;">{{ comment.body }}</div>
+        {# ---- Right: metadata + actions ----------------------------------- #}
+        <div class="col-lg-4 d-flex flex-column gap-3">
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "card-list" %} Details</div>
+                <dl class="ac-kv">
+                    <dt>Reporter</dt><dd>{{ report.player_name|default:"—" }}</dd>
+                    <dt>Level</dt><dd>{{ report.player_level|default:"—" }}</dd>
+                    <dt>Room vnum</dt><dd>{{ report.room_vnum|default:"—" }}</dd>
+                    <dt>Source</dt><dd class="text-capitalize">{{ report.source }}</dd>
+{% if report.acknowledged_by %}
+                    <dt>Acknowledged</dt><dd>{{ report.acknowledged_by }}</dd>
+{% endif %}
+{% if report.closed_by %}
+                    <dt>Closed by</dt><dd>{{ report.closed_by }}</dd>
+{% endif %}
+{% if report.resolution_note %}
+                    <dt>Note</dt><dd>{{ report.resolution_note }}</dd>
+{% endif %}
+{% if report.duplicate_of_id %}
+                    <dt>Duplicate of</dt><dd><a href="{% url 'feedback_detail' report.duplicate_of_id %}">#{{ report.duplicate_of_id }}</a></dd>
+{% endif %}
+{% if duplicates %}
+                    <dt>Duplicates</dt><dd>{% for d in duplicates %}<a href="{% url 'feedback_detail' d.pk %}">#{{ d.pk }}</a> {% endfor %}</dd>
+{% endif %}
+                </dl>
             </div>
-        {% empty %}
-            <div class="list-group-item bg-black text-secondary border-secondary fst-italic">No comments yet.</div>
-        {% endfor %}
+
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "lightning-charge" %} Actions</div>
+                <div class="d-grid gap-2" id="action-panel">
+                    <div id="action-msg" class="d-none" role="status"></div>
+
+{% if report.is_unacknowledged %}
+                    <button class="ac-btn ac-btn--ok" data-action="ack">{% bi "check-lg" %} Acknowledge</button>
+{% endif %}
+
+                    <div>
+                        <label class="ac-label" for="note">Optional note / reason</label>
+                        <input class="ac-field" id="note" placeholder="note (reason required for Close)">
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-1">
+                        <button class="ac-btn ac-btn--info flex-fill" data-action="progress">In&nbsp;Progress</button>
+                        <button class="ac-btn ac-btn--accent flex-fill" data-action="resolve">Resolve</button>
+                        <button class="ac-btn ac-btn--danger flex-fill" data-action="wontfix">Won't&nbsp;Fix</button>
+                    </div>
+                    <div class="d-flex flex-wrap gap-1">
+                        <button class="ac-btn flex-fill" data-action="close">Close&nbsp;(reason)</button>
+{% if not report.is_open %}
+                        <button class="ac-btn ac-btn--warn flex-fill" data-action="reopen">Reopen</button>
+{% endif %}
+{% if not report.bountied %}
+                        <button class="ac-btn ac-btn--warn flex-fill" data-action="bounty">{% bi "coin" %} Bounty</button>
+{% endif %}
+                    </div>
+
+                    <div class="d-flex gap-1">
+                        <input class="ac-field" id="of_id" type="number" min="1" placeholder="dupe of #id" aria-label="Duplicate of report ID">
+                        <button class="ac-btn" data-action="dupe">Mark&nbsp;Duplicate</button>
+                    </div>
+
+{% if can_promote %}
+                    <button class="ac-btn ac-btn--info" data-action="promote" {% if report.github_issue_url %}disabled title="Already promoted"{% endif %}>
+                        {% bi "github" %} Promote to GitHub
+                    </button>
+{% if is_god %}
+                    <div class="d-flex gap-1">
+                        <input class="ac-field" id="instructions" placeholder="Claude instructions (optional)" aria-label="Claude instructions">
+                        <button class="ac-btn ac-btn--warn" data-action="assign_claude">{% bi "robot" %} Assign&nbsp;Claude</button>
+                    </div>
+{% endif %}
+{% else %}
+                    <div class="ac-note ac-note--warn" role="note">
+                        {% bi "lock-fill" %}
+                        <span>Private report — not promotable to a public GitHub issue.</span>
+                    </div>
+{% endif %}
+
+                    <hr class="border-secondary my-1">
+                    <div>
+                        <label class="ac-label" for="comment-text">Comment</label>
+                        <textarea class="ac-field" id="comment-text" rows="3" placeholder="Add a staff comment…"></textarea>
+                    </div>
+                    <button class="ac-btn ac-btn--accent" data-action="comment">{% bi "chat-left-text" %} Add Comment</button>
+                </div>
+            </div>
         </div>
     </div>
 
-    {# ---- Right: metadata + actions ----------------------------------- #}
-    <div class="col-lg-4">
-        <div class="border bg-black card mb-3">
-            <div class="card-header"><strong>Details</strong></div>
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item bg-black text-light d-flex justify-content-between"><span class="text-secondary">Reporter</span><span>{{ report.player_name|default:"—" }}</span></li>
-                <li class="list-group-item bg-black text-light d-flex justify-content-between"><span class="text-secondary">Level</span><span>{{ report.player_level|default:"—" }}</span></li>
-                <li class="list-group-item bg-black text-light d-flex justify-content-between"><span class="text-secondary">Room vnum</span><span>{{ report.room_vnum|default:"—" }}</span></li>
-                <li class="list-group-item bg-black text-light d-flex justify-content-between"><span class="text-secondary">Source</span><span class="text-capitalize">{{ report.source }}</span></li>
-                {% if report.duplicate_of_id %}<li class="list-group-item bg-black text-light d-flex justify-content-between"><span class="text-secondary">Duplicate of</span><a href="{% url 'feedback_detail' report.duplicate_of_id %}">#{{ report.duplicate_of_id }}</a></li>{% endif %}
-                {% if duplicates %}<li class="list-group-item bg-black text-light d-flex justify-content-between"><span class="text-secondary">Duplicates</span><span>{% for d in duplicates %}<a href="{% url 'feedback_detail' d.pk %}">#{{ d.pk }}</a> {% endfor %}</span></li>{% endif %}
-            </ul>
-        </div>
-
-        <div class="border bg-black card">
-            <div class="card-header"><strong>Actions</strong></div>
-            <div class="card-body d-grid gap-2" id="action-panel">
-                <div id="action-msg" class="alert alert-info py-1 px-2 small d-none" role="status"></div>
-
-                {% if report.is_unacknowledged %}
-                <button class="btn btn-sm btn-outline-success" data-action="ack">Acknowledge</button>
-                {% endif %}
-
-                <label class="form-label small text-secondary m-0">Optional note / reason</label>
-                <input class="form-control form-control-sm bg-dark text-light border-secondary" id="note" placeholder="note (reason required for Close)">
-
-                <div class="btn-group btn-group-sm" role="group">
-                    <button class="btn btn-outline-info" data-action="progress">In&nbsp;Progress</button>
-                    <button class="btn btn-outline-primary" data-action="resolve">Resolve</button>
-                    <button class="btn btn-outline-danger" data-action="wontfix">Won't&nbsp;Fix</button>
-                </div>
-                <div class="btn-group btn-group-sm" role="group">
-                    <button class="btn btn-outline-secondary" data-action="close">Close&nbsp;(reason)</button>
-                    {% if not report.is_open %}<button class="btn btn-outline-warning" data-action="reopen">Reopen</button>{% endif %}
-                    {% if not report.bountied %}<button class="btn btn-outline-warning" data-action="bounty">Bounty</button>{% endif %}
-                </div>
-
-                <div class="input-group input-group-sm">
-                    <span class="input-group-text bg-dark text-secondary border-secondary">dupe of #</span>
-                    <input class="form-control bg-dark text-light border-secondary" id="of_id" type="number" min="1" placeholder="id">
-                    <button class="btn btn-outline-secondary" data-action="dupe">Mark&nbsp;Duplicate</button>
-                </div>
-
-                {% if can_promote %}
-                <button class="btn btn-sm btn-outline-info" data-action="promote" {% if report.github_issue_url %}disabled title="Already promoted"{% endif %}>Promote to GitHub</button>
-                {% if is_god %}
-                <div class="input-group input-group-sm">
-                    <input class="form-control bg-dark text-light border-secondary" id="instructions" placeholder="Claude instructions (optional)">
-                    <button class="btn btn-warning" data-action="assign_claude">Assign to Claude</button>
-                </div>
-                {% endif %}
-                {% else %}
-                <p class="small text-secondary fst-italic m-0">Private report — not promotable to a public GitHub issue.</p>
-                {% endif %}
-
-                <hr class="border-secondary my-1">
-                <label class="form-label small text-secondary m-0">Comment</label>
-                <textarea class="form-control form-control-sm bg-dark text-light border-secondary" id="comment-text" rows="3" placeholder="Add a staff comment…"></textarea>
-                <button class="btn btn-sm btn-outline-light" data-action="comment">Add Comment</button>
-            </div>
-        </div>
-    </div>
 </div>
 
 <script>
@@ -138,7 +180,7 @@
 
     function showMsg(text, ok) {
         msg.textContent = text
-        msg.className = `alert py-1 px-2 small ${ok ? "alert-success" : "alert-danger"}`
+        msg.className = `ac-note ${ok ? "ac-note--ok" : "ac-note--danger"}`
     }
 
     async function postAction(action) {

--- a/apps/feedback/views/actions.py
+++ b/apps/feedback/views/actions.py
@@ -100,6 +100,7 @@ class FeedbackActionView(EternalRequiredMixin, NeverCacheMixin, View):
             "state": feedback.state,
             "status_label": feedback.status_label,
             "status_css": feedback.status_css,
+            "status_pill": feedback.status_pill,
             "acknowledged_by": feedback.acknowledged_by,
             "bountied": feedback.bountied,
             "github_issue_url": feedback.github_issue_url,

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -90,15 +90,13 @@ tokens should be expressed in terms of the shared set.
 
 Incremental, page-by-page. Do the two enablers early so later pages are cheap.
 
-### Enablers (do these first)
-- **E1 · Shared token base.** Promote the Admin Console tokens (`--ac-*`) into a
-  small base stylesheet that any page can include (or fold into `style.css`), so
-  colors/surfaces/motion are defined once. Express `--hud-*` in terms of it.
-- **E2 · Shared components.** ishar-web has **no template partials or template
-  tags today** — markup is copy-pasted. Introduce `{% include %}` partials and a
-  `templatetags` module for the repeating pieces (icon, status pill, stat tile,
-  panel header, breadcrumb, empty state) so a component is defined once and
-  restyled once.
+### Enablers
+- **E1 · Shared token base.** ✅ **done** — the `--ac-*` tokens live in the
+  `:root` of `style.css` (loaded globally); `admin-console.css` is components
+  only. Still to do: express `--hud-*` in terms of the shared set.
+- **E2 · Shared components.** ✅ **started** — the `ishar` template tag library
+  (`{% bi %}` icons, `{% crumb %}` breadcrumbs) + `partials/` exist; new/touched
+  templates must use them. Old templates migrate as each page is facelifted.
 
 ### Page adoption order
 Staff surfaces first (highest value, lowest risk — few users, we control them):
@@ -106,8 +104,8 @@ Staff surfaces first (highest value, lowest risk — few users, we control them)
 | # | Surface | Status |
 |---|---|---|
 | 1 | Deploy console (`/portal/deploy`) | ✅ done — the reference implementation |
-| 2 | Feedback triage (`/feedback`) | next |
-| 3 | Processes / other Django-admin-adjacent staff pages | later |
+| 2 | Feedback triage (`/feedback`) | ✅ done — tiles, chips, rows, timeline |
+| 3 | Processes / other Django-admin-adjacent staff pages | next |
 | 4 | Portal (`/portal`) + global nav/layout shell | later |
 | 5 | Leaders, Challenges (DataTables pages) | later |
 | 6 | Connect HUD (align tokens) | later |

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -12,6 +12,30 @@ For each: what it is, canonical markup, where it's used, and status.
 
 ---
 
+## Template tags & partials (`{% load ishar %}`)
+
+Enabler E2 — defined in `apps/core/templatetags/ishar.py`, partials under
+`apps/core/templates/partials/`. Use these in any new/touched template instead
+of pasting the markup.
+
+### `{% bi %}` — sprite icon
+```django
+{% bi "rocket-takeoff" %}                              {# decorative (aria-hidden) #}
+{% bi "lock-fill" css="text-warning" label="Private" %} {# meaningful (role=img) #}
+```
+Output is built with `format_html` (labels are escaped). Status: **formalized.**
+
+### `{% crumb %}` — breadcrumb item
+```django
+{% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+{% crumb "Deploy" "rocket-takeoff" urlname="deploy" anchor="deploy" active=True %}
+```
+Reverses `urlname` (+ `#anchor`), puts `id="{{ anchor }}"` on the label span so
+`focusTo` deep-linking works, sets `aria-current` when active. Omit `urlname`
+for an unlinked crumb. Status: **formalized.**
+
+---
+
 ## Admin Console components
 
 Defined in `apps/core/static/css/admin-console.css`; load per page via
@@ -109,11 +133,106 @@ spinner + a headline parsed from `==>` lines); a monospace `.ac-console__body`
 log. Status: **formalized.** Use for any long-running job with streamed output.
 
 ### `.ac-note` — callout
-`--warn`/`--danger` variants; icon + text. Use for inline warnings/heads-ups.
+`--ok`/`--warn`/`--danger` variants; icon + text. Use for inline
+warnings/heads-ups and JS-swapped action results (`textContent` + class swap).
 ```html
 <div class="ac-note ac-note--warn" role="alert">{# icon #} <span>…</span></div>
 ```
 Status: **formalized.**
+
+### `.ac-tiles` + `.ac-tile` — KPI stat tiles
+Grid of clickable count tiles that double as filters. Semantic number color via
+`--ok/--info/--warn/--danger/--accent`; pass `--muted` when the count is zero
+so only live numbers draw the eye; `--active` marks the currently-applied
+filter.
+```html
+<div class="ac-tiles">
+  <a class="ac-tile ac-tile--danger ac-tile--active" href="?flag=unacked">
+    <span class="ac-tile__n">3</span>
+    <span class="ac-tile__label">Unacknowledged</span>
+  </a>
+</div>
+```
+Used: feedback dashboard. Status: **formalized** (supersedes the classic
+`display-6` card tile on admin surfaces).
+
+### `.ac-filter` + `.ac-chip` — filter bar
+Wrapping rows of pill chip links (one row per dimension, `.ac-filter__sep` as a
+group divider); active chip gets `--active` (amber wash). Compose with an inline
+`role="search"` form of `.ac-field`s. Driven by `{% querystring %}`.
+```html
+<div class="ac-filter" role="group" aria-label="State filter">
+  <a class="ac-chip ac-chip--active" href="…">Active</a>
+  <a class="ac-chip" href="…">Closed</a>
+</div>
+```
+Used: feedback dashboard. Status: **formalized.**
+
+### `.ac-btn` — secondary action button
+Small, bordered action button (the page's one primary stays `.ac-cta`).
+Semantic variants `--ok/--info/--warn/--danger/--accent` color text/border and
+fill the matching wash on hover. Works on `<a>` too (link colors are pinned).
+```html
+<button class="ac-btn ac-btn--ok" data-action="ack">Ack</button>
+```
+Status: **formalized.**
+
+### `.ac-field` + `.ac-label` — bare form field
+Input/textarea/select without the icon cell (`.ac-inputgroup` is the icon
+variant). `--inline` for auto width. `.ac-label` is the uppercase dim label.
+Status: **formalized.**
+
+### `.ac-rows` + `.ac-row` — record list
+The console list surface (mobile-first replacement for data tables — see
+decisions.md): one bordered stack; each row is wrapping flex with an icon tile
+(`__icon`), a main cell (`__title` with an `a.ac-row__link`, then a `__meta`
+line), and a right-aligned `__side` for pills/actions.
+```html
+<div class="ac-rows">
+  <div class="ac-row" id="row-7">
+    <span class="ac-row__icon">{% bi "bug" %}</span>
+    <div class="ac-row__main">
+      <div class="ac-row__title"><a class="ac-row__link" href="…">Summary</a></div>
+      <div class="ac-row__meta"><span class="mono">#7</span> <span>Reporter</span></div>
+    </div>
+    <div class="ac-row__side">{# .ac-pill, .ac-btn #}</div>
+  </div>
+</div>
+```
+Used: feedback dashboard. Status: **formalized.**
+
+### `.ac-empty` — empty state
+Dashed, centered, dim: icon + one sentence.
+```html
+<div class="ac-empty">{% bi "inbox" %} <span>No reports match.</span></div>
+```
+Status: **formalized** (supersedes the classic italic-card empty states as
+pages are touched).
+
+### `.ac-pager` — pagination
+Centered `.ac-btn` prev/next around a tabular-nums `.ac-pager__info`. Status:
+**formalized.**
+
+### `.ac-timeline` + `.ac-tl` — comment/audit trail
+Stacked entries: round source-icon tile, head line (author — `--staff` renders
+info-blue — pills, right-aligned time), pre-wrapped text. `--system` entries
+recede (deepest surface, dashed border, dim italic text) so human conversation
+stays foreground.
+Used: feedback detail. Status: **formalized.**
+
+### `.ac-quote` — verbatim text block
+Monospace `pre` on the deepest surface with a strong left edge — for captured
+player/machine text (report bodies, pasted output). The terminal feel is
+deliberate. Status: **formalized.**
+
+### `.ac-kv` — key/value details
+Two-column `dl` grid; dim keys, right-aligned values. Used: feedback detail.
+Status: **formalized.**
+
+### Container variants
+`.ac` (60rem) is the default console width; `.ac--wide` (72rem) for list-heavy
+surfaces. `.ac-cta--accent` is the amber non-destructive primary (red stays
+destructive).
 
 ---
 
@@ -134,8 +253,8 @@ Every page reimplements:
   <a class="icon-link icon-link-hover" href="…">{# icon #} <span>Label</span></a>
 </li>
 ```
-Admin/portal pages lead with a Portal crumb. Divider is `•`. **Prime candidate
-for a partial.**
+Admin/portal pages lead with a Portal crumb. Divider is `•`. **Formalized as
+`{% crumb %}` (see above) — use the tag; migrate old templates as touched.**
 
 ### Count pill
 `<span class="badge bg-dark rounded-pill border border-secondary">{{ n }}</span>`
@@ -152,22 +271,24 @@ semantic number color, zero-suppressed emphasis:
   </div>
 </a>
 ```
-Used in `apps/feedback/templates/feedback_dashboard.html`. **Formalize; the
-Admin Console equivalent should become an `.ac-tile`.**
+**Superseded on admin surfaces by `.ac-tile` (see above);** the classic markup
+survives only on untouched pages.
 
 ### Filter bar
 Row of `btn btn-sm btn-outline-*` toggles (active = solid), driven by Django's
-`{% querystring %}` tag, with an inline `role="search"` form. See the feedback
-dashboard. Candidate to standardize as `.ac-filter`.
+`{% querystring %}` tag, with an inline `role="search"` form. **Superseded by
+`.ac-filter` + `.ac-chip` (see above).**
 
 ### Contextual badge
 `<span class="badge text-bg-{{ status_css }}">{{ status_label }}</span>` with the
-color map on the model. On admin surfaces, migrate to `.ac-pill--{ok|info|…}`.
+color map on the model. **On admin surfaces this is now `.ac-pill--{{
+status_pill }}`** — the model carries both maps (see `Feedback.status_pill` and
+decisions.md); classic badges survive only on untouched pages.
 
 ### Empty state
 `<div class="card"><div class="card-body"><p class="card-text fst-italic lead
-text-warning">No … found.</p></div></div>` (leaders/challenges) — or the feedback
-dashboard's `border bg-black card` italic variant. Standardize one.
+text-warning">No … found.</p></div></div>` (leaders/challenges). **Superseded by
+`.ac-empty` (see above)** as pages are touched.
 
 ### DataTable
 `table table-hover table-dark table-flush table-sm table-responsive

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,70 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-11 — E1: shared tokens live in style.css
+
+**Decision.** The `--ac-*` design tokens (plus `--ishar-color`) are defined once
+in the `:root` block of `apps/core/static/css/style.css`, which every page loads
+via `layout.html`. `admin-console.css` (and any future per-page stylesheet) is a
+pure component layer that references those tokens without redefining them.
+`--ac-warn-wash` was added to complete the wash set.
+
+**Why.** One definition site means a palette change is a one-line edit, and any
+page — public or staff — can adopt console components without a token import
+dance. A separate `tokens.css` would add an HTTP request for a ~40-line block
+that the global stylesheet can carry for free.
+
+## 2026-07-11 — E2: shared markup via the `ishar` template tag library
+
+**Decision.** Repeating markup is consolidated in
+`apps/core/templatetags/ishar.py` (`{% load ishar %}`) plus partials under
+`apps/core/templates/partials/`. First tags: `{% bi name css label %}` for
+sprite icons (decorative by default, `role="img"` when labeled; output built
+with `format_html` so labels are escaped) and `{% crumb label icon urlname
+anchor active %}` for breadcrumb items. New/touched templates must use these
+instead of pasting SVG/breadcrumb boilerplate; mass adoption across old
+templates happens as each page is facelifted.
+
+**Why.** The site had no partials or template tags — every icon and crumb was
+copy-pasted. A tag is one place to fix accessibility, escaping, and markup.
+
+## 2026-07-11 — Admin list views are row stacks, not data tables
+
+**Decision.** Staff-tooling list surfaces use the `.ac-rows` / `.ac-row`
+component — a bordered stack of wrapping flex rows (icon tile, main
+title+meta, right-aligned status/actions) — rather than `<table>` markup.
+Tables remain appropriate for genuinely tabular, column-comparable data
+(leaders, challenges).
+
+**Why.** Mobile-first is non-negotiable: tables force horizontal scrolling at
+phone widths, while flex rows wrap gracefully. A triage list is a list of
+records with actions, not a matrix — rows are the honest structure.
+
+## 2026-07-11 — Status pills replace Bootstrap contextual badges on admin surfaces
+
+**Decision.** Admin/staff surfaces render status as `.ac-pill` with semantic
+modifiers, driven by a `status_pill` property on the model (e.g.
+`Feedback.status_pill` → `ok/info/warn/danger/accent/muted`), returned alongside
+`status_css` in action JSON so JS swaps `textContent` + `className`. Bootstrap
+`text-bg-*` badges remain only on untouched classic pages until each is
+facelifted.
+
+**Why.** One status vocabulary on console surfaces; the color map stays on the
+model (data-driven), the pill styling stays in the component layer.
+
+## 2026-07-11 — Feedback triage adopts the Admin Console language
+
+**Decision.** `/feedback` (dashboard + detail) is rebuilt as surface #2 of the
+facelift: `ac-hero` with a live unacked pill, `ac-tile` KPI tiles that double as
+filters (`--active` marks the applied one, zero counts render `--muted`),
+`ac-chip` filter bar, `.ac-rows` report list, `ac-timeline` for comments
+(system entries recede: dashed, dim, italic), `ac-kv` details, `ac-btn` action
+panel, and `ac-quote` — monospace-on-deepest-surface — for verbatim report
+bodies (they're captured game text; the terminal feel is deliberate).
+
+**Why.** Highest-traffic staff surface after deploy; it exercised and hardened
+the component set (tiles, chips, rows, timeline) the rest of the site will use.
+
 ## 2026-07-11 — Treat ishar-web as green field
 
 **Decision.** Design and refactor as if this were a green-field project: **no
@@ -97,10 +161,6 @@ swapped safely. **Why.** Removes an XSS foot-gun class and keeps updates cheap.
 
 ## Open decisions / to record when made
 
-- **E1 — shared token base:** where the canonical tokens live (fold `--ac-*` into
-  `style.css` vs a new `tokens.css` base include). Record when chosen.
-- **E2 — shared components:** the partial/templatetag structure for repeating
-  markup (icon, pill, tile, panel header, breadcrumb, empty state).
-- **Contextual badges:** migration path from Bootstrap `text-bg-*` to `.ac-pill`
-  on admin surfaces (and whether public pages follow).
 - **Live styleguide page:** whether to build a staff-only `/styleguide`.
+- **Public-shell facelift:** how far the layered-grey console surfaces replace
+  the black+amber-outline look on public pages (roadmap #4–#7).

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -3,18 +3,18 @@
 The canonical palette and scales. Every color, surface, and radius on a
 faceflifted page should come from here — no ad-hoc hex.
 
-Two token sets exist today and are **cohesive by design** (same amber, same body
-text). The **Admin Console set (`--ac-*`) is the go-forward vocabulary**; the
-classic site currently hard-codes most of these values inline in `style.css`.
-The target (enabler E1) is one shared base that both express in terms of.
+**Enabler E1 is done:** the `--ac-*` set (plus `--ishar-color`) is defined once
+in the `:root` block of `apps/core/static/css/style.css`, which every page loads
+via `layout.html`. Any stylesheet may reference these tokens without redefining
+them.
 
 Sources of truth:
-- `apps/core/static/css/admin-console.css` — the `--ac-*` tokens (defined as
-  `:root` custom properties; reference implementation).
-- `apps/core/static/css/style.css` — the classic values (only `--ishar-color` is
-  a variable today; the rest are literal).
-- `apps/connect/static/css/hud.css` — the HUD's `--hud-*` set (same idea, to be
-  aligned).
+- `apps/core/static/css/style.css` — **the canonical `:root` token block**, plus
+  the classic-site rules (some still literal; they migrate as pages are touched).
+- `apps/core/static/css/admin-console.css` — the component layer built on the
+  tokens (no token definitions of its own).
+- `apps/connect/static/css/hud.css` — the HUD's `--hud-*` set (same values, to
+  be re-expressed in terms of the shared set).
 
 ---
 
@@ -113,6 +113,7 @@ Subtle tints for selected/active states and hero banners.
 | `--ac-wash` | `rgba(255,170,119,.12)` (amber) |
 | `--ac-ok-wash` | `rgba(76,187,23,.12)` |
 | `--ac-info-wash` | `rgba(74,134,207,.14)` |
+| `--ac-warn-wash` | `rgba(255,136,0,.12)` |
 | `--ac-danger-wash` | `rgba(214,75,75,.14)` |
 
 ---


### PR DESCRIPTION
Design refresh, per the docs/design roadmap:

- E1: the --ac-* tokens (and --ishar-color) now live once in style.css's
  :root, loaded globally via layout.html; admin-console.css is a pure
  component layer. Added --ac-warn-wash; classic literals re-expressed
  via tokens where trivial. Sprite icons get a text-size default
  (svg.bi:not([width])) so unsized {% bi %} icons render sanely.

- E2: new `ishar` template tag library ({% bi %} icons with format_html
  escaping, {% crumb %} breadcrumbs) + partials/crumb.html — the first
  shared markup this repo has had.

- New Admin Console components: .ac-tile KPI tiles, .ac-chip filter bar,
  .ac-btn semantic buttons, .ac-field/.ac-label, .ac-rows record list
  (mobile-first replacement for admin tables), .ac-empty, .ac-pager,
  .ac-timeline, .ac-quote, .ac-kv, .ac-note--ok, .ac--wide, accent CTA.

- Feedback triage (dashboard + detail) rebuilt in the console language:
  hero with live unacked pill, filter tiles/chips, wrapping row list,
  timeline with receding system entries, ac-btn action panel. Status
  colors gain a model-side status_pill map (returned in action JSON so
  JS swaps textContent + className, never innerHTML).

- Design docs updated: decisions logged (E1/E2, rows-not-tables, pill
  migration, feedback adoption), component catalog extended, roadmap
  statuses advanced.

Verified: templates compiled + tags exercised under stub settings
(escaping asserted), py_compile, node --check on script blocks, and
full-page headless-Chromium screenshots of both pages at 1280px and a
true 390px viewport (no horizontal overflow). Not run against the live
DB/agent — end-to-end behavior needs the usual on-prod check.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT