### PR TITLE
Design refresh round 2: console shell, Portal rebuild, live /styleguide

### DIFF
--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -1,391 +1,297 @@
 {% extends "layout.html" %}
 {% load humanize %}
+{% load ishar %}
 {% load static %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Account Portal{% endblock meta_title %}
 {% block meta_description %}Portal for players to see information about their {{ WEBSITE_TITLE }} account and characters.{% endblock meta_description %}
 {% block meta_url %}{% url 'portal' %}#portal{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Portal{% endblock title %}
+{% block scripts %}let focusTo = 'portal'{% endblock scripts %}
+{% block includes %}
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
+{% endblock includes %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item active h2" aria-current="page" title="Portal">
-        <a class="icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-            </svg>
-            <span id="portal">
-                Portal
-            </span>
-        </a>
-    </li>
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" active=True %}
 {% endblock breadcrumbs %}
 {% block content %}
-<div class="card border-0">
-    <div class="card-body">
-        <ul class="list-group list-group-horizontal-sm">
-    {% if user.is_staff %}
-            <li class="card-text list-group-item" title="Administration">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'admin:index' %}" target="_blank">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#gear"></use>
-                    </svg>
-                    Administration
-                    <svg class="bi" aria-hidden="false" role="img" aria-label="Open {{ WEBSITE_TITLE }} Administration in a new window.">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#box-arrow-up-right"></use>
-                    </svg>
-                </a>
-            </li>
-    {% endif %}
+<div class="ac ac--wide">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "person-gear" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">{{ request.user.get_username }}</h2>
+            <p class="ac-hero__sub">
+                Account created {{ request.user.created_at|naturaltime }}
+                · {{ request.user.players.count }} character{{ request.user.players.count|pluralize }}
+                · {{ request.user.upgrades.count }} upgrade{{ request.user.upgrades.count|pluralize }}
+            </p>
+        </div>
+        <div class="ac-hero__status d-flex flex-wrap gap-1 justify-content-end">
+            <span class="ac-pill ac-pill--accent" title="{{ request.user.current_essence }} essence">
+                {% bi "gem" %} {{ request.user.current_essence }} essence
+            </span>
+            <span class="ac-pill {% if request.user.is_private %}ac-pill--warn{% else %}ac-pill--muted{% endif %}" id="privacyPill">
+                {% if request.user.is_private %}private{% else %}public{% endif %}
+            </span>
+        </div>
+    </header>
+
+    <!-- Tools -->
+{% if user.is_staff %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "wrench-adjustable" %} Staff Tools</div>
+        <div class="ac-grid">
+            <a class="ac-link" href="{% url 'admin:index' %}" target="_blank" title="Administration">
+                <span class="ac-link__icon">{% bi "gear" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Administration {% bi "box-arrow-up-right" css="text-secondary" label="Opens in a new window." %}</span>
+                    <span class="ac-link__note d-block">Django admin — models &amp; data</span>
+                </span>
+            </a>
     {% if user.is_god %}
-            <li class="card-text list-group-item" title="Deploy">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'deploy' %}#deploy">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use>
-                    </svg>
-                    Deploy
-                </a>
-            </li>
+            <a class="ac-link" href="{% url 'deploy' %}#deploy" title="Deploy Console">
+                <span class="ac-link__icon">{% bi "rocket-takeoff" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Deploy Console</span>
+                    <span class="ac-link__note d-block">Rebuild &amp; restart the stack</span>
+                </span>
+            </a>
     {% endif %}
-            <li class="card-text list-group-item" title="Challenges">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'challenges' %}#challenges">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#award"></use>
-                    </svg>
-                    Challenges
-                </a>
-            </li>
-            {% if user.is_eternal %}
-            <li class="card-text list-group-item" title="Feedback Triage">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'feedback' %}#feedback">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#flag"></use>
-                    </svg>
-                    Feedback Triage
-                </a>
-            </li>
-            {% endif %}
-            <li class="card-text list-group-item" title="Leaders">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'leaders' %}#leaders">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#trophy"></use>
-                    </svg>
-                    Leaders
-                </a>
-            </li>
-            <li class="card-text list-group-item" title="Password">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'password' %}#password">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#key"></use>
-                    </svg>
-                    Password
-                </a>
-            </li>
-            <li class="card-text list-group-item">
-                <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" role="switch" name="isPrivate" id="privateSwitch" value="{% if request.user.is_private %}true{% else %}false{% endif %}" onclick="togglePrivate(this.id);"{% if request.user.is_private %} checked{% endif %}>
-                    <label class="form-check-label" for="privateSwitch">
-                        Private
-                    </label>
-                    <button
-                        class="bg-black border-0 icon-link icon-link-hover p-1"
-                        data-bs-html="true"
-                        data-bs-title="<strong>Private?</strong>"
-                        data-bs-toggle="popover"
-                        data-bs-content="The &quot;<b>Private</b>&quot; setting hides your player's profile pages online."
-                        type="button">
-                        <svg class="bi" aria-hidden="false" role="note" aria-label="The &quot;private&quot; setting hides your player's profile pages online.">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#question-circle"></use>
-                        </svg>
-                    </button>
-                </div>
-            </li>
-            <li class="card-text list-group-item" title="Upgrades">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'upgrades' %}#upgrades">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#shield"></use>
-                    </svg>
-                    Upgrades
-                </a>
-            </li>
-            <li class="card-text list-group-item" title="Who's Online?">
-                <a class="list-group-item-text icon-link icon-link-hover" href="{% url 'who' %}#who">
-                    <svg class="bi" aria-hidden="true">
-                        <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#people"></use>
-                    </svg>
-                    Who's Online?
-                    <span class="badge bg-dark rounded-pill border border-secondary">
-                        {{ PLAYERS_ONLINE }}
-                    </span>
-                </a>
-            </li>
-        </ul>
+    {% if user.is_eternal %}
+            <a class="ac-link" href="{% url 'feedback' %}#feedback" title="Feedback Triage">
+                <span class="ac-link__icon">{% bi "flag" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Feedback Triage</span>
+                    <span class="ac-link__note d-block">Player bug / typo / idea reports</span>
+                </span>
+            </a>
+            <a class="ac-link" href="{% url 'styleguide' %}#styleguide" title="Style Guide">
+                <span class="ac-link__icon">{% bi "palette" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Style Guide</span>
+                    <span class="ac-link__note d-block">Design tokens &amp; components, live</span>
+                </span>
+            </a>
+    {% endif %}
+        </div>
+    </div>
+{% endif %}
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "compass" %} Game</div>
+        <div class="ac-grid">
+            <a class="ac-link" href="{% url 'who' %}#who" title="Who's Online?">
+                <span class="ac-link__icon">{% bi "people" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Who's Online?</span>
+                    <span class="ac-link__note d-block">Players in the game right now</span>
+                </span>
+                <span class="ac-link__side ac-pill ac-pill--{% if PLAYERS_ONLINE %}ok{% else %}muted{% endif %}">{{ PLAYERS_ONLINE }}</span>
+            </a>
+            <a class="ac-link" href="{% url 'challenges' %}#challenges" title="Challenges">
+                <span class="ac-link__icon">{% bi "award" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Challenges</span>
+                    <span class="ac-link__note d-block">Seasonal boss challenges</span>
+                </span>
+            </a>
+            <a class="ac-link" href="{% url 'leaders' %}#leaders" title="Leaders">
+                <span class="ac-link__icon">{% bi "trophy" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Leaders</span>
+                    <span class="ac-link__note d-block">All-time leaderboard</span>
+                </span>
+            </a>
+            <a class="ac-link" href="{% url 'upgrades' %}#upgrades" title="Upgrades">
+                <span class="ac-link__icon">{% bi "shield" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Upgrades</span>
+                    <span class="ac-link__note d-block">Remort upgrade catalog</span>
+                </span>
+            </a>
+            <a class="ac-link" href="{% url 'password' %}#password" title="Password">
+                <span class="ac-link__icon">{% bi "key" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Password</span>
+                    <span class="ac-link__note d-block">Change your account password</span>
+                </span>
+            </a>
+        </div>
     </div>
 
-    <div class="card m-1" id="privateMsgDiv" style="display: none;">
-        <div class="card-body">
-            <p class="card-text lead" id="privateMsgNode"></p>
+    <!-- Characters -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "person-badge" %} Characters</div>
+{% if request.user.players and request.user.players.count > 0 %}
+        <div class="ac-rows">
+    {% for player in request.user.players.all %}
+            <div class="ac-row">
+                <span class="ac-row__icon">
+                    {% if player.is_immortal %}{% bi "stars" %}{% else %}{% bi "person" %}{% endif %}
+                </span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title" title="{{ player.player_title }}">
+                        {{ player.player_link }}
+                    </div>
+                    <div class="ac-row__meta">
+        {% if not player.is_immortal %}
+                        <span>{{ player.common.player_class.get_class_name }}</span>
+                        <span>{{ player.common.race.display_name }}</span>
+                        <span>{{ player.get_player_alignment }}</span>
+            {% if player.remorts > 0 %}
+                        <span title="Remorts">{% bi "arrow-repeat" %} {{ player.remorts }}</span>
+            {% endif %}
+            {% if player.statistics.total_renown > 0 %}
+                        <span title="Total renown">{% bi "star" %} {{ player.statistics.total_renown }}</span>
+            {% endif %}
+            {% if player.statistics.total_quests > 0 %}
+                        <span title="Total quests">{% bi "signpost" %} {{ player.statistics.total_quests }}</span>
+            {% endif %}
+            {% if player.statistics.total_challenges > 0 %}
+                        <span title="Total challenges">{% bi "award" %} {{ player.statistics.total_challenges }}</span>
+            {% endif %}
+            {% if player.statistics.total_deaths > 0 %}
+                        <span title="Total deaths">{% bi "heartbreak" %} {{ player.statistics.total_deaths }}</span>
+            {% endif %}
+        {% else %}
+                        <span>{{ player.name|title }} {{ player.get_player_phrase }} a {{ player.player_type }} character.</span>
+        {% endif %}
+                    </div>
+                </div>
+                <div class="ac-row__side">
+        {% if player.is_immortal %}
+                    <span class="ac-pill ac-pill--info">{{ player.player_type }}</span>
+        {% else %}
+                    <span class="ac-pill ac-pill--accent" title="Level {{ player.common.level }}">lvl {{ player.common.level }}</span>
+        {% endif %}
+                </div>
+            </div>
+    {% endfor %}
         </div>
+{% else %}
+        <div class="ac-empty">
+            {% bi "person-plus" %}
+            <span>You have not created any players yet — connect and roll one!</span>
+        </div>
+{% endif %}
+    </div>
+
+    <div class="row g-3">
+        <!-- Essence -->
+        <div class="col-md-5 d-flex">
+            <div class="ac-panel flex-fill">
+                <div class="ac-panel__h">{% bi "gem" %} Essence</div>
+                <p class="ac-panel__hint">
+                    Reward points earned each season, preserved across seasons —
+                    spend them in-game with <code>shop</code>.
+                    <a href="{% url 'help_page' help_topic='Essence' %}#topic">More on essence.</a>
+                </p>
+                <div class="ac-tiles">
+                    <span class="ac-tile ac-tile--accent">
+                        <span class="ac-tile__n">{{ request.user.current_essence }}</span>
+                        <span class="ac-tile__label">Current</span>
+                    </span>
+                    <span class="ac-tile {% if request.user.seasonal_earned %}ac-tile--ok{% else %}ac-tile--muted{% endif %}">
+                        <span class="ac-tile__n">{{ request.user.seasonal_earned }}</span>
+                        <span class="ac-tile__label">Earned this season</span>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Upgrades -->
+        <div class="col-md-7 d-flex">
+            <div class="ac-panel flex-fill">
+                <div class="ac-panel__h">{% bi "shield" %} Upgrades</div>
+                <p class="ac-panel__hint">
+                    Remort upgrades bought with renown in-game —
+                    <a href="{% url 'upgrades' %}#upgrades">see the full catalog</a>.
+                </p>
+{% if request.user.upgrades.all %}
+                <dl class="ac-kv">
+    {% for upgraded in request.user.upgrades.all %}
+                    <dt>{{ upgraded.upgrade.name }}</dt>
+                    <dd class="text-ishar">×{{ upgraded.amount }}</dd>
+    {% endfor %}
+                </dl>
+{% else %}
+                <div class="ac-empty">
+                    {% bi "shield" %}
+                    <span>You have not purchased any upgrades.</span>
+                </div>
+{% endif %}
+            </div>
+        </div>
+    </div>
+
+    <!-- Account -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "person-vcard" %} Account</div>
+        <dl class="ac-kv mb-3">
+            <dt>Account</dt><dd>{{ request.user.get_username }}</dd>
+            <dt>Created</dt>
+            <dd title="{{ request.user.created_at }}">
+                {{ request.user.created_at|naturaltime }}
+                (<time datetime="{{ request.user.created_at|date:'c' }}">{{ request.user.created_at|date:"N j, Y" }}</time>)
+            </dd>
+        </dl>
+        <div class="form-check form-switch ac-switch">
+            <input class="form-check-input" type="checkbox" role="switch" id="privateSwitch"{% if request.user.is_private %} checked{% endif %}>
+            <label class="form-check-label ac-switch__text" for="privateSwitch">
+                Private profile
+                <span class="ac-switch__note d-block">Hides your players' profile pages on the website.</span>
+            </label>
+        </div>
+        <div class="ac-note ac-note--ok mt-2 d-none" id="privateMsg" role="status"></div>
     </div>
 
 </div>
 
-{% if request.user.players and request.user.players.count > 0 %}
-    <p class="lead" title="You have {{ request.user.players.count }} character{{ request.user.players.count|pluralize }}.">
-        You have {{ request.user.players.count }} character{{ request.user.players.count|pluralize }}:
-    </p>
-
-    {% for player in request.user.players.all %}
-    <details>
-
-        <summary class="h3 text-ishar" title="Player: {{ player.name }}">
-            <span class="text-secondary">
-                {{ forloop.counter }}.
-            </span>
-            <span class="{{ player.player_css }}">
-                {{ player.name }}
-            </span>
-        </summary>
-
-        <h4 title="{{ player.player_title }}">
-            {{ player.player_link }}
-        </h4>
-
-        {% if not player.is_immortal %}
-        <ol class="list-group list-group-horizontal-sm">
-            <li class="list-group-item list-group-item-text" title="Level: {{ player.common.level }}">
-                <strong>Level</strong>:
-                {{ player.common.level }}
-            </li>
-            <li class="list-group-item list-group-item-text" title="Class: {{ player.common.player_class.get_class_name }}">
-                <strong>Class</strong>:
-                {{ player.common.player_class.get_class_name }}
-            </li>
-            <li class="list-group-item list-group-item-text" title="Race: {{ player.common.race.display_name }}">
-                <strong>Race</strong>:
-                {{ player.common.race.display_name }}
-            </li>
-            <li class="list-group-item list-group-item-text" title="Alignment: {{ player.get_player_alignment }} ({{ player.common.alignment }})">
-                <strong>Alignment</strong>:
-                {{ player.get_player_alignment }}
-            </li>
-            {% if player.remorts > 0 %}
-            <li class="list-group-item list-group-item-text" title="Remorts: {{ player.remorts }}">
-                <strong>Remorts</strong>:
-                {{ player.remorts }}
-            </li>
-                {% endif %}
-                {% if player.statistics.total_renown > 0 %}
-            <li class="list-group-item list-group-item-text" title="Total Renown: {{ player.statistics.total_renown }}">
-                <strong>Total Renown</strong>:
-                {{ player.statistics.total_renown }}
-            </li>
-                {% endif %}
-                {% if player.statistics.total_quests > 0 %}
-            <li class="list-group-item list-group-item-text" title="Total Quests: {{ player.statistics.total_quests }}">
-                <strong>Total Quests</strong>:
-                {{ player.statistics.total_quests }}
-            </li>
-                {% endif %}
-                {% if player.statistics.total_challenges > 0 %}
-            <li class="list-group-item list-group-item-text" title="Total Challenges: {{ player.statistics.total_challenges }}">
-                <strong>Total Challenges</strong>:
-                {{ player.statistics.total_challenges }}
-            </li>
-                {% endif %}
-                {% if player.statistics.total_deaths > 0 %}
-            <li class="list-group-item list-group-item-text" title="Total Deaths: {{ player.statistics.total_deaths }}">
-                <strong>Total Deaths</strong>:
-                {{ player.statistics.total_deaths }}
-            </li>
-                {% endif %}
-        </ol>
-        {% else %}
-        <p class="lead">
-            {{ player.name | title }} {{ player.get_player_phrase }} a
-            <span class="{{ player.player_css }}">{{ player.player_type }}</span> character!
-        </p>
-        {% endif %}
-
-    </details>
-    <hr>
-    {% endfor %}
-{% else %}
-    <p class="lead" title="You have not created any players yet!">
-        You have not created any players yet!
-    </p>
-{% endif %}
-
-<details open>
-    <summary>
-        <a class="h4 icon-link icon-link-hover" href="#essence">
-            <svg aria-hidden="false" class="bi" role="img" aria-label="Link to this section: Essence">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#link-45deg">
-                </use>
-            </svg>
-        </a>
-        <h3 id="essence" title="Essence">
-            Essence
-        </h3>
-        <span class="badge bg-dark rounded-pill border border-secondary" title="{{ request.user.current_essence }} essence" data-bs-toggle="tooltip" data-bs-title="{{ request.user.current_essence }} essence">
-            {{ request.user.current_essence }}
-        </span>
-        <button
-            class="bg-black border-0 icon-link icon-link-hover p-1"
-            data-bs-toggle="popover"
-            data-bs-html="true"
-            data-bs-title="<strong>Essence?</strong>"
-            data-bs-content="&quot;<a title='Help: Essence' href='{% url 'help_page' help_topic='Essence' %}#topic' target='_blank'>Essence</a>&quot;
-                are rewards points earned each season. Essence is preserved across seasons,
-                and can be spent by typing &quot;<code>shop</code>&quot; any time."
-            type="button">
-            <svg
-                aria-hidden="false"
-                aria-label="Essence are rewards points earned each season: {{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'help_page' help_topic='Essence' %}#topic"
-                class="bi"
-                role="note">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#question-circle">
-                </use>
-            </svg>
-        </button>
-    </summary>
-    <ul class="list-group list-group-unbordered">
-        <li class="border-0 list-group-item list-group-item-text" title="Current: {{ request.user.current_essence }} essence">
-            <strong>Current</strong>:
-            {{ request.user.current_essence }} essence
-        </li>
-        <li class="border-0 list-group-item list-group-item-text" title="Earned: {{ request.user.seasonal_earned }} essence">
-            <strong>Earned</strong>:
-            {{ request.user.seasonal_earned }} essence
-        </li>
-    </ul>
-</details>
-<hr>
-<details {% if request.user.upgrades.count > 0 %} open{% endif %}>
-    <summary>
-        <a class="h4 icon-link icon-link-hover" href="#upgrades">
-            <svg aria-hidden="false" class="bi" role="img" aria-label="Link to this section: Upgrades ({{ request.user.upgrades.count }} upgrade{{ request.user.upgrades.count|pluralize }})">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#link-45deg">
-                </use>
-            </svg>
-        </a>
-        <h4 id="upgrades" title="Upgrades">
-            Upgrades
-        </h4>
-        <span class="badge bg-dark rounded-pill border border-secondary" data-bs-toggle="tooltip" data-bs-title="{{ request.user.upgrades.count }} upgrades">
-            {{ request.user.upgrades.count }}
-        </span>
-        <button
-                class="bg-black border-0 icon-link icon-link-hover p-1"
-                data-bs-toggle="popover"
-                data-bs-html="true"
-                data-bs-title="<strong>Upgrades?</strong>"
-                data-bs-content="A list of remort upgrades
-                (which can be &quot;bought&quot; with renown points in-game)
-                <a href='{% url 'upgrades' %}#upgrades' target='_blank'>is available here</a>."
-                type="button">
-            <svg class="bi" aria-hidden="false" role="note" aria-label="Remort Upgrades: {{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'upgrades' %}#upgrades">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#question-circle"></use>
-            </svg>
-        </button>
-    </summary>
-{% if request.user.upgrades.all %}
-    <ul class="list-group list-group-unbordered">
-    {% for upgraded in request.user.upgrades.all %}
-        <li class="list-group-item border-0" title="{{ upgraded.upgrade.name }} (x{{ upgraded.amount }})">
-            <span class="text-secondary me-3">
-                {{ forloop.counter }}.
-            </span>
-            <span class="list-group-item-text">
-                {{ upgraded.upgrade.name }}
-            </span>
-            <span class="badge bg-dark border border-secondary text-ishar rounded-pill">
-                x{{ upgraded.amount }}
-            </span>
-        </li>
-    {% endfor %}
-    </ul>
-{% else %}
-    <p class="fst-italic" title="You have not purchased any upgrades.">
-        You have not purchased any upgrades.
-    </p>
-{% endif %}
-</details>
-
-<hr>
-
-<details open>
-    <summary title="Account Created ({{ request.user.account_name }}): {{ request.user.created_at|naturaltime }}">
-        <a class="h4 icon-link icon-link-hover" href="#created">
-            <svg aria-hidden="false" class="bi" role="img" aria-label="Link to this section: Account Created ({{ request.user.account_name }}): {{ request.user.created_at|naturaltime }}">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#link-45deg">
-                </use>
-            </svg>
-        </a>
-        <h5 id="created">
-            Created
-        </h5>
-    </summary>
-    <blockquote class="ms-3 blockquote">
-        <p title="{{ request.user.created_at|naturaltime }}">
-            {{ request.user.created_at|naturaltime }}
-        </p>
-        <footer class="blockquote-footer" title="{{ request.user.created_at }}">
-            <time datetime="{{ request.user.created_at|date:"c" }}">
-                {{ request.user.created_at }}
-            </time>
-        </footer>
-    </blockquote>
-</details>
-
 <script>
-    // Enable Bootstrap tooltips and popovers.
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
-    const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
-    const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl));
+    // Toggle profile privacy; the endpoint flips the flag server-side and
+    // returns the new state. All DOM writes are textContent / class swaps.
+    (function () {
+        const sw = document.getElementById("privateSwitch");
+        const msg = document.getElementById("privateMsg");
+        const pill = document.getElementById("privacyPill");
 
-    /* Define function to let a user toggle their profile public/private. */
-    function togglePrivate(itemId) {
-
-        // Get toggle switch.
-        const item = document.getElementById(itemId);
-
-        // Set up confirmation text.
-        let messageText = "";
-        const msgDiv = document.getElementById("privateMsgDiv");
-        const msgNode = document.getElementById("privateMsgNode");
-
-        // Change value, and format text when either making...
-
-        // Public.
-        if (item.value === "true") {
-            item.value = false;
-            messageText = "public";
-            msgNode.classList.remove("message-success");
-            msgNode.classList.add("message-warning");
-
-        // Private.
-        } else if (item.value === "false") {
-            item.value = true;
-            messageText = "private";
-            msgNode.classList.remove("message-warning");
-            msgNode.classList.add("message-success");
+        function render(isPrivate) {
+            sw.checked = isPrivate;
+            pill.textContent = isPrivate ? "private" : "public";
+            pill.className = "ac-pill " + (isPrivate ? "ac-pill--warn" : "ac-pill--muted");
+            msg.textContent = "Your profile is now " + (isPrivate ? "private" : "public") + ".";
+            msg.className = "ac-note ac-note--ok mt-2";
+            setTimeout(function () { msg.className = "ac-note ac-note--ok mt-2 d-none"; }, 5000);
         }
 
-        // POST request to HTTPS endpoint to toggle profile privacy.
-        const xhr = new XMLHttpRequest();
-        xhr.open("POST", "{% url 'set_private' %}");
-        xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-
-        // Show text five (5) seconds before clearing, upon successful request.
-        xhr.onreadystatechange = () => {
-            if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
-                msgDiv.style.display = 'block';
-                msgNode.innerHTML = `Your profile has been made <b>${messageText}</b>.`
-                setTimeout(function() { msgNode.innerHTML = ""; msgDiv.style.display = 'none'; }, 5*1000);
-            }
-        };
-
-        // Include CSRF token in the POST request.
-        xhr.send(`csrfmiddlewaretoken={{ csrf_token }}`);
-    };
+        sw.addEventListener("change", function () {
+            sw.disabled = true;
+            fetch("{% url 'set_private' %}", {
+                method: "POST",
+                headers: {
+                    "X-CSRFToken": "{{ csrf_token }}",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: "csrfmiddlewaretoken={{ csrf_token }}",
+            }).then(function (resp) {
+                return resp.json().then(function (data) { return { ok: resp.status === 200, data: data }; });
+            }).then(function (r) {
+                if (r.ok && r.data.message && typeof r.data.message.is_private === "boolean") {
+                    render(r.data.message.is_private);
+                } else {
+                    sw.checked = !sw.checked;
+                    msg.textContent = "Could not update your privacy setting.";
+                    msg.className = "ac-note ac-note--danger mt-2";
+                }
+            }).catch(function () {
+                sw.checked = !sw.checked;
+                msg.textContent = "Could not update your privacy setting.";
+                msg.className = "ac-note ac-note--danger mt-2";
+            }).finally(function () {
+                sw.disabled = false;
+            });
+        });
+    })();
 </script>
 {% endblock content %}

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -692,6 +692,45 @@ a.ac-row__link:hover { color: var(--ac-accent); }
     gap: .5rem;
 }
 
+/* ------------------------------------------------------- link cards --- */
+/* Navigation card (anchor sibling of .ac-toggle): icon tile + name + note,
+   optional trailing element (badge/pill). Lay out in .ac-grid. */
+.ac-link {
+    display: flex;
+    align-items: flex-start;
+    gap: .7rem;
+    padding: .8rem .9rem;
+    border-radius: var(--ac-radius-sm);
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+    text-decoration: none;
+    transition: background .15s, border-color .15s, transform .1s;
+}
+a.ac-link:link, a.ac-link:visited { color: var(--ac-text); }
+.ac-link:hover {
+    background: var(--ac-elev);
+    border-color: rgba(255, 170, 119, .45);
+    color: var(--ac-text);
+    transform: translateY(-1px);
+}
+.ac-link:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: 2px; }
+.ac-link__icon {
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: var(--ac-radius-sm);
+    color: var(--ac-accent);
+    background: var(--ac-wash);
+    border: 1px solid rgba(255, 170, 119, .25);
+}
+.ac-link__icon .bi { width: 1.1rem; height: 1.1rem; }
+.ac-link__body { min-width: 0; flex: 1 1 auto; }
+.ac-link__name { font-weight: 600; display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; }
+.ac-link__note { color: var(--ac-dim); font-size: .78rem; margin-top: .1rem; }
+.ac-link__side { margin-left: auto; flex: 0 0 auto; align-self: center; }
+
 /* ------------------------------------------------------ empty state --- */
 .ac-empty {
     display: flex;

--- a/apps/core/static/css/style.css
+++ b/apps/core/static/css/style.css
@@ -48,25 +48,54 @@
 svg.bi:not([width]) { width: 1em; height: 1em; }
 .bi { vertical-align: -.125em; fill: currentColor; }
 
-.navbar, .navbar-expand-lg .navbar-nav .nav-link, .list-group, .list-group-item, .card { background-color: #000; }
+/* --------------------------------------------------------------------------
+   Shell surfaces — the global frame every page sits in (nav, breadcrumb,
+   content, messages, footer). Layered-grey panels with restrained amber;
+   the heavy black+amber-outline boxes live on only in untouched page content.
+   -------------------------------------------------------------------------- */
+.shell-panel {
+    background: var(--ac-panel);
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius);
+}
+.navbar.shell-panel { border-bottom: 2px solid rgba(255, 170, 119, .4); }
+.shell-menu {
+    background: var(--ac-elev);
+    border: 1px solid var(--ac-border-2);
+    border-radius: var(--ac-radius-sm);
+}
+.shell-menu .dropdown-item { border-radius: var(--ac-radius-sm); }
+#logo { height: 8rem; }
+@media (max-width: 575.98px) {
+    #logo { height: 5.5rem; }
+}
+
+.list-group, .list-group-item, .card { background-color: #000; }
 
 .list-group a .bi,
 .blockquote-footer .bi,
 .navbar,
-.navbar-expand-lg .navbar-nav .nav-link,
+.navbar .nav-link,
 .text-ishar
 {
     color: var(--ishar-color);
 }
 
+/* Breadcrumbs: a quiet page-title line, not a boxed banner. Old templates
+   still emit h2-sized crumbs — these rules size both patterns down. */
 .breadcrumb {
     --bs-breadcrumb-margin-bottom: 0;
     --bs-breadcrumb-divider: '•';
     --bs-breadcrumb-divider-color: var(--bs-secondary);
 }
-.breadcrumb-item .bi, .nav-link .bi, footer a .bi {
-    color: var(--bs-primary);
+.breadcrumb-item.h2, .breadcrumb .h2, .breadcrumb h2 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-bottom: 0;
 }
+.breadcrumb-item .bi { color: var(--ishar-color); }
+.nav-link .bi { color: var(--ishar-color); }
+footer a .bi { color: var(--ac-dim); }
 
 .icon-link-hover { --bs-icon-link-transform: translate3d(0, -.3rem, 0); }
 svg[role="img"] { color: var(--bs-primary); }
@@ -78,7 +107,7 @@ a[target="_blank"] {
     }
 }
 
-body { background-color: #323639; color: var(--ac-text); }
+body { background-color: var(--ac-bg); color: var(--ac-text); }
 .card-header, .card-title { color: var(--ishar-color); }
 .card, .card-text, .card-footer { color: var(--ac-text); }
 button, textarea, select {

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -1,4 +1,5 @@
 {% load humanize %}
+{% load ishar %}
 {% load static %}
 <!DOCTYPE html>
 <html class="dark" data-bs-theme="dark" lang="en">
@@ -85,11 +86,11 @@
 
         <header class="mt-1 p-1">
 
-            <nav class="border-ishar navbar navbar-dark navbar-expand-lg rounded">
+            <nav class="navbar navbar-dark navbar-expand-lg shell-panel">
 
                 <a href="{% url 'index' %}" title="{{ WEBSITE_TITLE }}">
                     <h1 class="visually-hidden">{% block page_heading %}{{ WEBSITE_TITLE }} - Free Online MUD (Multi-User Dungeon){% endblock page_heading %}</h1>
-                    <img class="navbar-brand" id="logo" alt="{{ WEBSITE_TITLE }} - Free Online MUD" src="{% static "images/logo.png" %}" style="height: 10rem;">
+                    <img class="navbar-brand" id="logo" alt="{{ WEBSITE_TITLE }} - Free Online MUD" src="{% static "images/logo.png" %}">
                 </a>
 
                 <button class="border-ishar m-3 navbar-dark navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle Navigation">
@@ -101,26 +102,20 @@
 
                         <li class="nav-item" title="Home">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'index' %}">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#house"></use>
-                                </svg>
+                                {% bi "house" %}
                                 Home
                             </a>
                         </li>
                         <li class="nav-item" title="Connect to {{ WEBSITE_TITLE }}">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'connect' %}">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#globe"></use>
-                                </svg>
+                                {% bi "globe" %}
                                 Connect
                             </a>
                         </li>
 
                         <li class="nav-item" title="Events ({{ GLOBAL_EVENT_COUNT }})">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'events' %}#events">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#calendar-event"></use>
-                                </svg>
+                                {% bi "calendar-event" %}
                                 Events
 {% if GLOBAL_EVENT_COUNT > 0 %}
                                 <span class="badge bg-dark rounded-pill border border-secondary">
@@ -131,21 +126,17 @@
                         </li>
                         <li class="nav-item" title="Frequently Asked Questions">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'faq' %}#faq">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#patch-question"></use>
