### PR TITLE
Mobile-friendliness pass: fix touch/phone regressions; pin the mobile checklist

### DIFF
--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -604,7 +604,7 @@ a.ac-btn:link, a.ac-btn:visited { color: var(--ac-text); }
     display: block;
     width: 100%;
     padding: .5rem .7rem;
-    font-size: .9rem;
+    font-size: 1rem; /* never below 16px: sub-16px inputs make iOS zoom-jump on focus */
     color: var(--ac-text);
     background: var(--ac-bg);
     border: 1px solid var(--ac-border);
@@ -866,8 +866,30 @@ a.ac-link:link, a.ac-link:visited { color: var(--ac-text); }
 
 /* ----------------------------------------------------- responsive --- */
 @media (max-width: 575.98px) {
-    .ac-hero { flex-wrap: wrap; }
+    .ac-hero { flex-wrap: wrap; padding: .9rem 1rem; }
     .ac-hero__status { align-self: stretch; }
+    .ac-hero__badge { width: 2.6rem; height: 2.6rem; }
+    .ac-hero__badge .bi { width: 1.25rem; height: 1.25rem; }
+    .ac-hero__title { font-size: 1.3rem; }
     .ac-seg { width: 100%; }
     .ac-seg__item { flex: 1 1 0; justify-content: center; padding: .5rem .5rem; }
+    .ac-panel { padding: .9rem .9rem; }
+}
+
+/* ------------------------------------------------- touch ergonomics --- */
+/* Mobile friendliness is a gating requirement (docs/design/decisions.md).
+   On coarse pointers: comfortable tap targets; and hover transforms are
+   suppressed everywhere hover isn't real, so taps don't leave components
+   stuck mid-"lift" (sticky :hover). */
+@media (pointer: coarse) {
+    .ac-btn { padding: .55rem .9rem; }
+    .ac-chip { padding: .45rem .85rem; }
+    .ac-copy { padding: .35rem .6rem; }
+    .ac-pager .ac-btn { min-width: 5.5rem; }
+}
+@media (hover: none) {
+    a.ac-tile:hover,
+    .ac-link:hover,
+    .ac-toggle:hover { transform: none; }
+    .ac-row:hover { background: transparent; }
 }

--- a/apps/core/static/css/style.css
+++ b/apps/core/static/css/style.css
@@ -98,6 +98,11 @@ svg.bi:not([width]) { width: 1em; height: 1em; }
 footer a .bi { color: var(--ac-dim); }
 
 .icon-link-hover { --bs-icon-link-transform: translate3d(0, -.3rem, 0); }
