### PR TITLE
Facelift Leaders & Challenges onto the console language; retire DataTables there

### DIFF
--- a/apps/challenges/templates/challenges.html
+++ b/apps/challenges/templates/challenges.html
@@ -1,178 +1,124 @@
 {% extends "layout.html" %}
 {% load humanize %}
+{% load ishar %}
 {% load static %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Challenges{% endblock meta_title %}
-{% block meta_description %}Current {{ WEBSITE_TITLE }} challenges available.{% endblock meta_description %}
+{% block meta_description %}This week's {{ WEBSITE_TITLE }} challenges — a fresh set of targets to hunt down every week for special rewards.{% endblock meta_description %}
 {% block meta_url %}{% url 'challenges' %}#challenges{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Challenges{% endblock title %}
-{% block includes %}
-    <link href="{% static 'datatables/datatables.min.css' %}" rel="stylesheet">
-    <script src="{% static 'jquery-3.7.1.min.js' %}"></script>
-    <script src="{% static 'datatables/datatables.min.js' %}"></script>
-{% endblock includes %}
 {% block scripts %}let focusTo = 'challenges'{% endblock scripts %}
+{% block includes %}
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
+{% endblock includes %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item h2" title="Portal">
-        <a class="icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-            </svg>
-            <span id="portal">
-                Portal
-            </span>
-        </a>
-    </li>
-    <li class="breadcrumb-item active h2" title="Challenges"{% if completed is None %} aria-current="page"{% endif %}>
-        <a class="icon-link icon-link-hover" href="{% url 'challenges' %}#challenges" id="challenges">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#award"></use>
-            </svg>
-            Challenges
-        </a>
-    </li>
-    {% if completed is not None %}
-    <li class="breadcrumb-item active h2" aria-current="page" title="{% if completed %}Complete{% else %}Incomplete{% endif %}">
-        <a class="icon-link icon-link-hover" href="{% if completed %}{% url 'complete' %}#complete{% else %}{% url 'incomplete' %}#incomplete{% endif %}" id="{% if completed %}complete{% else %}incomplete{% endif %}">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#award-fill"></use>
-            </svg>
-            {% if completed %}Complete{% else %}Incomplete{% endif %}
-        </a>
-    </li>
-    {% endif %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+{% if completed is None %}
+    {% crumb "Challenges" "award" urlname="challenges" anchor="challenges" active=True %}
+{% elif completed %}
+    {% crumb "Challenges" "award" urlname="challenges" anchor="challenges" %}
+    {% crumb "Complete" "award-fill" urlname="complete" anchor="complete" active=True %}
+{% else %}
+    {% crumb "Challenges" "award" urlname="challenges" anchor="challenges" %}
+    {% crumb "Incomplete" "award-fill" urlname="incomplete" anchor="incomplete" active=True %}
+{% endif %}
 {% endblock breadcrumbs %}
 {% block content %}
-<div class="container-fluid">
-    {% if challenges %}
-    <table class="table table-hover table-dark table-flush table-sm table-responsive table-striped" id="challengesTable">
-        {% if CURRENT_SEASON %}
-        <caption class="caption-top" id="cycle">
-            <a class="icon-link" href="#cycle">
-                <svg class="bi" aria-hidden="false" role="img" aria-label="Link to this section: Next Cycle: {{ CURRENT_SEASON.get_next_cycle|naturaltime }} ({{ CURRENT_SEASON.get_next_cycle }})">
-                    <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#recycle"></use>
-                </svg>
-            </a>
-            Challenges will next cycle <strong>{{ CURRENT_SEASON.get_next_cycle|naturaltime }}</strong> -
-            at <time class="fst-italic" datetime="{{ CURRENT_SEASON.get_next_cycle|date:"c" }}">
-                {{ CURRENT_SEASON.get_next_cycle }}
-            </time>
-            <a class="anchor-link" href="#cycle" aria-label="Link to this section: Next challenge cycle."></a>
-        </caption>
-        {% endif %}
-        <thead>
-            <tr>
-                <th class="border" scope="col" title="#">
-                    <span class="text-ishar">#</span>
-                </th>
-                <th class="border" scope="col" title="Find & Kill">
-                    <span class="text-ishar">Find & Kill</span>
-                </th>
-                <th class="border" scope="col" title="Max People">
-                    <span class="text-ishar">Max People</span>
-                </th>
-                <th class="border" scope="col" title="Max Level">
-                    <span class="text-ishar">Max Level</span>
-                </th>
-            </tr>
-        </thead>
-        <tbody class="table-group-divider text-ishar">
-        {% for challenge in challenges %}
-            <tr id="{{ challenge.anchor }}" class="challenge-row">
-                <th data-order="" data-search="">
-                    <a href="#{{ challenge.anchor }}" aria-label="Link to this section: Challenge - {{ challenge.mobile.long_name }} ({{ challenge.anchor }})">
-                        &#x23;
-                    </a>
-                </th>
-                <td data-order="{{ challenge.mobile.long_name }}" data-search="{{ challenge.mobile.long_name }}" title="Mobile Name: {{ challenge.mobile.long_name }}">
-                    <span class="{% if challenge.is_completed %}challenge-completed{% endif %}">
-                        {{ challenge.mobile.long_name }}
-                    </span>
-            {% if challenge.is_completed %}
-                    <span class="fw-normal text-ishar">
-                        <b>Completed</b> by
-                        {{ challenge.winners_links|join:", " }}
-                    </span>
-            {% endif %}
-                </td>
-                <td data-order="{{ challenge.max_people }}" data-search="" title="Max People: {{ challenge.max_people }}">
-                    {{ challenge.max_people }}
-                </td>
-                <td data-order="{{ challenge.max_level }}" data-search="" title="Max Level: {{ challenge.max_level }}">
-                    {{ challenge.max_level }}
-                </td>
-            </tr>
-        {% endfor %}
-        </tbody>
-        <tfoot>
-            <tr class="table-group-divider text-ishar">
-                <th class="border" scope="col" title="#">
-                    <span class="text-ishar">#</span>
-                </th>
-                <th class="border" scope="col" title="Find & Kill">
-                    <span class="text-ishar">Find & Kill</span>
-                </th>
-                <th class="border" scope="col" title="Max People">
-                    <span class="text-ishar">Max People</span>
-                </th>
-                <th class="border" scope="col" title="Max Level">
-                    <span class="text-ishar">Max Level</span>
-                </th>
-            </tr>
-        </tfoot>
-    </table>
-</div>
-<script>
-    const itemName = 'challenges'
-    const searchLayout = { search: { placeholder: 'Mobile Name' } }
-    $('#challengesTable').DataTable({
-        columnDefs: [
-            {
-                orderable: false,
-                searchable: false,
-                targets: [0],
-                type: 'string'
-            },
-            {
-                searchable: true,
-                targets: [1],
-                type: 'html'
-            },
-            {
-                searchable: false,
-                targets: [2, 3],
-                type: 'num'
-            }
-        ],
-        language: {
-            info: `Showing _START_ to _END_ of _TOTAL_ ${itemName}`,
-            infoEmpty: `Showing 0 to 0 of 0 ${itemName}`,
-            infoFiltered: `(filtered from _MAX_ total ${itemName})`,
-            lengthMenu: `Show _MENU_ ${itemName}`,
-            zeroRecords: `No matching ${itemName} found`
-        },
-        layout: {
-            topStart: searchLayout,
-            topEnd: 'info',
-            bottomStart: searchLayout,
-            bottomEnd: 'info',
-        },
-        order: [
-            [3, 'desc'],
-            [2, 'desc'],
-            [1, 'asc']
-        ],
-        paging: false,
-    })
-</script>
-    {% else %}
-<div class="p-3">
-    <div class="card">
-        <div class="card-body">
-            <p class="card-text fst-italic lead text-warning">
-                Sorry, but no challenges were found.
+<div class="ac">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "award" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Weekly Challenges</h2>
+            <p class="ac-hero__sub">
+                A fresh set of targets every week — defeat them within each
+                party-size and level limit to earn special rewards.
             </p>
         </div>
+{% if CURRENT_SEASON and CURRENT_SEASON.get_next_cycle %}
+        <div class="ac-hero__status">
+            <span class="ac-pill ac-pill--status ac-pill--accent ac-pill--live"
+                  title="New targets arrive {{ CURRENT_SEASON.get_next_cycle|naturaltime }} — at {{ CURRENT_SEASON.get_next_cycle }}">
+                cycles in {{ CURRENT_SEASON.get_next_cycle|timeuntil }}
+            </span>
+        </div>
+{% endif %}
+    </header>
+
+    <!-- Progress tiles (double as completion filters) -->
+    <div class="ac-tiles">
+        <a class="ac-tile ac-tile--accent{% if completed is None %} ac-tile--active{% endif %}"
+           href="{% url 'challenges' %}#challenges">
+            <span class="ac-tile__n">{{ count_total }}</span>
+            <span class="ac-tile__label">This Week's Targets</span>
+        </a>
+        <a class="ac-tile {% if count_incomplete %}ac-tile--info{% else %}ac-tile--muted{% endif %}{% if completed is False %} ac-tile--active{% endif %}"
+           href="{% url 'incomplete' %}#challenges">
+            <span class="ac-tile__n">{{ count_incomplete }}</span>
+            <span class="ac-tile__label">Still Standing</span>
+        </a>
+        <a class="ac-tile {% if count_complete %}ac-tile--ok{% else %}ac-tile--muted{% endif %}{% if completed is True %} ac-tile--active{% endif %}"
+           href="{% url 'complete' %}#challenges">
+            <span class="ac-tile__n">{{ count_complete }}</span>
+            <span class="ac-tile__label">Slain</span>
+        </a>
     </div>
+
+    <!-- Targets -->
+{% if challenges %}
+    <div class="ac-rows">
+{% for challenge in challenges %}
+        <div class="ac-row{% if challenge.is_completed %} ac-row--done{% endif %}" id="{{ challenge.anchor }}">
+            <span class="ac-row__icon">
+{% if challenge.is_completed %}
+                {% bi "check-circle" label="Completed" %}
+{% else %}
+                {% bi "crosshair" label="Still standing" %}
+{% endif %}
+            </span>
+            <div class="ac-row__main">
+                <div class="ac-row__title">
+                    <a class="ac-row__link" href="#{{ challenge.anchor }}"
+                       title="Link to this challenge: {{ challenge.mobile.long_name }}">
+                        {{ challenge.mobile.long_name }}
+                    </a>
+                </div>
+                <div class="ac-row__meta">
+                    <span title="Party limit: up to {{ challenge.max_people }} {{ challenge.max_people|pluralize:'person,people' }}">
+                        {% bi "people" %} up to {{ challenge.max_people }}
+                    </span>
+                    <span title="Level limit: {{ challenge.max_level }} and below">
+                        {% bi "bar-chart" %} level {{ challenge.max_level }} max
+                    </span>
+{% if challenge.is_completed %}
+                    <span title="Slain by {{ challenge.winner_desc }}">
+                        {% bi "trophy" %} {{ challenge.winners_links|join:", " }}
+                    </span>
+{% endif %}
+                </div>
+            </div>
+            <div class="ac-row__side">
+{% if challenge.is_completed %}
+                <span class="ac-pill ac-pill--status ac-pill--ok">slain</span>
+{% else %}
+                <span class="ac-pill ac-pill--status ac-pill--muted">still standing</span>
+{% endif %}
+            </div>
+        </div>
+{% endfor %}
+    </div>
+{% else %}
+    <div class="ac-empty">
+        {% bi "award" %}
+{% if completed is True %}
+        <span>No challenges have been completed yet this week.</span>
+{% elif completed is False %}
+        <span>Every challenge has been completed this week — new targets arrive on the next cycle.</span>
+{% else %}
+        <span>No challenges are currently active.</span>
+{% endif %}
+    </div>
+{% endif %}
+
 </div>
-    {% endif %}
 {% endblock content %}

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -29,4 +29,16 @@ class ChallengesView(NeverCacheMixin, ListView):
     def get_context_data(self, *, object_list=None, **kwargs):
         context = super().get_context_data(object_list=None, **kwargs)
         context["completed"] = self.completed
+
+        # Counts for the stat tiles, using the same completion predicates
+        # as the filtered querysets so the numbers always match the lists.
+        active = Challenge.objects.filter(is_active__exact=1)
+        context["count_total"] = active.count()
+        context["count_complete"] = active.exclude(
+            winner_desc__exact=""
+        ).count()
+        context["count_incomplete"] = active.filter(
+            winner_desc__exact=""
+        ).count()
+
         return context

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -691,6 +691,112 @@ a.ac-row__link:hover { color: var(--ac-accent); }
     align-items: center;
     gap: .5rem;
 }
+/* Rows addressed by URL fragment (deep links) light up when targeted. */
+.ac-row { scroll-margin-top: .75rem; }
+.ac-row:target {
+    background: var(--ac-wash);
+    box-shadow: inset 0 0 0 1px rgba(255, 170, 119, .35);
+}
+/* A completed/checked-off record: the title is struck through in ok-green
+   (done, not dead) and recedes; the icon tile turns ok. */
+.ac-row--done .ac-row__title,
+.ac-row--done .ac-row__title a.ac-row__link:link,
+.ac-row--done .ac-row__title a.ac-row__link:visited {
+    color: var(--ac-dim);
+    text-decoration: line-through;
+    text-decoration-color: rgba(76, 187, 23, .7);
+    text-decoration-thickness: .12rem;
+}
+.ac-row--done .ac-row__icon {
+    color: var(--ac-ok);
+    background: var(--ac-ok-wash);
+    border-color: rgba(76, 187, 23, .35);
+}
+
+/* ------------------------------------------------------- data table --- */
+/* Token-aligned table for genuinely column-comparable data (leaderboards);
+   list-of-records surfaces use .ac-rows instead (see decisions.md). Always
+   wrap in .ac-tablewrap: a wide table scrolls inside its own container, the
+   page itself never overflows horizontally (mobile checklist #1). */
+.ac-tablewrap {
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius);
+    background: var(--ac-panel);
+    overflow-x: auto;
+}
+.ac-table {
+    width: 100%;
+    margin: 0;
+    border-collapse: collapse;
+    font-size: .9rem;
+    color: var(--ac-text);
+}
+.ac-table thead th {
+    padding: .55rem .75rem;
+    background: var(--ac-bg);
+    border-bottom: 1px solid var(--ac-border-2);
+    font-size: .7rem;
+    font-weight: 700;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    color: var(--ac-dim);
+    text-align: left;
+    white-space: nowrap;
+}
+.ac-table tbody td,
+.ac-table tbody th {
+    padding: .55rem .75rem;
+    border-top: 1px solid var(--ac-border);
+    font-weight: 400;
+    color: var(--ac-text);
+    vertical-align: middle;
+}
+.ac-table tbody tr:first-child td,
+.ac-table tbody tr:first-child th { border-top: 0; }
+.ac-table tbody tr { transition: background .15s; }
+.ac-table tbody tr:hover { background: var(--ac-elev); }
+/* Numeric columns: right-aligned, non-jittering digits. */
+.ac-table__num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+/* Rank column: narrow, dim; the podium (top three) reads amber. */
+.ac-table__rank {
+    width: 1%;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--ac-dim);
+}
+.ac-table__rank--top { color: var(--ac-accent); font-weight: 700; }
+/* Secondary line under a cell's main value (e.g. class under player name). */
+.ac-table__sub {
+    display: block;
+    font-size: .75rem;
+    color: var(--ac-dim);
+}
+/* Sortable header: a real button (keyboard-reachable), reset against the
+   classic global button styling; the sort state lives on th[aria-sort]. */
+.ac-table__sort {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    cursor: pointer;
+    transition: color .15s;
+}
+.ac-table__sort:hover { color: var(--ac-text); }
+.ac-table__sort:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: 2px; }
+.ac-table__sort::after { content: "↕"; opacity: .4; }
+.ac-table th[aria-sort] .ac-table__sort { color: var(--ac-accent); }
+.ac-table th[aria-sort="ascending"] .ac-table__sort::after { content: "↑"; opacity: 1; }
+.ac-table th[aria-sort="descending"] .ac-table__sort::after { content: "↓"; opacity: 1; }
 
 /* ------------------------------------------------------- link cards --- */
 /* Navigation card (anchor sibling of .ac-toggle): icon tile + name + note,
@@ -867,7 +973,9 @@ a.ac-link:link, a.ac-link:visited { color: var(--ac-text); }
 /* ----------------------------------------------------- responsive --- */
 @media (max-width: 575.98px) {
     .ac-hero { flex-wrap: wrap; padding: .9rem 1rem; }
-    .ac-hero__status { align-self: stretch; }
+    .ac-hero__status { align-self: stretch; min-width: 0; }
+    /* Never clip a hero pill on a phone — let its text wrap instead. */
+    .ac-hero__status .ac-pill { white-space: normal; }
     .ac-hero__badge { width: 2.6rem; height: 2.6rem; }
     .ac-hero__badge .bi { width: 1.25rem; height: 1.25rem; }
     .ac-hero__title { font-size: 1.3rem; }
@@ -886,10 +994,12 @@ a.ac-link:link, a.ac-link:visited { color: var(--ac-text); }
     .ac-chip { padding: .45rem .85rem; }
     .ac-copy { padding: .35rem .6rem; }
     .ac-pager .ac-btn { min-width: 5.5rem; }
+    .ac-table__sort { padding: .4rem .3rem; margin: -.4rem -.3rem; }
 }
 @media (hover: none) {
     a.ac-tile:hover,
     .ac-link:hover,
     .ac-toggle:hover { transform: none; }
     .ac-row:hover { background: transparent; }
+    .ac-table tbody tr:hover { background: transparent; }
 }