-                                </svg>
+                                {% bi "patch-question" %}
                                 FAQs
                             </a>
                         </li>
 
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle icon-link icon-link-hover" href="{% url 'help' %}#help" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#info-circle"></use>
-                                </svg>
+                                {% bi "info-circle" %}
                                 Help
                             </a>
-                            <ul class="bg-black border border-secondary dropdown-menu dropdown-menu-dark p-1">
+                            <ul class="dropdown-menu dropdown-menu-dark p-1 shell-menu">
                                 <li class="nav-item" title="Search Help Topics">
                                     <div class="form-control-dark input-group">
                                         <form method="post" action="{% url 'help' %}#search">
@@ -160,49 +151,37 @@
                                 </li>
                                 <li class="nav-item" title="All Help Topics">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'help' %}#topics">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#question-circle"></use>
-                                        </svg>
+                                        {% bi "question-circle" %}
                                         All Topics
                                     </a>
                                 </li>
                                 <li class="nav-item" title="Basics">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'help_page' help_topic='MUD Basics' %}#topic">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#collection-play"></use>
-                                        </svg>
+                                        {% bi "collection-play" %}
                                         Basics
                                     </a>
                                 </li>
                                 <li class="nav-item" title="Get Started">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'start' %}#start">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use>
-                                        </svg>
+                                        {% bi "rocket-takeoff" %}
                                         Get Started
                                     </a>
                                 </li>
                                 <li class="nav-item" title="Help">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'help' %}#help">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#info-circle"></use>