+/* Hover affordances are hover-only: on touch, taps must not leave icons
+   stuck mid-lift (mobile friendliness — see docs/design/decisions.md). */
+@media (hover: none) {
+    .icon-link-hover { --bs-icon-link-transform: none; }
+}
 svg[role="img"] { color: var(--bs-primary); }
 svg[role="note"] { color: var(--bs-secondary); }
 a[target="_blank"] {

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -93,7 +93,7 @@
                     <img class="navbar-brand" id="logo" alt="{{ WEBSITE_TITLE }} - Free Online MUD" src="{% static "images/logo.png" %}">
                 </a>
 
-                <button class="border-ishar m-3 navbar-dark navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle Navigation">
+                <button class="border-ishar m-2 navbar-dark navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle Navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="collapse navbar-collapse p-2" id="navbarNavDropdown">
@@ -370,7 +370,7 @@
     {% endif %}
 {% endblock messages %}
 
-            <div class="my-1 p-3 shell-panel" id="content">
+            <div class="my-1 p-2 p-md-3 shell-panel" id="content">
 {% block content %}
 {% endblock content %}
             </div>
@@ -388,13 +388,13 @@
         <footer class="mx-3 text-center">
 {% if CURRENT_SEASON %}
             <div class="my-1 p-1 row shell-panel">
-                <div class="col">
+                <div class="col-12 col-sm py-1">
                     <a class="icon-link icon-link-hover" href="{% url 'current_season' %}#season">
                         {% bi "calendar" %}
                         Season {{ CURRENT_SEASON.season_id }}
                     </a>
                 </div>
-                <div class="col p-1">
+                <div class="col-12 col-sm py-1">
                     <span class="icon-link">
                         {% bi "hourglass-split" css="text-secondary" %}
                         Ends {{ CURRENT_SEASON.expiration_date | naturaltime }}
@@ -403,7 +403,7 @@
             </div>
 {% endif %}
             <div class="my-1 p-1 row shell-panel">
-                <div class="col">
+                <div class="col-12 col-sm py-1">
                     <a class="icon-link icon-link-hover" href="mailto:{{ ADMIN_EMAIL }}" target="_blank" title="E-mail Us! ({{ ADMIN_EMAIL }})">
                         {% bi "envelope-at" %}
                         E-mail us!
@@ -411,14 +411,14 @@
                     </a>
                 </div>
 
-                <div class="col">
+                <div class="col-12 col-sm py-1">
                     <a class="icon-link icon-link-hover" href="{% url 'support' %}#support" title="Support {{ WEBSITE_TITLE }}">
                         {% bi "heart" %}
                         Support {{ WEBSITE_TITLE }}
                     </a>
                 </div>
 
-                <div class="col">
+                <div class="col-12 col-sm py-1">
                     <a class="icon-link icon-link-hover" href="{% url 'discord' %}" target="_blank" title="Join us on Discord!">
                         {% bi "discord" %}
                         Join us on Discord!

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -56,8 +56,11 @@ keeping the amber brand.
 6. **No new frontend libraries; self-host everything.** We ship Bootstrap +
    Bootstrap Icons and a little vanilla JS. Don't add a framework, a CDN
    dependency, or a web font without a decision entry.
-7. **Mobile-first.** The playerbase deploys and plays from phones. Every admin
-   tool and page must be usable at a phone width.
+7. **Mobile-first — a gating requirement, not a vibe.** The playerbase deploys
+   and plays from phones. Every surface must pass the **mobile checklist** in
+   `decisions.md` (no horizontal overflow, ≥16px form fields, coarse-pointer
+   tap targets, no hover-only affordances or sticky lifts, stacked shell rows,
+   compact chrome, 390px screenshot proof) before it ships.
 8. **Icons via the SVG sprite.** Prefer
    `<svg class="bi"><use href="…bootstrap-icons.svg#name"></svg>` over the font
    classes — it inherits `currentColor` and scales cleanly.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,37 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-12 — Mobile friendliness is a gating requirement (with a checklist)
+
+**Decision.** Every shipped surface must pass this checklist at a true 390px
+viewport before it lands — it is a release gate, not an aspiration:
+
+1. **No horizontal overflow** — `document.scrollWidth == viewport width`.
+2. **Form fields ≥ 16px** (`1rem`) — sub-16px inputs make iOS Safari zoom-jump
+   on focus, the single most jarring mobile failure.
+3. **Comfortable tap targets on touch** — `@media (pointer: coarse)` bumps
+   `.ac-btn` / `.ac-chip` / `.ac-copy` padding; new interactive components must
+   join that block.
+4. **No hover-only affordances, no sticky lifts** — anything conveyed on hover
+   must also be visible statically, and hover `transform`s are suppressed under
+   `@media (hover: none)` so a tap doesn't leave a component stuck mid-"lift"
+   (`.icon-link-hover` included).
+5. **Shell rows stack, never squeeze** — multi-column rows (footer, season bar)
+   use `col-12 col-sm`-style stacking at phone width; columns must never
+   compress until words wrap letter-by-letter.
+6. **Compact chrome at `<576px`** — heroes, panels, and the logo shrink;
+   vertical space on a phone is content space.
+7. **Verification includes phone proof** — full-page screenshots at 390px plus
+   the scrollWidth assertion (the headless-Chromium/Playwright harness), and
+   when the owner reports feel-jank on a real device, that report wins over a
+   passing screenshot.
+
+**Why.** The playerbase and the developer drive the game from phones; this has
+always been principle #7, but round 2 of the facelift still shipped
+desktop-first regressions (iOS focus zoom, squeezed footer columns, sticky
+hover transforms). A vibe is not a gate; a checklist is. This entry supersedes
+"mobile-first" as prose — cite the numbered items in review.
+
 ## 2026-07-12 — The global shell moves to the console surfaces
 
 **Decision.** The frame every page sits in — body, navbar, breadcrumb,


### PR DESCRIPTION
Follow-up to #68, which shipped with desktop-first regressions that made the new shell feel jarring on a phone. This fixes the concrete offenders and pins mobile friendliness in the design docs as a **gating requirement with a testable checklist**, not a vibe.

## Fixes

- **iOS focus zoom-jump**: `.ac-field` was `.9rem` (14.4px) — any input under 16px makes mobile Safari zoom the page when tapped. Now `1rem`, with the rule documented inline.
- **Tap targets**: `@media (pointer: coarse)` enlarges `.ac-btn` / `.ac-chip` / `.ac-copy` padding (buttons now ~39px tall on touch, up from ~30px).
- **Sticky hover "lifts"**: on touch screens a tap latches `:hover`, leaving tiles/links/toggles stuck mid-transform and icon-links mid-float. All hover transforms are suppressed under `@media (hover: none)`.
- **Squeezed footer/season rows**: three `.col`s at 390px compressed until words wrapped letter-by-letter. Shell rows now stack (`col-12 col-sm`).
- **Chrome density on phones**: heroes/panels/badges compact at `<576px`; `#content` padding responsive (`p-2 p-md-3`); navbar toggler margin tightened.

## Docs

- `decisions.md`: new entry **"Mobile friendliness is a gating requirement"** with a 7-point checklist (scrollWidth assertion, ≥16px fields, coarse-pointer targets, no hover-only affordances, stacked shell rows, compact chrome, 390px screenshot proof — and a real-device jank report from the owner beats a passing screenshot).
- `README.md` principle #7 now cites the checklist instead of prose.

## Verification

Rendered portal, styleguide, home, and both feedback pages under real mobile emulation (Playwright `isMobile` + `hasTouch`, 390px): `scrollWidth == viewport` on every page, zero sub-16px form fields, coarse-pointer media confirmed active. Feel on a physical device is the final gate — that's yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT

---
_Generated by [Claude Code](https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT)_