### PR TITLE
Warn on ishar-web deploy when web-client players are connected

### DIFF
--- a/apps/accounts/templates/deploy.html
+++ b/apps/accounts/templates/deploy.html
@@ -113,6 +113,13 @@
                 <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#exclamation-triangle"></use></svg>
                 <span><strong>Heads up —</strong> deploying <code>ishar-web</code> restarts the container serving <em>this page</em>. The console will freeze mid-deploy; the host audit log is the source of truth.</span>
             </div>
+
+            <div class="ac-note ac-note--danger mt-3 d-none" id="webClientsWarning" role="alert">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#people-fill"></use></svg>
+                <span><strong>Players are in the game via the web client —</strong>
+                <span id="webClientsText">checking…</span>
+                Deploying <code>ishar-web</code> will cut their connection mid-session.</span>
+            </div>
         </div>
 
         <!-- Options + confirm -->
@@ -237,15 +244,59 @@
         }
     }
 
-    // ---- self-deploy caveat ---------------------------------------------
-    function refreshWarning() {
+    // ---- self-deploy caveat + live web-client count ----------------------
+    // "Nothing selected = all services" includes ishar-web, so an empty
+    // selection gets the same warnings as an explicit ishar-web check.
+    function deployIncludesWeb() {
         const web = document.getElementById("svc-ishar-web");
-        warning.classList.toggle("d-none", !(web && web.checked));
+        const anyChecked = form.querySelector(".service-check:checked") !== null;
+        return (web && web.checked) || !anyChecked;
+    }
+
+    // Live count of /connect sessions proxied through this container — an
+    // ishar-web deploy severs every one of them mid-game.
+    const webClientsWarning = document.getElementById("webClientsWarning");
+    const webClientsText = document.getElementById("webClientsText");
+    let webClientCount = 0;
+
+    function fmtAge(s) {
+        if (s < 60) { return s + "s"; }
+        if (s < 3600) { return Math.floor(s / 60) + "m"; }
+        return Math.floor(s / 3600) + "h " + (Math.floor(s / 60) % 60) + "m";
+    }
+
+    function refreshWarning() {
+        const includesWeb = deployIncludesWeb();
+        warning.classList.toggle("d-none", !includesWeb);
+        webClientsWarning.classList.toggle(
+            "d-none", !(includesWeb && webClientCount > 0)
+        );
     }
     document.querySelectorAll(".service-check").forEach(function (el) {
         el.addEventListener("change", refreshWarning);
     });
+
+    function pollWebClients() {
+        post("{% url 'deploy_web_clients' %}", {})
+            .then(function (r) {
+                if (r.status !== 200) { return; }
+                webClientCount = r.data.count || 0;
+                if (webClientCount > 0) {
+                    let text = webClientCount + " live session" +
+                        (webClientCount === 1 ? "" : "s");
+                    if (r.data.ages && r.data.ages.length) {
+                        text += " (longest connected " +
+                            fmtAge(r.data.ages[0]) + ")";
+                    }
+                    webClientsText.textContent = text + ".";
+                }
+                refreshWarning();
+            })
+            .catch(function () { /* keep last known count */ });
+    }
     refreshWarning();
+    pollWebClients();
+    setInterval(pollWebClients, 10000);
 
     // ---- live agent health (hero pill) ----------------------------------
     if (deployConfigured) {
@@ -361,7 +412,13 @@
             return;
         }
         const label = services.length ? services.join(", ") : "ALL services";
-        if (!confirm("Deploy " + label + " to " + env + "?")) {
+        let prompt = "Deploy " + label + " to " + env + "?";
+        if (deployIncludesWeb() && webClientCount > 0) {
+            prompt += "\n\nWARNING: " + webClientCount +
+                " player session" + (webClientCount === 1 ? "" : "s") +
+                " on the web client will be disconnected mid-game.";
+        }
+        if (!confirm(prompt)) {
             return;
         }
 

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -5,6 +5,7 @@ from .views.deploy import (
     DeployPingView,
     DeployStatusView,
     DeployView,
+    DeployWebClientsView,
 )
 from .views.password import PasswordView
 from .views.portal import PortalView
@@ -20,4 +21,9 @@ urlpatterns = [
     path("deploy/run/", DeployActionView.as_view(), name="deploy_run"),
     path("deploy/status/", DeployStatusView.as_view(), name="deploy_status"),
     path("deploy/ping/", DeployPingView.as_view(), name="deploy_ping"),
+    path(
+        "deploy/web-clients/",
+        DeployWebClientsView.as_view(),
+        name="deploy_web_clients",
+    ),
 ]

--- a/apps/accounts/views/deploy.py
+++ b/apps/accounts/views/deploy.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.views.generic.base import TemplateView, View
 
+from apps.connect import tracker as connect_tracker
 from apps.core.views.mixins import GodRequiredMixin, NeverCacheMixin
 
 from ..utils.deploy_agent import DeployAgentError, deploy_status, ping, start_deploy
@@ -86,6 +87,22 @@ class DeployPingView(GodRequiredMixin, NeverCacheMixin, View):
         if "ok" not in result:
             result = {"ok": True, **result}
         return JsonResponse(result)
+
+
+class DeployWebClientsView(GodRequiredMixin, NeverCacheMixin, View):
+    """POST-only count of live web-client (/connect) game sessions.
+
+    Deploying ishar-web restarts Daphne, which severs every browser player's
+    telnet proxy mid-game — the console polls this to warn before that happens.
+    Reads an in-process registry (Daphne is a single process; see
+    apps.connect.tracker), so it costs nothing and needs no agent or DB.
+    Read-only (no re-auth); God gate + CSRF still apply.
+    """
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        return JsonResponse(connect_tracker.snapshot())
 
 
 class DeployStatusView(GodRequiredMixin, NeverCacheMixin, View):

--- a/apps/connect/consumers.py
+++ b/apps/connect/consumers.py
@@ -5,6 +5,8 @@ import logging
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.conf import settings
 
+from . import tracker
+
 
 logger = logging.getLogger(__name__)
 
@@ -53,11 +55,13 @@ class TelnetConsumer(AsyncWebsocketConsumer):
             return
 
         await self.accept()
+        tracker.register(self)
 
         # Read from the MUD in the background.
         self._read_task = asyncio.create_task(self._read_telnet())
 
     async def disconnect(self, code):
+        tracker.unregister(self)
         if self._read_task:
             self._read_task.cancel()
         if self._writer:

--- a/apps/connect/tracker.py
+++ b/apps/connect/tracker.py
@@ -1,0 +1,38 @@
+"""In-process registry of live web-client (telnet proxy) sessions.
+
+Daphne serves HTTP and WebSocket from a single process (see Dockerfile CMD),
+so a module-level registry is visible to both the Channels consumer and the
+ordinary Django views — no channel layer or database needed. The Deploy
+Console reads this to warn a God that deploying ishar-web will sever every
+browser player's game connection mid-session.
+
+Consumers register after the socket is fully accepted (browser attached AND
+the game-side telnet connect succeeded), so the count is "players actually
+in the game via the web client", not half-open handshakes.
+"""
+import time
+from threading import Lock
+
+
+_lock = Lock()
+_sessions: dict[int, float] = {}  # id(consumer) -> time.monotonic() at accept
+
+
+def register(consumer) -> None:
+    """Record a fully-established web-client session."""
+    with _lock:
+        _sessions[id(consumer)] = time.monotonic()
+
+
+def unregister(consumer) -> None:
+    """Drop a session. Idempotent — safe on never-registered consumers."""
+    with _lock:
+        _sessions.pop(id(consumer), None)
+
+
+def snapshot() -> dict:
+    """Return {"count": int, "ages": [seconds, ...]} (ages descending)."""
+    now = time.monotonic()
+    with _lock:
+        ages = sorted((now - t for t in _sessions.values()), reverse=True)
+    return {"count": len(ages), "ages": [int(age) for age in ages]}


### PR DESCRIPTION
Deploying ishar-web restarts Daphne, which severs every /connect
player's telnet proxy mid-game. The Deploy Console now knows about
those sessions and says so before the God pulls the trigger:

- apps/connect/tracker.py: in-process registry of live web-client
  sessions (Daphne is a single process, so module state is shared
  between the Channels consumer and the HTTP views — no Redis or DB).
  TelnetConsumer registers only after the browser socket is accepted
  AND the game-side telnet connect succeeded, and unregisters on
  disconnect, so the count is players actually in the game.
- DeployWebClientsView (POST /portal/deploy/web-clients/, God-gated,
  CSRF, never-cache) returns {count, ages}.
- Deploy Console polls it every 10s: a danger note appears when the
  selected deploy includes ishar-web and sessions are live, showing
  the count and the longest session age; the confirm dialog repeats
  the warning at submit time with the latest count.
- The ishar-web warnings now also fire when NO services are selected,
  since an empty selection deploys ALL services, including ishar-web.

Verified: py_compile on changed Python; template parse via Django
engine; node --check on the extracted script; an end-to-end Channels
WebsocketCommunicator test against a fake telnet server (count 1 while
connected, 0 after disconnect, 0 when the game refuses); headless-
Chromium screenshots of the new note at desktop and phone widths.
Live count endpoint + polling left to on-prod test.

Relates to #76

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GV41c8i38LiBJbvfpv4nWP