-                                        </svg>
+                                        {% bi "info-circle" %}
                                         Help
                                     </a>
                                 </li>
                                 <li class="nav-item" title="History">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'history' %}#history">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#clock-history"></use>
-                                        </svg>
+                                        {% bi "clock-history" %}
                                         History
                                     </a>
                                 </li>
                                 <li class="nav-item" title="MUD Clients">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'clients' %}#clients">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#terminal-split"></use>
-                                        </svg>
+                                        {% bi "terminal-split" %}
                                         MUD Clients
                                     </a>
                                 </li>
@@ -210,25 +189,19 @@
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle icon-link icon-link-hover" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#bandaid"></use>
-                                </svg>
+                                {% bi "bandaid" %}
                                 Patches
                             </a>
-                            <ul class="bg-black border border-secondary dropdown-menu dropdown-menu-dark p-1">
+                            <ul class="dropdown-menu dropdown-menu-dark p-1 shell-menu">
                                 <li class="nav-item" title="Latest Patch">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'latest_patch' %}#latest">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#file-earmark-pdf"></use>
-                                        </svg>
+                                        {% bi "file-earmark-pdf" %}
                                         Latest
                                     </a>
                                 </li>
                                 <li class="nav-item" title="All Patches">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'patches' %}#patches">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#collection"></use>
