### PR TITLE
Season auto-cycle and feature gating infrastructure

### DIFF
--- a/apps/players/templates/who.html
+++ b/apps/players/templates/who.html
@@ -31,7 +31,7 @@
 {% if players %}
     <div class="ac-rows">
 {% for player in players.all %}
-        <div class="ac-row" title="{{ player.player_name }}">
+        <div class="ac-row" title="{{ player.name }}">
             <span class="ac-row__icon">
 {% if player.is_immortal %}
                 {% bi "star" label="Immortal" %}

--- a/apps/players/views/who.py
+++ b/apps/players/views/who.py
@@ -1,5 +1,9 @@
-from django.db.models.expressions import F
+from datetime import timedelta
+
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Q
+from django.db.models.expressions import F
+from django.utils.timezone import now
 from django.views.generic.list import ListView
 
 from apps.core.views.mixins import NeverCacheMixin
@@ -15,8 +19,12 @@ class PlayerWhoView(LoginRequiredMixin, NeverCacheMixin, ListView):
     template_name = "who.html"
 
     def get_queryset(self):
+        # There is no live presence signal yet (isharmud/ishar-mud#1771).
+        # "Online" is inferred: logon >= logout alone breaks once the game's
+        # 5-minute autosave refreshes logout mid-session, so a recent logout
+        # also counts. Just-quit players linger here for up to 10 minutes.
         return super().get_queryset().filter(
-            logon__gte=F("logout"),
+            Q(logon__gte=F("logout"))
+            | Q(logout__gte=now() - timedelta(minutes=10)),
             is_deleted=False,
-            online__gt=0
         )

--- a/apps/seasons/admin/season.py
+++ b/apps/seasons/admin/season.py
@@ -17,6 +17,9 @@ class SeasonAdmin(ModelAdmin):
                     "is_active",
                     "game_state",
                     "enigma",
+                    "next_enigma",
+                    "new_features_on",
+                    "auto_cycle",
                 )
             }
         ),
@@ -80,9 +83,16 @@ class SeasonAdmin(ModelAdmin):
         "multiplay_limit",
         "enigma",
     )
+    # The game loads the seasons table at boot only — admin writes to these
+    # would silently diverge from the running game's in-memory season until
+    # a reboot, so they are surfaced read-only (mutations belong to the
+    # future season console, which routes through the game).
     readonly_fields = (
         "season_id",
-        "next_cycle"
+        "next_cycle",
+        "next_enigma",
+        "new_features_on",
+        "auto_cycle",
     )
     search_fields = (
         "seasonal_leader_name",

--- a/apps/seasons/models/season.py
+++ b/apps/seasons/models/season.py
@@ -92,6 +92,30 @@ class Season(models.Model):
         help_text="Enigma related to the season.",
         verbose_name="Enigma",
     )
+    new_features_on = models.BooleanField(
+        blank=True,
+        null=True,
+        help_text="Are the season's gated new features enabled?",
+        verbose_name="New Features On?",
+    )
+    next_enigma = models.ForeignKey(
+        blank=True,
+        null=True,
+        to=SeasonalEnigma,
+        to_field="seasonal_enigma_id",
+        on_delete=models.DO_NOTHING,
+        related_name="+",
+        help_text="Enigma that will run in the next season.",
+        verbose_name="Next Enigma",
+    )
+    auto_cycle = models.BooleanField(
+        default=True,
+        help_text=(
+            "Automatically cycle and start the next season"
+            " when the expiration date is reached?"
+        ),
+        verbose_name="Auto-Cycle?",
+    )
 
     class Meta:
         managed = False


### PR DESCRIPTION
## Summary

Adds three new fields to the `Season` model to support automatic season cycling and gated feature rollout, plus fixes the "Who's Online" player detection logic and template reference.

## Changes

**Season model (`apps/seasons/models/season.py`)**
- Added `new_features_on` (BooleanField) — toggles gated new features for a season
- Added `next_enigma` (ForeignKey to SeasonalEnigma) — specifies the enigma to run in the next season
- Added `auto_cycle` (BooleanField, default=True) — controls whether the next season starts automatically at expiration

**Season admin (`apps/seasons/admin/season.py`)**
- Surfaced the three new fields in the fieldset for visibility
- Marked all three as read-only with a comment explaining why: the game loads seasons at boot only, so admin writes would silently diverge from the running game's in-memory state until reboot. Mutations belong in the future season console (routed through the game)

**Player "Who's Online" view (`apps/players/views/who.py`)**
- Fixed player detection logic: changed from `logon >= logout` alone to `logon >= logout OR logout >= now() - 10 minutes`
- Rationale: the game's 5-minute autosave refreshes logout mid-session, breaking the original logic. A recent logout now also counts as "online" to handle this; just-quit players linger for up to 10 minutes
- Removed the `online__gt=0` filter (no longer needed with the new logic)
- Added explanatory comment documenting the absence of a live presence signal (isharmud/ishar-mud#1771)

**Player template (`apps/players/templates/who.html`)**
- Fixed template reference: changed `{{ player.player_name }}` to `{{ player.name }}` in the title attribute

All three new Season fields are read-only in admin to enforce the constraint that the game engine owns season state; they are surfaced for inspection only.

https://claude.ai/code/session_01Mh1C4q1vQ3vAhcJ1Q89mnP