### PR TITLE
Fix giant mobile logo: content-hashed statics (cache busting) + logo fallback

### DIFF
--- a/apps/core/storage.py
+++ b/apps/core/storage.py
@@ -1,0 +1,26 @@
+"""
+Static-files storage with content-hashed filenames (cache busting).
+
+Browsers cache stylesheets hard, so a shipped CSS change may otherwise render
+new templates with a stale sheet (e.g. the round-2 shell with the old logo
+sizing). ManifestStaticFilesStorage makes every {% static %} URL change when
+the file's content changes, so caches can never go stale.
+
+Non-strict: an asset missing from the manifest falls back to its plain name
+instead of raising — consistent with docker-entrypoint.sh, where a failed
+collectstatic degrades to stale assets rather than a dead site.
+"""
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class IsharManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    manifest_strict = False
+
+    def hashed_name(self, name, content=None, filename=None):
+        # Third-party assets (e.g. jazzmin's vendored bootstrap) reference
+        # sourcemaps that were never shipped; leave such dangling references
+        # unhashed instead of failing the whole collectstatic run.
+        try:
+            return super().hashed_name(name, content, filename)
+        except ValueError:
+            return name

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -90,7 +90,8 @@
 
                 <a href="{% url 'index' %}" title="{{ WEBSITE_TITLE }}">
                     <h1 class="visually-hidden">{% block page_heading %}{{ WEBSITE_TITLE }} - Free Online MUD (Multi-User Dungeon){% endblock page_heading %}</h1>
-                    <img class="navbar-brand" id="logo" alt="{{ WEBSITE_TITLE }} - Free Online MUD" src="{% static "images/logo.png" %}">
+                    {# height attribute = stale-CSS fallback; the #logo CSS rule overrides it responsively #}
+                    <img class="navbar-brand" id="logo" height="128" alt="{{ WEBSITE_TITLE }} - Free Online MUD" src="{% static "images/logo.png" %}">
                 </a>
 
                 <button class="border-ishar m-2 navbar-dark navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle Navigation">

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,24 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-12 — Static assets are content-hashed (cache busting)
+
+**Decision.** `{% static %}` URLs carry a content hash
+(`style.2aed1762….css`) via `ManifestStaticFilesStorage` — subclassed in
+`apps/core/storage.py` as non-strict, with dangling third-party references
+(jazzmin's unshipped sourcemaps) left unhashed instead of failing
+collectstatic. Consequences for design work: **never rely on a same-name CSS
+edit reaching users** (that's now guaranteed by the hash), templates must
+reference assets through `{% static %}` (or `{% bi %}`), and load-bearing
+presentation must not live only in a stylesheet a stale cache could hold —
+the shell's logo keeps a `height` attribute fallback for exactly that reason.
+
+**Why.** Round 2 shipped new templates whose logo sizing lived only in
+`style.css`; phones holding the cached old sheet rendered a full-size logo
+(and blue oversized breadcrumbs) — new markup styled by old CSS. With hashed
+filenames a stylesheet change changes its URL, so templates and styles always
+arrive as a matched set.
+
 ## 2026-07-12 — Mobile friendliness is a gating requirement (with a checklist)
 
 **Decision.** Every shipped surface must pass this checklist at a true 390px

--- a/settings.example.py
+++ b/settings.example.py
@@ -213,6 +213,20 @@ USE_TZ = True
 STATIC_URL = "static/"
 STATIC_ROOT = Path(BASE_DIR, STATIC_URL)
 
+# Content-hashed static filenames (cache busting): {% static %} URLs change
+# whenever a file's content changes, so browsers can never serve a stale
+# stylesheet against new templates. Non-strict variant degrades to plain
+# names if the manifest is missing (see apps/core/storage.py).
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "apps.core.storage.IsharManifestStaticFilesStorage",
+    },
+}
+
+
 # Media.
 MEDIA_URL = "media/"
 MEDIA_ROOT = Path(BASE_DIR, MEDIA_URL)

--- a/settings.py
+++ b/settings.py
@@ -228,6 +228,20 @@ USE_TZ = True
 STATIC_URL = "static/"
 STATIC_ROOT = Path(BASE_DIR, STATIC_URL)
 
+# Content-hashed static filenames (cache busting): {% static %} URLs change
+# whenever a file's content changes, so browsers can never serve a stale
+# stylesheet against new templates. Non-strict variant degrades to plain
+# names if the manifest is missing (see apps/core/storage.py).
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "apps.core.storage.IsharManifestStaticFilesStorage",
+    },
+}
+
+
 # Media.
 MEDIA_URL = "media/"
 MEDIA_ROOT = Path(BASE_DIR, MEDIA_URL)


### PR DESCRIPTION
Root-causes the giant header logo from the phone screenshot (and the blue oversized breadcrumbs visible in the same shot): **new templates rendering under a stale cached `style.css`**. Round 2 moved logo sizing from an inline `style` attribute into the stylesheet; templates deploy instantly but browsers kept the old cached sheet, so there was no `#logo` rule to size it.

## Changes

- **Cache busting, systemically**: static files switch to `ManifestStaticFilesStorage` (subclassed as `apps.core.storage.IsharManifestStaticFilesStorage`), so every `{% static %}` URL embeds a content hash (`style.2aed1762….css`). A CSS change now changes its URL — stale caches are impossible, and future facelift rounds can't repeat this failure mode. Non-strict + tolerant of dangling third-party references (jazzmin's vendored bootstrap points at sourcemaps it never shipped; those stay unhashed instead of failing collectstatic).
- **Belt-and-braces logo fallback**: the `<img id="logo">` gets `height="128"`, so even a client that somehow holds a stale sheet renders a sane header; the `#logo` CSS rule overrides it responsively (8rem desktop / 5.5rem phones).
- **`decisions.md`**: records the cache-busting decision and its rule of thumb — load-bearing presentation must not live only where a stale cache can hold it.

## Verification

- `manage.py collectstatic` run with the real settings module: all 2,352 files post-process cleanly.
- Manifest resolution confirmed: `css/style.css` → `css/style.2aed17620f1c.css`, ditto `admin-console.css`, the bootstrap-icons sprite (fragment URLs still work — the hash is in the path, the `#icon` fragment is appended after), and `images/logo.png`.
- `manage.py check`: no issues.
- Takes effect on the next deploy (`collectstatic` runs on container start). After deploying, a normal refresh on the phone should pull the hashed sheet immediately — no hard-refresh evangelism required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT

---
_Generated by [Claude Code](https://claude.ai/code/session_011peouJzACoFFYRCyt2YAYT)_