-                                        </svg>
+                                        {% bi "collection" %}
                                         All
                                     </a>
                                 </li>
@@ -237,99 +210,86 @@
 {% if user and user.is_authenticated %}
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle icon-link icon-link-hover" href="{% url 'portal' %}#portal" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-                                </svg>
+                                {% bi "person-gear" %}
                                 Portal
                             </a>
-                            <ul class="bg-black border border-secondary dropdown-menu dropdown-menu-dark p-1">
+                            <ul class="dropdown-menu dropdown-menu-dark p-1 shell-menu">
     {% if user.is_staff %}
                                 <li class="nav-item" title="Administration">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'admin:index' %}" target="_blank">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#gear"></use>
-                                        </svg>
+                                        {% bi "gear" %}
                                         Administration
-                                        <svg class="bi" aria-hidden="false" role="img" aria-label="Open Administration in a new window.">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#box-arrow-up-right"></use>
-                                        </svg>
+                                        {% bi "box-arrow-up-right" label="Open Administration in a new window." %}
                                     </a>
                                 </li>
         {% if user.is_god %}
                                 <li class="nav-item" title="Deploy">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'deploy' %}#deploy">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#rocket-takeoff"></use>
-                                        </svg>
+                                        {% bi "rocket-takeoff" %}
                                         Deploy
                                     </a>
                                 </li>
         {% endif %}
