### PR TITLE
Correct the portal's Challenges card note

### DIFF
--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -93,7 +93,7 @@
                 <span class="ac-link__icon">{% bi "award" %}</span>
                 <span class="ac-link__body">
                     <span class="ac-link__name">Challenges</span>
-                    <span class="ac-link__note d-block">Seasonal boss challenges</span>
+                    <span class="ac-link__note d-block">This week's kill targets &amp; rewards</span>
                 </span>
             </a>
             <a class="ac-link" href="{% url 'leaders' %}#leaders" title="Leaders">


### PR DESCRIPTION
Fast follow to #72: the portal's Challenges link card still described challenges as "Seasonal boss challenges." They're weekly rotating kill targets, so the note now reads "This week's kill targets & rewards," matching the rebuilt challenges page.

One-line copy change in `apps/accounts/templates/portal.html`; template compiles under the stub-settings check.

Relates to #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuDNZq1J9sdVHNpZZBEQvC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDNZq1J9sdVHNpZZBEQvC)_