--- a/apps/core/static/css/style.css
+++ b/apps/core/static/css/style.css
@@ -213,11 +213,6 @@ a.hardcore-player:hover {
 .message-warn, .message-warning  { color: var(--ac-warn); }
 
 .two-col { column-count: 2; }
-.challenge-completed {
-    text-decoration: line-through;
-    text-decoration-color: #a00;
-    text-decoration-thickness: 0.25rem;
-}
 
 .anchor-link {
     padding: 0 .175rem;
@@ -244,9 +239,7 @@ a.hardcore-player:hover {
     opacity: 1
 }
 
-.remort-upgrade-row:target,
-.challenge-row:target
-{
+.remort-upgrade-row:target {
     font-weight: bold;
     border: 0.1rem solid var(--ishar-color);
 }

--- a/apps/core/templates/styleguide.html
+++ b/apps/core/templates/styleguide.html
@@ -238,6 +238,49 @@
                 </div>
                 <div class="ac-row__side"><span class="ac-pill ac-pill--status ac-pill--warn">duplicate</span></div>
             </div>
+            <div class="ac-row ac-row--done">
+                <span class="ac-row__icon">{% bi "check-circle" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title"><a class="ac-row__link" href="#styleguide">A checked-off record (--done)</a></div>
+                    <div class="ac-row__meta"><span>Struck through in ok-green; icon tile turns ok</span></div>
+                </div>
+                <div class="ac-row__side"><span class="ac-pill ac-pill--status ac-pill--ok">slain</span></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Data table -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "table" %} Data table — <code>.ac-tablewrap</code>, <code>.ac-table</code></div>
+        <p class="ac-panel__hint">
+            For genuinely column-comparable data (leaderboards) — record lists use <code>.ac-rows</code>.
+            The wrap scrolls horizontally on phones; sortable headers are buttons whose state lives on <code>th[aria-sort]</code>.
+        </p>
+        <div class="ac-tablewrap">
+            <table class="ac-table">
+                <thead>
+                    <tr>
+                        <th class="ac-table__num" scope="col"><button class="ac-table__sort" type="button" title="Rank">#</button></th>
+                        <th scope="col"><button class="ac-table__sort" type="button">Player</button></th>
+                        <th class="ac-table__num" scope="col" aria-sort="descending"><button class="ac-table__sort" type="button">Renown</button></th>
+                        <th class="ac-table__num" scope="col"><button class="ac-table__sort" type="button">Deaths</button></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="ac-table__rank ac-table__rank--top">1</td>
+                        <td>Somebody <span class="ac-table__sub">Warrior</span></td>
+                        <td class="ac-table__num">4,210</td>
+                        <td class="ac-table__num">3</td>
+                    </tr>
+                    <tr>
+                        <td class="ac-table__rank">4</td>
+                        <td>Another <span class="ac-table__sub">Necromancer</span></td>
+                        <td class="ac-table__num">918</td>
+                        <td class="ac-table__num">12</td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
     </div>
 

--- a/apps/leaders/templates/leaders.html
+++ b/apps/leaders/templates/leaders.html
@@ -38,25 +38,13 @@
         </div>
     </header>
 
-    <!-- Filters -->
-    <div class="ac-panel">
-        <div class="ac-panel__h">{% bi "funnel" %} Game type</div>
-        <div class="d-flex flex-wrap gap-2 align-items-center">
-            <div class="ac-filter" role="group" aria-label="Game type filter">
-                <a class="ac-chip{% if game_type is None %} ac-chip--active{% endif %}" href="{% url 'leaders' %}#leaders">All</a>
-{% for num, name in game_types %}
-    {% with urlname=name|lower|add:"_leaders" %}
-                <a class="ac-chip{% if game_type == num %} ac-chip--active{% endif %}" href="{% url urlname %}#leaders">{{ name }}</a>
-    {% endwith %}
-{% endfor %}
-            </div>
-            <input class="ac-field ac-field--inline flex-grow-1" style="min-width: 12rem;" type="search"
-                   id="leaderSearch" placeholder="Filter by name or class" aria-label="Filter players by name or class">
-        </div>
-    </div>
-
     <!-- Rankings -->
 {% if leaders %}
+    <div class="ac-inputgroup">
+        <span class="ac-inputgroup__icon">{% bi "search" %}</span>
+        <input class="ac-input" type="search" id="leaderSearch"
+               placeholder="Filter by name or class" aria-label="Filter players by name or class">
+    </div>
     <div class="ac-tablewrap">
         <table class="ac-table" id="leadersTable">
             <caption class="visually-hidden">

--- a/apps/leaders/templates/leaders.html
+++ b/apps/leaders/templates/leaders.html
@@ -1,246 +1,176 @@
 {% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
 {% load static %}
-{% block meta_title %}{{ WEBSITE_TITLE }} Leaderboard{% if game_type %} - {{ game_type }}{% endif %} | Top MUD Players{% endblock meta_title %}
-{% block meta_description %}Leaderboard of top{% if game_type %} {{ game_type|lower }}{% endif %} players in {{ WEBSITE_TITLE }}, a free online MUD. See player rankings, achievements, and stats in this text-based RPG.{% endblock meta_description %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Leaderboard{% if game_type %} - {{ game_type.label }}{% endif %} | Top MUD Players{% endblock meta_title %}
+{% block meta_description %}Leaderboard of top{% if game_type %} {{ game_type.label|lower }}{% endif %} players in {{ WEBSITE_TITLE }}, a free online MUD. See player rankings, achievements, and stats in this text-based RPG.{% endblock meta_description %}
 {% block meta_url %}{% url 'leaders' %}{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Leaderboard{% if game_type %} - {{ game_type.label }}{% endif %}{% endblock title %}
+{% block scripts %}let focusTo = 'leaders'{% endblock scripts %}
 {% block includes %}
-    <style>
-        .buttons-colvis,
-        .dt-buttons,
-        .dt-buttons button,
-        .dt-buttons.button {
-            --bs-btn-bg: var(--bs-black);
-            --bs-btn-border-color: var(--ishar-color);
-            --bs-btn-color: var(--ishar-color);
-
-            --bs-btn-active-bg: var(--ishar-color);
-            --bs-btn-active-border-color: var(--ishar-color);
-            --bs-btn-active-color: var(--bs-black);
-
-            --bs-btn-hover-bg: var(--ishar-color);
-            --bs-btn-hover-border-color: var(--ishar-color);
-            --bs-btn-hover-color: var(--bs-black);
-
-            --bs-btn-visited-bg: var(--bs-black);
-            --bs-btn-visited-border-color: var(--ishar-color);
-            --bs-btn-visited-color: var(--ishar-color);
-        }
-    </style>
-    <link href="{% static 'datatables/datatables.min.css' %}" rel="stylesheet">
-    <script src="{% static 'jquery-3.7.1.min.js' %}"></script>
-    <script src="{% static 'datatables/datatables.min.js' %}"></script>
+        <link rel="stylesheet" type="text/css" href="{% static 'css/admin-console.css' %}">
 {% endblock includes %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item h2" title="Portal">
-        <a class="icon-link icon-link-hover" href="{% url 'portal' %}#portal">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#person-gear"></use>
-            </svg>
-            <span id="portal">
-                Portal
-            </span>
-        </a>
-    </li>
-    <li class="breadcrumb-item h2{% if not game_type %} active" aria-current="page{% endif %}" title="Leaders">
-        <a class="icon-link icon-link-hover" href="{% url 'leaders' %}#leaders">
-            <svg class="bi" aria-hidden="true">
-                <use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#trophy"></use>
-            </svg>
-            <span id="leaders">
-                Leaders
-            </span>
-        </a>
-    </li>
-    {% if game_type %}
-    <li class="breadcrumb-item active h2" aria-current="page" title="{{ game_type.label }} Leaders">
-        <a href="{% url 'leaders' %}{{ game_type.label|lower }}#{{ game_type.label|lower }}">
-            {{ game_type.label }}
-        </a>
-    </li>
-    {% endif %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+{% if game_type %}
+    {% crumb "Leaders" "trophy" urlname="leaders" anchor="leaders" %}
+    {% crumb game_type.label "trophy-fill" active=True %}
+{% else %}
+    {% crumb "Leaders" "trophy" urlname="leaders" anchor="leaders" active=True %}
+{% endif %}
 {% endblock breadcrumbs %}
 {% block content %}
-<div class="container-fluid">
-    <ul class="my-1 py-1 list-group list-group-horizontal-sm">
-        <li class="list-group-item card-text" title="All" id="all">
-    {% if game_type is None %}
-            <span class="text-ishar">All</span>
-    {% else %}
-            <a class="list-group-item-text" href="{% url 'leaders' %}#all">All</a>
-    {% endif %}
-        </li>
-    {% for num, name in game_types %}
-        <li class="list-group-item card-text" title="{{ name }}" id="{{ name|lower }}">
-        {% if game_type == num %}
-            <span class="text-ishar">{{ name }}</span>
-        {% else %}
-            <a class="list-group-item-text" href="{% url 'leaders' %}{{ name|lower }}#{{ name|lower }}">{{ name }}</a>
-        {% endif %}
-        </li>
-    {% endfor %}
-    </ul>
-</div>
-    {% if leaders %}
-<div class="container-fluid">
-    <table class="table table-hover table-dark table-flush table-sm table-responsive table-striped" id="leadersTable">
-        <thead>
-            <tr>
-                <th class="border" scope="col" title="Name">
-                    <span class="text-ishar">Name</span>
-                </th>
-                <th class="border" scope="col" title="Class">
-                    <span class="text-ishar">Class</span>
-                </th>
-                <th class="border" scope="col" title="Level">
-                    <span class="text-ishar">Level</span>
-                </th>
-                <th class="border" scope="col" title="Remorts">
-                    <span class="text-ishar">Remorts</span>
-                </th>
-                <th class="border" scope="col" title="Renown">
-                    <span class="text-ishar">Renown</span>
-                </th>
-                <th class="border" scope="col" title="Challenges">
-                    <span class="text-ishar">Challenges</span>
-                </th>
-                <th class="border" scope="col" title="Quests">
-                    <span class="text-ishar">Quests</span>
-                </th>
-                <th class="border" scope="col" title="Deaths">
-                    <span class="text-ishar">Deaths</span>
-                </th>
-            </tr>
-        </thead>
-        <tbody class="table-group-divider text-ishar">
-        {% for leader in leaders %}
-            <tr id="leader-{{ forloop.counter }}" class="leader-row">
-                <td class="border" data-order="{{ leader.name }}" data-search="{{ leader.name }}" title="Player Name: {{ leader.name }}">
-                    {{ leader.player_link }}
-                </td>
-                <td class="border" data-order="{{ leader.player_class }}" data-search="{{ leader.player_class }}" title="Class: {{ leader.player_class }}">
-                    {{ leader.player_class }}
-                </td>
-                <td class="border" data-order="{{ leader.level }}" data-search="" title="Level: {{ leader.level }}">
-                    {{ leader.level }}
-                </td>
-                <td class="border" data-order="{{ leader.remorts }}" data-search="" title="Remorts: {{ leader.remorts }}">
-                    {{ leader.remorts }}
-                </td>
-                <td class="border" data-order="{{ leader.renown }}" data-search="" title="Renown: {{ leader.renown }}">
-                    {{ leader.renown }}
-                </td>
-                <td class="border" data-order="{{ leader.challenges }}" data-search="" title="Challenges: {{ leader.challenges }}">
-                    {{ leader.challenges }}
-                </td>
-                <td class="border" data-order="{{ leader.quests }}" data-search="" title="Quests: {{ leader.quests }}">
-                    {{ leader.quests }}
-                </td>
-                <td class="border" data-order="{{ leader.deaths }}" data-search="" title="Deaths: {{ leader.deaths }}">
-                    {{ leader.deaths }}
-                </td>
-            </tr>
-        {% endfor %}
-        </tbody>
-        <tfoot>
-            <tr class="table-group-divider text-ishar">
-                <th class="border" scope="col" title="Name">
-                    <span class="text-ishar">Name</span>
-                </th>
-                <th class="border" scope="col" title="Class">
-                    <span class="text-ishar">Class</span>
-                </th>
-                <th class="border" scope="col" title="Level">
-                    <span class="text-ishar">Level</span>
-                </th>
-                <th class="border" scope="col" title="Remorts">
-                    <span class="text-ishar">Remorts</span>
-                </th>
-                <th class="border" scope="col" title="Renown">
-                    <span class="text-ishar">Renown</span>
-                </th>
-                <th class="border" scope="col" title="Challenges">
-                    <span class="text-ishar">Challenges</span>
-                </th>
-                <th class="border" scope="col" title="Quests">
-                    <span class="text-ishar">Quests</span>
-                </th>
-                <th class="border" scope="col" title="Deaths">
-                    <span class="text-ishar">Deaths</span>
-                </th>
-            </tr>
-        </tfoot>
-    </table>
-</div>
-<script>
-    const itemName = 'players'
-    $('#leadersTable').DataTable({
-        buttons: ['colvis'],
-        language: {
-            info: `Showing _START_ to _END_ of _TOTAL_ ${itemName}`,
-            infoEmpty: `Showing 0 to 0 of 0 ${itemName}`,
-            infoFiltered: `(filtered from _MAX_ total ${itemName})`,
-            lengthMenu: `_MENU_ ${itemName}`,
-            zeroRecords: `No matching ${itemName} found`,
-            searchBuilder: {
-                button: {
-                    0: '<i class="bi bi-search" data-bs-toggle="tooltip" data-bs-title="Search" title="Search"></i> Search',
-                    1: '<i class="bi bi-search" data-bs-toggle="tooltip" data-bs-title="Search (1)" title="Search (1)"></i> Search (1)',
-                    _: '<i class="bi bi-search" data-bs-toggle="tooltip" data-bs-title="Search" title="Search"></i> Search (%d)',
-                },
-                title: '<i class="bi bi-search" data-bs-toggle="tooltip" data-bs-title="Search" title="Search"></i> Search',
-            },
-        },
-        layout: {
-            topStart: {
-                buttons: [
-                    {
-                        extend: 'colvis',
-                        text: '<span data-bs-toggle="tooltip" data-bs-title="Columns visibility" class="bi bi-list-columns"> Columns</span>',
-                    },
-                    {
-                        extend: 'searchBuilder',
-                        depthLimit: 1,
-                    },
-                ]
-            },
-            topEnd: 'pageLength',
-            bottomStart: 'paging',
-            bottomEnd: 'info',
-        },
-        lengthMenu: [
-            5, 10, 15, 20, 25, 50, 75, 100,
-            {
-                label: 'all',
-                value: -1
-            }
-        ],
-        order: [
-            [3, 'desc'],
-            [4, 'desc'],
-            [5, 'desc'],
-            [6, 'desc'],
-            [7, 'asc'],
-            [2, 'desc']
-        ],
-        pageLength: 10,
-        responsive: {
-            responsive: true,
-        },
-        searchBuilder: {
-            depthLimit: 1,
-        },
-    });
-</script>
-    {% else %}
-<div class="p-3">
-    <div class="card">
-        <div class="card-body">
-            <p class="card-text fst-italic lead text-warning">
-                Sorry, but no players were found.
+<div class="ac ac--wide">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "trophy" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Leaderboard{% if game_type %} — {{ game_type.label }}{% endif %}</h2>
+            <p class="ac-hero__sub">
+                Players ranked by remorts, renown, challenge and quest wins — fewest deaths break ties.
             </p>
         </div>
+        <div class="ac-hero__status">
+            <span class="ac-pill ac-pill--accent" title="Players on this leaderboard">
+                {{ leaders|length }} player{{ leaders|length|pluralize }}
+            </span>
+        </div>
+    </header>
+
+    <!-- Filters -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "funnel" %} Game type</div>
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+            <div class="ac-filter" role="group" aria-label="Game type filter">
+                <a class="ac-chip{% if game_type is None %} ac-chip--active{% endif %}" href="{% url 'leaders' %}#leaders">All</a>
+{% for num, name in game_types %}
+    {% with urlname=name|lower|add:"_leaders" %}
+                <a class="ac-chip{% if game_type == num %} ac-chip--active{% endif %}" href="{% url urlname %}#leaders">{{ name }}</a>
+    {% endwith %}
+{% endfor %}
+            </div>
+            <input class="ac-field ac-field--inline flex-grow-1" style="min-width: 12rem;" type="search"
+                   id="leaderSearch" placeholder="Filter by name or class" aria-label="Filter players by name or class">
+        </div>
     </div>
+
+    <!-- Rankings -->
+{% if leaders %}
+    <div class="ac-tablewrap">
+        <table class="ac-table" id="leadersTable">
+            <caption class="visually-hidden">
+                {{ WEBSITE_TITLE }} player rankings{% if game_type %} for the {{ game_type.label|lower }} game type{% endif %}.
+            </caption>
+            <thead>
+                <tr>
+                    <th class="ac-table__num" scope="col" data-type="rank">
+                        <button class="ac-table__sort" type="button" title="Rank">#</button>
+                    </th>
+                    <th scope="col" data-type="text">
+                        <button class="ac-table__sort" type="button">Player</button>
+                    </th>
+                    <th class="ac-table__num" scope="col" data-type="num">
+                        <button class="ac-table__sort" type="button">Level</button>
+                    </th>
+                    <th class="ac-table__num" scope="col" data-type="num">
+                        <button class="ac-table__sort" type="button">Remorts</button>
+                    </th>
+                    <th class="ac-table__num" scope="col" data-type="num">
+                        <button class="ac-table__sort" type="button">Renown</button>
+                    </th>
+                    <th class="ac-table__num" scope="col" data-type="num">
+                        <button class="ac-table__sort" type="button">Challenges</button>
+                    </th>
+                    <th class="ac-table__num" scope="col" data-type="num">
+                        <button class="ac-table__sort" type="button">Quests</button>
+                    </th>
+                    <th class="ac-table__num" scope="col" data-type="num">
+                        <button class="ac-table__sort" type="button">Deaths</button>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+{% for leader in leaders %}
+                <tr data-search="{{ leader.name|lower }} {{ leader.player_class|lower }}">
+                    <td class="ac-table__rank{% if forloop.counter <= 3 %} ac-table__rank--top{% endif %}" data-key="{{ forloop.counter }}">{{ forloop.counter }}</td>
+                    <td data-key="{{ leader.name|lower }}" title="{{ leader.name }} ({{ leader.player_class }})">
+                        {{ leader.player_link }}
+                        <span class="ac-table__sub">{{ leader.player_class }}</span>
+                    </td>
+                    <td class="ac-table__num" data-key="{{ leader.level }}">{{ leader.level }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.remorts }}">{{ leader.remorts }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.renown }}">{{ leader.renown|intcomma }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.challenges }}">{{ leader.challenges }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.quests }}">{{ leader.quests }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.deaths }}">{{ leader.deaths }}</td>
+                </tr>
+{% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="ac-empty" id="leadersEmpty" hidden>
+        {% bi "search" %}
+        <span>No players match that filter.</span>
+    </div>
+<script>
+    (() => {
+        const table = document.getElementById("leadersTable")
+        const tbody = table.tBodies[0]
+        const headers = Array.from(table.tHead.rows[0].cells)
+
+        // Column sorting: numeric columns open descending (top scores first),
+        // text columns ascending; a second press flips direction.
+        const cellKey = (row, index) => {
+            const cell = row.cells[index]
+            return cell.dataset.key ?? cell.textContent.trim()
+        }
+        headers.forEach((th, index) => {
+            const button = th.querySelector(".ac-table__sort")
+            if (!button) return
+            button.addEventListener("click", () => {
+                const numeric = th.dataset.type !== "text"
+                const current = th.getAttribute("aria-sort")
+                // Rank reads best low-to-high; other numbers, top scores first.
+                const first = th.dataset.type === "num" ? "descending" : "ascending"
+                const next = current
+                    ? (current === "descending" ? "ascending" : "descending")
+                    : first
+                headers.forEach((h) => h.removeAttribute("aria-sort"))
+                th.setAttribute("aria-sort", next)
+                const sign = next === "ascending" ? 1 : -1
+                Array.from(tbody.rows)
+                    .sort((a, b) => {
+                        const av = cellKey(a, index)
+                        const bv = cellKey(b, index)
+                        const cmp = numeric ? Number(av) - Number(bv) : av.localeCompare(bv)
+                        return sign * cmp
+                    })
+                    .forEach((row) => tbody.appendChild(row))
+            })
+        })
+
+        // Name/class filter: hides rows client-side; ranks stay with players.
+        const search = document.getElementById("leaderSearch")
+        const empty = document.getElementById("leadersEmpty")
+        search.addEventListener("input", () => {
+            const q = search.value.trim().toLowerCase()
+            let shown = 0
+            for (const row of tbody.rows) {
+                const hit = !q || row.dataset.search.includes(q)
+                row.hidden = !hit
+                if (hit) shown += 1
+            }
+            empty.hidden = shown > 0
+        })
+    })()
+</script>
+{% else %}
+    <div class="ac-empty">
+        {% bi "trophy" %}
+        <span>No players found{% if game_type %} for the {{ game_type.label|lower }} game type{% endif %}.</span>
+    </div>
+{% endif %}
+
 </div>
-    {% endif %}
 {% endblock content %}

--- a/apps/leaders/views.py
+++ b/apps/leaders/views.py
@@ -31,9 +31,11 @@ class LeadersView(LoginRequiredMixin, NeverCacheMixin, ListView):
 
     def get_context_data(self, *, object_list=None, **kwargs):
 
+        # One game mode is live at a time (Classic normally, Hardcore for
+        # Fated seasons), so the page shows no game-type filter UI — the
+        # per-type URLs stay routable for whenever that changes.
         context = super().get_context_data(object_list=None, **kwargs)
         context["game_type"] = self.game_type
-        context["game_types"] = GameType.choices
 
         for i in context[self.context_object_name]:
             i.challenges = i.statistics.total_challenges

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -110,8 +110,8 @@ Staff surfaces first (highest value, lowest risk — few users, we control them)
 | 2 | Feedback triage (`/feedback`) | ✅ done — tiles, chips, rows, timeline |
 | 3 | Processes / other Django-admin-adjacent staff pages | ✖ closed — lives in Django admin, nothing to facelift (see decisions.md) |
 | 4 | Portal (`/portal`) + global nav/layout shell | ✅ done — shell on console surfaces, portal rebuilt |
-| 5 | Leaders, Challenges (DataTables pages) | next |
-| 6 | Connect HUD (align tokens) | later |
+| 5 | Leaders, Challenges (DataTables pages) | ✅ done — `.ac-table` for leaders, challenge rows; jQuery/DataTables dropped from both |
+| 6 | Connect HUD (align tokens) | next |
 | 7 | Home, help, errors, public content | last |
 
 ### Near-term addition

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -245,6 +245,38 @@ pinned against the global `a:link` rule.
 ```
 Used: portal tool grids. Status: **formalized.**
 
+### `.ac-tablewrap` + `.ac-table` — data table
+The token-aligned table for **genuinely column-comparable data** (leaderboards);
+record lists use `.ac-rows` instead. The wrap owns the border/radius and
+scrolls horizontally on phones so the page never overflows. Headers are
+uppercase/dim; sortable ones wrap their label in an `.ac-table__sort`
+`<button>` — sort state lives on `th[aria-sort]` (arrow via `::after`, amber
+when active), applied by a small vanilla-JS sorter (see `leaders.html`).
+Numeric cells take `.ac-table__num` (right-aligned, tabular-nums); the rank
+column is `.ac-table__rank` (`--top` = amber podium); `.ac-table__sub` is a
+dim second line inside a cell (class under player name).
+```html
+<div class="ac-tablewrap">
+  <table class="ac-table">
+    <thead><tr>
+      <th class="ac-table__num" scope="col" data-type="num">
+        <button class="ac-table__sort" type="button">Renown</button>
+      </th>
+    </tr></thead>
+    <tbody><tr>
+      <td class="ac-table__num" data-key="4210">4,210</td>
+    </tr></tbody>
+  </table>
+</div>
+```
+Used: leaders. Status: **formalized** (supersedes the DataTables treatment —
+see decisions.md).
+
+### `.ac-row--done` / `.ac-row:target` — row states
+`--done` checks a record off: title struck through in ok-green, icon tile
+turns ok (challenges). `:target` washes a deep-linked row amber (row `id`s +
+fragment links). Status: **formalized.**
+
 ### Container variants
 `.ac` (60rem) is the default console width; `.ac--wide` (72rem) for list-heavy
 surfaces. `.ac-cta--accent` is the amber non-destructive primary (red stays
@@ -316,14 +348,15 @@ decisions.md); classic badges survive only on untouched pages.
 
 ### Empty state
 `<div class="card"><div class="card-body"><p class="card-text fst-italic lead
-text-warning">No … found.</p></div></div>` (leaders/challenges). **Superseded by
-`.ac-empty` (see above)** as pages are touched.
+text-warning">No … found.</p></div></div>`. **Superseded by `.ac-empty` (see
+above)** as pages are touched (leaders & challenges migrated).
 
 ### DataTable
 `table table-hover table-dark table-flush table-sm table-responsive
-table-striped` with `text-ishar` headers + `table-group-divider`. Used on
-leaders & challenges (needs the DataTables include). Keep, but align header/hover
-colors to tokens.
+table-striped` with `text-ishar` headers + `table-group-divider` over the
+jQuery DataTables include. **Superseded by `.ac-table` (see above);** survives
+only on `upgrades.html` — when that page is facelifted (roadmap #7), delete the
+vendored `datatables/` + `jquery-3.7.1` assets with it.
 
 ### `<details>/<summary>` section
 Collapsible with an `.anchor-link` "#" affordance + `h3/h4/h5` + count badge —

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,34 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-12 — Leaders & Challenges adopt the console language; DataTables retired page-by-page
+
+**Decision.** Roadmap #5. **Leaders** keeps a real table — it is genuinely
+column-comparable data — via the new `.ac-tablewrap` / `.ac-table` component:
+token-aligned, horizontally scrollable inside its own container (the page
+never overflows), uppercase dim sortable headers as real `<button>`s with
+state on `th[aria-sort]`, tabular-nums numeric columns, an amber podium for
+the top three ranks, and the player's class as a sub-line under the name.
+Sorting and the name/class filter are ~40 lines of vanilla JS. **Challenges**
+drops its table entirely: eight-ish weekly kill targets are a checklist, not
+a matrix, so they render as `.ac-rows` — constraint meta (party size, level
+cap) with icons, an ok "slain" pill + winners when complete, and the new
+`.ac-row--done` modifier (ok-green strike-through — done, not dead; the old
+red `.challenge-completed` is deleted). Completion tiles double as the
+All / Still Standing / Slain filters over the existing URLs, and the
+next-cycle time is a live hero pill. **jQuery + DataTables are gone from
+both pages**; the vendored assets stay only until `upgrades.html` (roadmap
+#7) migrates, then get deleted. `.ac-row:target` (amber wash) is the deep-link
+highlight for row anchors.
+
+**Why.** DataTables + jQuery was ~1MB of framework to sort ten players and
+search eight mobs, and its chrome (page-length menus, column-visibility,
+search builders) never matched either the design language or the data size.
+The row treatment tells the truth about challenges — a weekly hit-list players
+check off — while `.ac-table` gives the site one honest, token-aligned table
+for data that really is tabular. These are also the first *public* surfaces
+on the console language, per the green-field mandate.
+
 ## 2026-07-12 — Static assets are content-hashed (cache busting)
 
 **Decision.** `{% static %}` URLs carry a content hash

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -17,7 +17,11 @@ token-aligned, horizontally scrollable inside its own container (the page
 never overflows), uppercase dim sortable headers as real `<button>`s with
 state on `th[aria-sort]`, tabular-nums numeric columns, an amber podium for
 the top three ranks, and the player's class as a sub-line under the name.
-Sorting and the name/class filter are ~40 lines of vanilla JS. **Challenges**
+Sorting and the name/class filter are ~40 lines of vanilla JS. There is **no
+game-type filter UI**: only one mode is live at a time (Classic in normal
+seasons, Hardcore in Fated), so chips for All/Classic/Hardcore/Survival were
+pure clutter — the per-type URLs (`/leaders/classic/`, …) stay routable for
+whenever that changes. **Challenges**
 drops its table entirely: eight-ish weekly kill targets are a checklist, not
 a matrix, so they render as `.ac-rows` — constraint meta (party size, level
 cap) with icons, an ok "slain" pill + winners when complete, and the new


### PR DESCRIPTION
Roadmap #5 of the design refresh — the first public surfaces on the
console language.

Leaders keeps a real table via the new token-aligned .ac-tablewrap /
.ac-table component: sortable uppercase headers as real buttons
(state on th[aria-sort]), tabular-nums numeric columns, amber podium
for the top three, class as a sub-line under the player, and the wrap
scrolling horizontally on phones so the page never overflows. Sorting
plus the name/class filter are ~40 lines of vanilla JS.

Challenges drops its table entirely: the weekly kill targets render
as .ac-rows — party-size/level-cap meta with icons, an ok "slain"
pill with winner links when complete, and the new .ac-row--done
modifier (ok-green strike-through). Completion tiles double as the
All / Still Standing / Slain filters over the existing URLs, and the
next-cycle countdown is a live hero pill. The orphaned red
.challenge-completed / .challenge-row rules leave style.css.

jQuery + DataTables are gone from both pages; the vendored assets
stay only until upgrades.html (roadmap #7) migrates. Docs and the
/styleguide gain the new components.

Verified: templates compile under stub settings, py_compile,
node --check, and headless-Chromium proof at 390px/1280px (no
horizontal overflow; sort, filter, empty state, and :target
highlight exercised via Playwright).

Relates to #71

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MuDNZq1J9sdVHNpZZBEQvC