+    {% endif %}
+    {% if user.is_eternal %}
+                                <li class="nav-item" title="Feedback Triage">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'feedback' %}#feedback">
+                                        {% bi "flag" %}
+                                        Feedback Triage
+                                    </a>
+                                </li>
+                                <li class="nav-item" title="Style Guide">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'styleguide' %}#styleguide">
+                                        {% bi "palette" %}
+                                        Style Guide
+                                    </a>
+                                </li>
+                                <li class="nav-item">
+                                    <hr class="dropdown-divider">
+                                </li>
+    {% elif user.is_staff %}
                                 <li class="nav-item">
                                     <hr class="dropdown-divider">
                                 </li>
     {% endif %}
                                 <li class="nav-item" title="Challenges">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'challenges' %}#challenges">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#award"></use>
-                                        </svg>
+                                        {% bi "award" %}
                                         Challenges
                                     </a>
                                 </li>
 
-    {% if user.is_eternal %}
-                                <li class="nav-item" title="Feedback Triage">
-                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'feedback' %}#feedback">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#flag"></use>
-                                        </svg>
-                                        Feedback Triage
-                                    </a>
-                                </li>
-    {% endif %}
-
                                 <li class="nav-item" title="Leaders">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'leaders' %}#leaders">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#trophy"></use>
-                                        </svg>
+                                        {% bi "trophy" %}
                                         Leaders
                                     </a>
                                 </li>
 
                                 <li class="nav-item" title="Password">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'password' %}#password">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#key"></use>
-                                        </svg>
+                                        {% bi "key" %}
                                         Password
                                     </a>
                                 </li>
 
                                 <li class="nav-item" title="Portal">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-                                        </svg>
+                                        {% bi "person-gear" %}
                                         Portal
                                     </a>
                                 </li>
 
                                 <li class="nav-item" title="Upgrades">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'upgrades' %}#upgrades">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#shield"></use>
-                                        </svg>
+                                        {% bi "shield" %}
                                         Upgrades
                                     </a>
                                 </li>
 
                                 <li class="nav-item" title="Who's Online?">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'who' %}#who">
-                                        <svg class="bi" aria-hidden="true">
-                                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#people"></use>
-                                        </svg>
+                                        {% bi "people" %}
                                         Who's Online?
                                         <span class="badge bg-dark rounded-pill border border-secondary" title="{{ PLAYERS_ONLINE }} player{{ PLAYERS_ONLINE|pluralize }} online">
                                             {{ PLAYERS_ONLINE }}
@@ -345,9 +305,7 @@
                                     <form action="{% url 'logout' %}#messages" method="post">
                                         {% csrf_token %}
                                         <button class="nav-link dropdown-item icon-link icon-link-hover" type="submit">
-                                            <svg class="bi" aria-hidden="true">
-                                                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#door-closed"></use>
-                                            </svg>
+                                            {% bi "door-closed" %}
                                             Log out ({{ request.user.get_username }})
                                         </button>
                                     </form>
@@ -359,30 +317,22 @@
 {% else %}
                         <li class="nav-item" title="Portal">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-                                </svg>
+                                {% bi "person-gear" %}
                                 Portal
                             </a>
                         </li>
 {% endif %}
                         <li class="nav-item" title="Wiki">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'wiki' %}" target="_blank">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#globe"></use>
-                                </svg>
+                                {% bi "globe" %}
                                 Wiki
-                                <svg class="bi" aria-hidden="false" role="img" aria-label="Open Ishar MUD wiki in a new window.">
-                                    <use xlink:href="/static/bootstrap-icons/bootstrap-icons.svg#box-arrow-up-right"></use>
-                                </svg>
+                                {% bi "box-arrow-up-right" label="Open Ishar MUD wiki in a new window." %}
                             </a>
                         </li>
 
                         <li class="nav-item" title="World">
                             <a class="nav-link icon-link icon-link-hover" href="{% url 'world' %}#world">
-                                <svg class="bi" aria-hidden="true">
-                                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#globe-asia-australia"></use>
-                                </svg>
+                                {% bi "globe-asia-australia" %}
                                 World
                             </a>
                         </li>
@@ -397,15 +347,10 @@
 
         <main class="p-1">
 
-            <nav class="bg-black border-ishar ps-1 pt-1 rounded" aria-label="breadcrumb">
+            <nav class="ps-2 pt-2" aria-label="breadcrumb">
                 <ol class="breadcrumb gap-1 grid">
 {% block breadcrumbs %}
-                    <li class="breadcrumb-item h2" title="Welcome">
-                        <svg class="bi" aria-hidden="true">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#house"></use>
-                        </svg>
-                        Welcome
-                    </li>
+                    {% crumb "Welcome" "house" active=True %}
 {% endblock breadcrumbs %}
                 </ol>
             </nav>
@@ -414,7 +359,7 @@
     {% if messages %}
             <div class="p-1" id="messages">
         {% for message in messages %}
-                <div class="alert alert-dark alert-dismissible bg-black border-ishar fade p-2 show" role="alert">
+                <div class="alert alert-dark alert-dismissible fade p-2 shell-panel show" role="alert">
                     <p class="fw-bold lead message-{{ message.tags }}">
                         {{ message }}
                     </p>
@@ -425,14 +370,14 @@
     {% endif %}
 {% endblock messages %}
 
-            <div class="bg-black border-ishar my-1 p-2 rounded" id="content">
+            <div class="my-1 p-3 shell-panel" id="content">
 {% block content %}
 {% endblock content %}
             </div>
             <script src="{% static 'js/alertRefocus.js' %}"></script>
 {% block player_search_form %}
         {% if user and user.is_authenticated and PLAYER_SEARCH_FORM %}
-            <div class="bg-black border-ishar my-1 p-2 rounded">
+            <div class="my-1 p-2 shell-panel">
                 {% include "search_form.html" %}
             </div>
         {% endif %}
@@ -442,56 +387,42 @@
 
         <footer class="mx-3 text-center">
 {% if CURRENT_SEASON %}
-            <div class="bg-black border-ishar my-1 p-1 rounded row">
+            <div class="my-1 p-1 row shell-panel">
                 <div class="col">
                     <a class="icon-link icon-link-hover" href="{% url 'current_season' %}#season">
-                        <svg class="bi" aria-hidden="true">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#calendar"></use>
-                        </svg>
+                        {% bi "calendar" %}
                         Season {{ CURRENT_SEASON.season_id }}
                     </a>
                 </div>
                 <div class="col p-1">
                     <span class="icon-link">
-                        <svg class="bi text-secondary" aria-hidden="true">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#hourglass-split"></use>
-                        </svg>
+                        {% bi "hourglass-split" css="text-secondary" %}
                         Ends {{ CURRENT_SEASON.expiration_date | naturaltime }}
                     </span>
                 </div>
             </div>
 {% endif %}
-            <div class="bg-black border-ishar my-1 p-1 rounded row">
+            <div class="my-1 p-1 row shell-panel">
                 <div class="col">
                     <a class="icon-link icon-link-hover" href="mailto:{{ ADMIN_EMAIL }}" target="_blank" title="E-mail Us! ({{ ADMIN_EMAIL }})">
-                        <svg class="bi" aria-hidden="true">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#envelope-at"></use>
-                        </svg>
+                        {% bi "envelope-at" %}
                         E-mail us!
-                        <svg class="bi" aria-hidden="false" role="img" aria-label="Send an e-mail to {{ ADMIN_EMAIL }}.">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#box-arrow-up-right"></use>
-                        </svg>
+                        {% bi "box-arrow-up-right" label="Opens your e-mail app." %}
                     </a>
                 </div>
 
                 <div class="col">
                     <a class="icon-link icon-link-hover" href="{% url 'support' %}#support" title="Support {{ WEBSITE_TITLE }}">
-                        <svg class="bi" aria-hidden="true">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#heart"></use>
-                        </svg>
+                        {% bi "heart" %}
                         Support {{ WEBSITE_TITLE }}
                     </a>
                 </div>
 
                 <div class="col">
                     <a class="icon-link icon-link-hover" href="{% url 'discord' %}" target="_blank" title="Join us on Discord!">
-                        <svg class="bi" aria-hidden="true">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#discord"></use>
-                        </svg>
+                        {% bi "discord" %}
                         Join us on Discord!
-                        <svg class="bi" aria-hidden="false" role="img" aria-label="Join {{ WEBSITE_TITLE }} Discord.">
-                            <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#box-arrow-up-right"></use>
-                        </svg>
+                        {% bi "box-arrow-up-right" label="Join the Discord server." %}
                     </a>
                 </div>
 

--- a/apps/core/templates/styleguide.html
+++ b/apps/core/templates/styleguide.html
@@ -1,0 +1,322 @@
+{% extends "layout.html" %}
+{% load ishar %}
+{% load static %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Style Guide{% endblock meta_title %}
+{% block meta_description %}Live design-system reference for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
+{% block meta_url %}{% url 'styleguide' %}#styleguide{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Style Guide{% endblock title %}
+{% block scripts %}let focusTo = 'styleguide'{% endblock scripts %}
+{% block includes %}
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
+        <style>
+            .sg-swatches { display: flex; flex-wrap: wrap; gap: .6rem; }
+            .sg-swatch {
+                display: flex; flex-direction: column; align-items: center; gap: .25rem;
+                font-size: .72rem; color: var(--ac-dim); min-width: 5.5rem;
+            }
+            .sg-swatch i {
+                display: block; width: 100%; height: 2.2rem;
+                border-radius: var(--ac-radius-sm); border: 1px solid var(--ac-border-2);
+                background: var(--sw);
+            }
+            .sg-swatch code { font-size: .72rem; color: var(--ac-text); background: none; padding: 0; }
+            .sg-cluster { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; }
+            .sg-stack { display: flex; flex-direction: column; gap: .75rem; }
+        </style>
+{% endblock includes %}
+{% block breadcrumbs %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Style Guide" "palette" urlname="styleguide" anchor="styleguide" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac ac--wide">
+
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "palette" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Style Guide</h2>
+            <p class="ac-hero__sub">
+                The design system, live. Markup and rules in <code>docs/design/</code>;
+                components in <code>admin-console.css</code>, tokens in <code>style.css</code>.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+            <span class="ac-pill ac-pill--status ac-pill--ok ac-pill--live">reference</span>
+        </div>
+    </header>
+
+    <!-- Tokens -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "droplet" %} Tokens — brand, surfaces, semantics</div>
+        <p class="ac-panel__hint">Every color on a faceflifted page comes from these custom properties.</p>
+        <div class="sg-swatches">
+            <span class="sg-swatch"><i style="--sw: var(--ac-accent)"></i><code>--ac-accent</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-accent-2)"></i><code>--ac-accent-2</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-bg)"></i><code>--ac-bg</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-panel)"></i><code>--ac-panel</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-elev)"></i><code>--ac-elev</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-border)"></i><code>--ac-border</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-border-2)"></i><code>--ac-border-2</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-text)"></i><code>--ac-text</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-dim)"></i><code>--ac-dim</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-ok)"></i><code>--ac-ok</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-info)"></i><code>--ac-info</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-warn)"></i><code>--ac-warn</code></span>
+            <span class="sg-swatch"><i style="--sw: var(--ac-danger)"></i><code>--ac-danger</code></span>
+            <span class="sg-swatch"><i style="--sw: #00b7eb"></i><code>immortal</code></span>
+        </div>
+    </div>
+
+    <!-- Pills -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "circle-fill" %} Status pills — <code>.ac-pill</code></div>
+        <div class="sg-cluster">
+            <span class="ac-pill ac-pill--muted">muted</span>
+            <span class="ac-pill ac-pill--ok">ok</span>
+            <span class="ac-pill ac-pill--info">info</span>
+            <span class="ac-pill ac-pill--warn">warn</span>
+            <span class="ac-pill ac-pill--danger">danger</span>
+            <span class="ac-pill ac-pill--accent">accent</span>
+            <span class="ac-pill ac-pill--status ac-pill--ok">with dot</span>
+            <span class="ac-pill ac-pill--status ac-pill--ok ac-pill--live">live</span>
+        </div>
+    </div>
+
+    <!-- Buttons -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "hand-index" %} Buttons — <code>.ac-btn</code>, <code>.ac-cta</code></div>
+        <div class="sg-stack">
+            <div class="sg-cluster">
+                <button class="ac-btn" type="button">default</button>
+                <button class="ac-btn ac-btn--ok" type="button">{% bi "check-lg" %} ok</button>
+                <button class="ac-btn ac-btn--info" type="button">info</button>
+                <button class="ac-btn ac-btn--warn" type="button">warn</button>
+                <button class="ac-btn ac-btn--danger" type="button">danger</button>
+                <button class="ac-btn ac-btn--accent" type="button">accent</button>
+                <button class="ac-btn" type="button" disabled>disabled</button>
+            </div>
+            <div class="row g-2">
+                <div class="col-md-6">
+                    <button class="ac-cta" type="button">{% bi "rocket-takeoff" %} destructive primary</button>
+                </div>
+                <div class="col-md-6">
+                    <button class="ac-cta ac-cta--accent" type="button">{% bi "check-lg" %} accent primary</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Filter chips + fields -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "funnel" %} Filter bar — <code>.ac-filter</code>, <code>.ac-chip</code>, <code>.ac-field</code></div>
+        <div class="ac-filter mb-2">
+            <a class="ac-chip ac-chip--active" href="#styleguide">Active</a>
+            <a class="ac-chip" href="#styleguide">Open</a>
+            <a class="ac-chip" href="#styleguide">Closed</a>
+            <span class="ac-filter__sep" aria-hidden="true"></span>
+            <a class="ac-chip" href="#styleguide">Bug</a>
+            <a class="ac-chip" href="#styleguide">Idea</a>
+        </div>
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+            <input class="ac-field ac-field--inline flex-grow-1" style="min-width: 10rem;" type="search" placeholder="Search…" aria-label="Example search">
+            <select class="ac-field ac-field--inline" aria-label="Example sort">
+                <option>Newest</option>
+                <option>Oldest</option>
+            </select>
+            <button class="ac-btn" type="button">{% bi "search" %} Search</button>
+        </div>
+        <div class="mt-3">
+            <label class="ac-label" for="sg-input">Icon input — <code>.ac-inputgroup</code></label>
+            <div class="ac-inputgroup">
+                <span class="ac-inputgroup__icon">{% bi "key" %}</span>
+                <input class="ac-input" type="text" id="sg-input" placeholder="Placeholder text">
+            </div>
+        </div>
+    </div>
+
+    <!-- Tiles -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "grid" %} Stat tiles — <code>.ac-tiles</code>, <code>.ac-tile</code></div>
+        <div class="ac-tiles">
+            <a class="ac-tile ac-tile--accent ac-tile--active" href="#styleguide">
+                <span class="ac-tile__n">7</span><span class="ac-tile__label">Active filter</span>
+            </a>
+            <a class="ac-tile ac-tile--danger" href="#styleguide">
+                <span class="ac-tile__n">3</span><span class="ac-tile__label">Danger</span>
+            </a>
+            <a class="ac-tile ac-tile--info" href="#styleguide">
+                <span class="ac-tile__n">2</span><span class="ac-tile__label">Info</span>
+            </a>
+            <a class="ac-tile ac-tile--muted" href="#styleguide">
+                <span class="ac-tile__n">0</span><span class="ac-tile__label">Zero = muted</span>
+            </a>
+        </div>
+    </div>
+
+    <!-- Selection controls -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "ui-checks" %} Selection — <code>.ac-seg</code>, <code>.ac-toggle</code>, <code>.ac-switch</code></div>
+        <div class="sg-stack">
+            <div class="ac-seg" role="radiogroup" aria-label="Example environment">
+                <input class="btn-check" type="radio" name="sg-env" id="sg-env-prod" checked>
+                <label class="ac-seg__item ac-seg__item--prod" for="sg-env-prod">{% bi "hdd-stack" %} prod</label>
+                <input class="btn-check" type="radio" name="sg-env" id="sg-env-test">
+                <label class="ac-seg__item ac-seg__item--test" for="sg-env-test">{% bi "cone-striped" %} test</label>
+            </div>
+            <div class="ac-grid">
+                <input class="btn-check" type="checkbox" id="sg-svc-a" checked>
+                <label class="ac-toggle" for="sg-svc-a">
+                    <span class="ac-toggle__icon">{% bi "controller" %}</span>
+                    <span class="ac-toggle__body">
+                        <span class="ac-toggle__name">ishar-app</span>
+                        <span class="ac-toggle__note">Selected toggle card</span>
+                    </span>
+                    <span class="ac-toggle__check">{% bi "check-circle-fill" %}</span>
+                </label>
+                <input class="btn-check" type="checkbox" id="sg-svc-b">
+                <label class="ac-toggle" for="sg-svc-b">
+                    <span class="ac-toggle__icon">{% bi "globe2" %}</span>
+                    <span class="ac-toggle__body">
+                        <span class="ac-toggle__name">ishar-web</span>
+                        <span class="ac-toggle__note">Unselected toggle card</span>
+                    </span>
+                    <span class="ac-toggle__check">{% bi "check-circle-fill" %}</span>
+                </label>
+            </div>
+            <div class="form-check form-switch ac-switch">
+                <input class="form-check-input" type="checkbox" role="switch" id="sg-switch" checked>
+                <label class="form-check-label ac-switch__text" for="sg-switch">
+                    Labeled switch
+                    <span class="ac-switch__note d-block">With a supporting note.</span>
+                </label>
+            </div>
+        </div>
+    </div>
+
+    <!-- Link cards -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "link-45deg" %} Link cards — <code>.ac-link</code></div>
+        <div class="ac-grid">
+            <a class="ac-link" href="#styleguide">
+                <span class="ac-link__icon">{% bi "flag" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Feedback Triage</span>
+                    <span class="ac-link__note d-block">Navigation card with a note</span>
+                </span>
+            </a>
+            <a class="ac-link" href="#styleguide">
+                <span class="ac-link__icon">{% bi "people" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Who's Online?</span>
+                    <span class="ac-link__note d-block">With a trailing pill</span>
+                </span>
+                <span class="ac-link__side ac-pill ac-pill--ok">4</span>
+            </a>
+        </div>
+    </div>
+
+    <!-- Rows -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "list-ul" %} Record list — <code>.ac-rows</code>, <code>.ac-row</code></div>
+        <div class="ac-rows">
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "bug" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title"><a class="ac-row__link" href="#styleguide">A record title that links somewhere</a></div>
+                    <div class="ac-row__meta"><span class="mono">#214</span> <span>Meta</span> <span>wraps</span> <span>gracefully</span></div>
+                </div>
+                <div class="ac-row__side">
+                    <span class="ac-pill ac-pill--status ac-pill--danger">open</span>
+                    <button class="ac-btn ac-btn--ok" type="button">Ack</button>
+                </div>
+            </div>
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "lightbulb" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title"><a class="ac-row__link" href="#styleguide">Second row</a></div>
+                    <div class="ac-row__meta"><span class="mono">#209</span> <span>Hover raises the row</span></div>
+                </div>
+                <div class="ac-row__side"><span class="ac-pill ac-pill--status ac-pill--warn">duplicate</span></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Timeline + quote -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "chat-left-text" %} Timeline &amp; quote — <code>.ac-timeline</code>, <code>.ac-quote</code></div>
+        <div class="sg-stack">
+            <pre class="ac-quote">Verbatim player/machine text lives in an .ac-quote —
+monospace on the deepest surface, like a captured terminal excerpt.</pre>
+            <div class="ac-timeline">
+                <div class="ac-tl ac-tl--system">
+                    <span class="ac-tl__icon">{% bi "gear" %}</span>
+                    <div class="ac-tl__body">
+                        <div class="ac-tl__head">
+                            <span class="ac-tl__author">system</span>
+                            <span class="ac-tl__time">an hour ago</span>
+                        </div>
+                        <div class="ac-tl__text">System entries recede: dashed, dim, italic.</div>
+                    </div>
+                </div>
+                <div class="ac-tl">
+                    <span class="ac-tl__icon">{% bi "controller" %}</span>
+                    <div class="ac-tl__body">
+                        <div class="ac-tl__head">
+                            <span class="ac-tl__author ac-tl__author--staff">Ilistar</span>
+                            <span class="ac-pill ac-pill--info">staff</span>
+                            <span class="ac-tl__time">just now</span>
+                        </div>
+                        <div class="ac-tl__text">Human conversation stays foreground.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Notes, kv, empty, pager -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "card-list" %} Callouts, key/values, empty, pager</div>
+        <div class="sg-stack">
+            <div class="ac-note ac-note--ok" role="note">{% bi "check-circle" %} <span>An <strong>ok</strong> note.</span></div>
+            <div class="ac-note ac-note--warn" role="note">{% bi "exclamation-triangle" %} <span>A <strong>warn</strong> note with <code>code</code>.</span></div>
+            <div class="ac-note ac-note--danger" role="note">{% bi "x-octagon" %} <span>A <strong>danger</strong> note.</span></div>
+            <dl class="ac-kv">
+                <dt>Key</dt><dd>Right-aligned value</dd>
+                <dt>Another key</dt><dd>Another value</dd>
+            </dl>
+            <div class="ac-empty">
+                {% bi "inbox" %}
+                <span>The empty state: dashed, centered, one sentence.</span>
+            </div>
+            <nav class="ac-pager" aria-label="Example pager">
+                <a class="ac-btn" href="#styleguide">{% bi "chevron-left" %} Prev</a>
+                <span class="ac-pager__info">Page 2 of 3</span>
+                <a class="ac-btn" href="#styleguide">Next {% bi "chevron-right" %}</a>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Console -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "terminal" %} Job console — <code>.ac-console</code></div>
+        <section class="ac-console" aria-label="Example console">
+            <div class="ac-console__bar">
+                <span class="ac-console__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+                <span class="ac-console__title">deploy.sh</span>
+                <span class="ac-pill ac-pill--status ac-pill--warn ac-pill--live">running</span>
+                <span class="ac-console__spacer"></span>
+                <span class="ac-console__timer">1:23</span>
+                <button type="button" class="ac-copy">{% bi "clipboard" %} <span>Copy</span></button>
+            </div>
+            <div class="ac-console__step">
+                <span class="ac-spin" aria-hidden="true"></span>
+                <span class="ac-console__step-text">Building ishar-app (blue)…</span>
+            </div>
+            <pre class="ac-console__body">==> Pulling latest…
+==> Building ishar-app (blue)…
+Step 12/28 : COPY . /srv/ishar</pre>
+        </section>
+    </div>
+
+</div>
+{% endblock content %}

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -5,10 +5,12 @@ from apps.players.views.who import PlayerWhoView
 
 from .views import HomeView, StartView, UpgradesView, SupportView
 from .views.auth import IsharLoginView, IsharLogoutView
+from .views.styleguide import StyleGuideView
 
 
 urlpatterns = [
     path("", HomeView.as_view(), name="index"),
+    path("styleguide/", StyleGuideView.as_view(), name="styleguide"),
 
     # Authentication.
     path("login/", IsharLoginView.as_view(), name="login"),

--- a/apps/core/views/styleguide.py
+++ b/apps/core/views/styleguide.py
@@ -1,0 +1,14 @@
+"""
+Live style guide — staff-only page rendering every design token and Admin
+Console component from docs/design/, so a consistent page is copy-paste away
+and visual regressions are eyeballed in one place.
+"""
+from django.views.generic.base import TemplateView
+
+from .mixins import EternalRequiredMixin, NeverCacheMixin
+
+
+class StyleGuideView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
+    """The design system, rendered live (Eternal+)."""
+
+    template_name = "styleguide.html"

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -105,17 +105,16 @@ Staff surfaces first (highest value, lowest risk — few users, we control them)
 |---|---|---|
 | 1 | Deploy console (`/portal/deploy`) | ✅ done — the reference implementation |
 | 2 | Feedback triage (`/feedback`) | ✅ done — tiles, chips, rows, timeline |
-| 3 | Processes / other Django-admin-adjacent staff pages | next |
-| 4 | Portal (`/portal`) + global nav/layout shell | later |
-| 5 | Leaders, Challenges (DataTables pages) | later |
+| 3 | Processes / other Django-admin-adjacent staff pages | ✖ closed — lives in Django admin, nothing to facelift (see decisions.md) |
+| 4 | Portal (`/portal`) + global nav/layout shell | ✅ done — shell on console surfaces, portal rebuilt |
+| 5 | Leaders, Challenges (DataTables pages) | next |
 | 6 | Connect HUD (align tokens) | later |
 | 7 | Home, help, errors, public content | last |
 
-### Recommended near-term addition
-- **A live `/styleguide` page** (staff-only) that renders every token and
-  component from this doc, with copy-paste markup. It becomes the fastest way to
-  build a consistent page and to eyeball regressions. Not built yet — a good
-  next step once E1/E2 land.
+### Near-term addition
+- **`/styleguide`** (Eternal+): ✅ built — renders every token and component
+  live, linked from the Portal dropdown. The fastest way to build a consistent
+  page and eyeball regressions.
 
 ---
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -229,10 +229,39 @@ deliberate. Status: **formalized.**
 Two-column `dl` grid; dim keys, right-aligned values. Used: feedback detail.
 Status: **formalized.**
 
+### `.ac-link` — navigation card
+Anchor sibling of `.ac-toggle`: amber icon tile + name + note, optional
+trailing `__side` element (pill/badge). Lay out in `.ac-grid`. Link colors are
+pinned against the global `a:link` rule.
+```html
+<a class="ac-link" href="…">
+  <span class="ac-link__icon">{% bi "flag" %}</span>
+  <span class="ac-link__body">
+    <span class="ac-link__name">Feedback Triage</span>
+    <span class="ac-link__note d-block">Player bug / typo / idea reports</span>
+  </span>
+  <span class="ac-link__side ac-pill ac-pill--ok">4</span>
+</a>
+```
+Used: portal tool grids. Status: **formalized.**
+
 ### Container variants
 `.ac` (60rem) is the default console width; `.ac--wide` (72rem) for list-heavy
 surfaces. `.ac-cta--accent` is the amber non-destructive primary (red stays
 destructive).
+
+---
+
+## Shell components (global frame, `style.css`)
+
+- **`.shell-panel`** — the frame surface (nav, messages, `#content`, footer,
+  search): `--ac-panel` bg, `--ac-border` hairline, `--ac-radius`. The navbar
+  variant adds a 2px amber bottom edge.
+- **`.shell-menu`** — dropdown menus: `--ac-elev` bg, `--ac-border-2` hairline,
+  small radius.
+- **Breadcrumbs** are a quiet page-title line (no box); h2-sized crumbs from
+  old templates are downsized by CSS. Crumb/nav icons are amber; footer icons
+  dim.
 
 ---
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,61 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-12 — The global shell moves to the console surfaces
+
+**Decision.** The frame every page sits in — body, navbar, breadcrumb,
+messages, `#content`, footer — now uses the layered-grey token surfaces:
+`body` on `--ac-bg`, panels via the new `.shell-panel` (panel bg, hairline
+border, `--ac-radius`), dropdown menus via `.shell-menu` (elev bg). Amber is
+restrained to brand: nav text/icons, a 2px amber bottom edge on the navbar,
+headings. Breadcrumbs become a quiet page-title line (no box; h2-sized crumbs
+downsized by CSS so untouched templates inherit the fix). The logo slims to
+8rem (5.5rem on phones). The heavy black + `.border-ishar` outline boxes are no
+longer part of the shell — they live on only inside untouched page content, and
+`.border-ishar` remains defined for them.
+
+**Why.** The shell is the highest-leverage surface (every page, every visit).
+Nesting the console pages inside a black+amber frame produced two competing
+visual systems on one screen; one quiet frame lets both console surfaces and
+classic content read well while pages migrate. Icons also converge on amber
+(nav/breadcrumb) and dim (footer), replacing the blue/amber mishmash.
+
+## 2026-07-12 — Portal adopts the console language; popovers retired there
+
+**Decision.** `/portal` is rebuilt: hero (account, created, counts, essence +
+privacy pills), gated tool grids using the new `.ac-link` navigation card,
+characters as `.ac-rows` (immortals get an info pill and recede to a phrase;
+mortals show class/race/alignment and nonzero lifetime stats as icon+number
+meta), essence as `.ac-tile`s, upgrades as `.ac-kv`, and the private-profile
+toggle as an `.ac-switch` whose result renders in an `.ac-note` via
+`textContent` (the old `innerHTML` write is gone). Bootstrap tooltip/popover
+help-icons are replaced by `.ac-panel__hint` prose with links — fewer JS
+behaviors, better on phones.
+
+**Why.** The portal is the account hub and the template other pages copy; it
+was the largest remaining pile of pasted list-group/details markup.
+
+## 2026-07-12 — Live style guide at /styleguide (Eternal+)
+
+**Decision.** A staff-only page (`apps/core/views/styleguide.py`, linked from
+the Portal dropdown and portal grid) renders every token and component live.
+Page-specific demo CSS stays in the template's `<style>` block, not the shared
+layer.
+
+**Why.** The component set is now large enough that a copy-paste reference and
+one-glance regression check pays for itself.
+
+## 2026-07-12 — Roadmap #3 (Processes) is closed as not-a-surface
+
+**Decision.** The "Processes" staff pages live in Django admin (jazzmin), not
+in this site's template layer, and the admin's own notes mark its actions as
+container-model relics (the Deploy Console replaced the actionable part).
+There is nothing to facelift; removing the app entirely is tracked as game-repo
+follow-up cleanup, not design work.
+
+**Why.** Honest roadmap: a facelift line item that would restyle a dead surface
+is entropy, not progress.
+
 ## 2026-07-11 — E1: shared tokens live in style.css
 
 **Decision.** The `--ac-*` design tokens (plus `--ishar-color`) are defined once


### PR DESCRIPTION
Round 2 of the design refresh, per the `docs/design/` roadmap — this takes **#4 (Portal + global nav/layout shell)** and the recommended **`/styleguide`** addition, and closes **#3 (Processes)** as not-a-surface.

## Global shell (`layout.html` + `style.css`)

- Every page's frame now uses the console token surfaces: body on `--ac-bg`, navbar/messages/`#content`/footer as the new `.shell-panel` (panel bg, hairline border, radius) with a 2px amber navbar edge; dropdown menus as `.shell-menu`.
- Breadcrumbs become a quiet page-title line instead of a boxed h2 banner — CSS downsizes the h2-sized crumbs old templates still emit, so untouched pages inherit the fix.
- Icon colors converge: nav/breadcrumb amber, footer dim (replacing the blue/amber mix). Logo slims to 8rem (5.5rem on phones).
- `layout.html` fully adopts the `{% bi %}` / `{% crumb %}` tags, removing dozens of pasted SVG blocks.

## Portal rebuild (`/portal`)

- Hero with essence + privacy pills; staff/game tool grids on a new `.ac-link` navigation card; characters as `.ac-rows` with level/type pills and icon-coded lifetime stats; essence as `.ac-tile`s; upgrades as `.ac-kv`.
- The private-profile toggle is an `.ac-switch` whose result renders via `textContent` into an `.ac-note` — the old `innerHTML` write is removed. Tooltip/popover JS retired in favour of hint prose.

## Live style guide (`/styleguide`)

- Eternal-gated (404 to everyone else, per the mixin convention), rendering every token and component live; linked from the Portal dropdown and the portal staff grid.

## Docs

- `decisions.md` entries for the shell move, portal adoption, styleguide, and closing roadmap #3 (Processes lives in Django admin; its actions are container-model relics — nothing to facelift). Component catalog and roadmap statuses updated.

## Verification

- All templates rendered end-to-end under stub settings (portal, styleguide, home, plus both feedback pages against the rewritten layout); `py_compile`; `node --check` on script blocks.
- Full-page headless-Chromium screenshots at 1280px and a true 390px viewport, with `scrollWidth == viewport` asserted on every page (no horizontal overflow).
- Not exercised against the live DB/deploy agent: the private-toggle POST (endpoint unchanged) and the shell on real data — worth a quick prod skim of a few classic pages (help, leaders, who).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT

---
_Generated by [Claude Code](https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT)_