### PR TITLE
Events console (Eternal+), Season console (God), and the who's-online badge fix

### DIFF
--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -54,8 +54,22 @@
                     <span class="ac-link__note d-block">Rebuild &amp; restart the stack</span>
                 </span>
             </a>
+            <a class="ac-link" href="{% url 'season_console' %}#console" title="Season Console">
+                <span class="ac-link__icon">{% bi "hourglass-split" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Season Console</span>
+                    <span class="ac-link__note d-block">Expiration, auto-cycle &amp; cycling</span>
+                </span>
+            </a>
     {% endif %}
     {% if user.is_eternal %}
+            <a class="ac-link" href="{% url 'events_console' %}#console" title="Events Console">
+                <span class="ac-link__icon">{% bi "stars" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Events Console</span>
+                    <span class="ac-link__note d-block">Start, extend &amp; end in-game events</span>
+                </span>
+            </a>
             <a class="ac-link" href="{% url 'feedback' %}#feedback" title="Feedback Triage">
                 <span class="ac-link__icon">{% bi "flag" %}</span>
                 <span class="ac-link__body">

--- a/apps/core/migrations/0007_webadmintask.py
+++ b/apps/core/migrations/0007_webadmintask.py
@@ -1,0 +1,148 @@
+"""
+Register the game-owned `web_admin_queue` outbox model.
+
+**This migration issues no DDL.** `WebAdminTask` is `managed = False` — the
+table is created game-side by the ishar-mud rust-interop migration
+`2026-07-12-000000-0000_web_admin_queue`, which must be applied (a game
+deploy) before the events/season consoles can enqueue. See
+`docs/web_bridge_contracts.md` in ishar-mud.
+"""
+import apps.core.models.unsigned
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0006_title"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WebAdminTask",
+            fields=[
+                (
+                    "id",
+                    apps.core.models.unsigned.UnsignedAutoField(
+                        db_column="id",
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="Task ID",
+                    ),
+                ),
+                (
+                    "command",
+                    models.CharField(
+                        choices=[
+                            ("event_start", "Start/Extend Event"),
+                            ("event_end", "End Event"),
+                            ("season_set_expiration", "Set Season Expiration"),
+                            ("season_set_auto_cycle", "Set Season Auto-Cycle"),
+                            ("season_cycle", "Cycle Season"),
+                            ("season_start", "Start Season"),
+                        ],
+                        db_column="command",
+                        help_text="Semantic verb the game executes.",
+                        max_length=32,
+                        verbose_name="Command",
+                    ),
+                ),
+                (
+                    "payload",
+                    models.JSONField(
+                        blank=True,
+                        db_column="payload",
+                        help_text=(
+                            "Verb parameters: {event_type?, duration_seconds?,"
+                            " expiration_date?, enabled?}."
+                        ),
+                        null=True,
+                        verbose_name="Payload",
+                    ),
+                ),
+                (
+                    "actor_account",
+                    models.PositiveIntegerField(
+                        db_column="actor_account",
+                        help_text=(
+                            "accounts.account_id of the staff member; the game"
+                            " re-checks its immortal_level against the verb's"
+                            " privilege floor."
+                        ),
+                        verbose_name="Actor Account ID",
+                    ),
+                ),
+                (
+                    "actor_name",
+                    models.CharField(
+                        db_column="actor_name",
+                        help_text="Staff attribution (immortal character name).",
+                        max_length=64,
+                        verbose_name="Actor",
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("done", "Done"),
+                            ("error", "Error"),
+                            ("cancelled", "Cancelled"),
+                        ],
+                        db_column="status",
+                        default="pending",
+                        max_length=16,
+                        verbose_name="Status",
+                    ),
+                ),
+                (
+                    "attempts",
+                    models.PositiveIntegerField(
+                        db_column="attempts",
+                        default=0,
+                        verbose_name="Attempts",
+                    ),
+                ),
+                (
+                    "result",
+                    models.CharField(
+                        blank=True,
+                        db_column="result",
+                        help_text=(
+                            "Human-readable outcome (or error) written by the"
+                            " game."
+                        ),
+                        max_length=255,
+                        null=True,
+                        verbose_name="Result",
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        blank=True,
+                        db_column="created_at",
+                        null=True,
+                        verbose_name="Created At",
+                    ),
+                ),
+                (
+                    "processed_at",
+                    models.DateTimeField(
+                        blank=True,
+                        db_column="processed_at",
+                        null=True,
+                        verbose_name="Processed At",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Web Admin Task",
+                "verbose_name_plural": "Web Admin Tasks",
+                "db_table": "web_admin_queue",
+                "ordering": ("-id",),
+                "managed": False,
+            },
+        ),
+    ]

--- a/apps/core/models/webadmin.py
+++ b/apps/core/models/webadmin.py
@@ -1,0 +1,127 @@
+"""
+Web admin command outbox (`web_admin_queue` table).
+
+The game loads `global_event` and `seasons` at boot only, so the website
+cannot write that state directly — a Django UPDATE would be invisible to the
+running game until a reboot. Instead the staff consoles (events, season)
+enqueue an *intent* here; the game drains one command per game-minute,
+validates it (verb, parameter bounds, and a re-check of the enqueuing
+account's `immortal_level` against the verb's privilege floor), executes it
+through its own entry points, and writes `status`/`result` back for the
+console to poll. Rows are never deleted — the table is the admin audit log.
+
+The table is game-owned (rust-interop migration
+`2026-07-12-000000-0000_web_admin_queue`), so this model is `managed = False`
+and the command/status strings are a contract that must not drift. See
+`docs/web_bridge_contracts.md` in ishar-mud.
+"""
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from .unsigned import UnsignedAutoField
+
+
+class WebAdminCommand(models.TextChoices):
+    """`web_admin_queue.command` — semantic verbs the game executes."""
+
+    EVENT_START = "event_start", _("Start/Extend Event")
+    EVENT_END = "event_end", _("End Event")
+    SEASON_SET_EXPIRATION = "season_set_expiration", _("Set Season Expiration")
+    SEASON_SET_AUTO_CYCLE = "season_set_auto_cycle", _("Set Season Auto-Cycle")
+    SEASON_CYCLE = "season_cycle", _("Cycle Season")
+    SEASON_START = "season_start", _("Start Season")
+
+
+class WebAdminStatus(models.TextChoices):
+    """`web_admin_queue.status` ENUM('pending','done','error','cancelled')."""
+
+    PENDING = "pending", _("Pending")
+    DONE = "done", _("Done")
+    ERROR = "error", _("Error")
+    CANCELLED = "cancelled", _("Cancelled")
+
+
+class WebAdminTask(models.Model):
+    """One queued admin command for the game to execute."""
+
+    id = UnsignedAutoField(
+        primary_key=True,
+        db_column="id",
+        verbose_name="Task ID",
+    )
+    command = models.CharField(
+        max_length=32,
+        db_column="command",
+        choices=WebAdminCommand,
+        help_text="Semantic verb the game executes.",
+        verbose_name="Command",
+    )
+    payload = models.JSONField(
+        db_column="payload",
+        blank=True,
+        null=True,
+        help_text=(
+            "Verb parameters:"
+            " {event_type?, duration_seconds?, expiration_date?, enabled?}."
+        ),
+        verbose_name="Payload",
+    )
+    actor_account = models.PositiveIntegerField(
+        db_column="actor_account",
+        help_text=(
+            "accounts.account_id of the staff member; the game re-checks"
+            " its immortal_level against the verb's privilege floor."
+        ),
+        verbose_name="Actor Account ID",
+    )
+    actor_name = models.CharField(
+        max_length=64,
+        db_column="actor_name",
+        help_text="Staff attribution (immortal character name).",
+        verbose_name="Actor",
+    )
+    status = models.CharField(
+        max_length=16,
+        db_column="status",
+        choices=WebAdminStatus,
+        default=WebAdminStatus.PENDING,
+        verbose_name="Status",
+    )
+    attempts = models.PositiveIntegerField(
+        db_column="attempts",
+        default=0,
+        verbose_name="Attempts",
+    )
+    result = models.CharField(
+        max_length=255,
+        db_column="result",
+        blank=True,
+        null=True,
+        help_text="Human-readable outcome (or error) written by the game.",
+        verbose_name="Result",
+    )
+    created_at = models.DateTimeField(
+        db_column="created_at",
+        blank=True,
+        null=True,
+        verbose_name="Created At",
+    )
+    processed_at = models.DateTimeField(
+        db_column="processed_at",
+        blank=True,
+        null=True,
+        verbose_name="Processed At",
+    )
+
+    class Meta:
+        managed = False
+        db_table = "web_admin_queue"
+        ordering = ("-id",)
+        verbose_name = "Web Admin Task"
+        verbose_name_plural = "Web Admin Tasks"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {self.__str__()} ({self.id})"
+
+    def __str__(self) -> str:
+        return f"{self.get_command_display()} [{self.status}]"

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -230,9 +230,21 @@
                                         Deploy
                                     </a>
                                 </li>
+                                <li class="nav-item" title="Season Console">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'season_console' %}#console">
+                                        {% bi "hourglass-split" %}
+                                        Season Console
+                                    </a>
+                                </li>
         {% endif %}
     {% endif %}
     {% if user.is_eternal %}
+                                <li class="nav-item" title="Events Console">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'events_console' %}#console">
+                                        {% bi "stars" %}
+                                        Events Console
+                                    </a>
+                                </li>
                                 <li class="nav-item" title="Feedback Triage">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'feedback' %}#feedback">
                                         {% bi "flag" %}

--- a/apps/core/templates/partials/webadmin_js.html
+++ b/apps/core/templates/partials/webadmin_js.html
@@ -1,0 +1,67 @@
+{% comment %}
+Shared console JS for the web_admin_queue outbox: form-encoded CSRF POSTs and
+a status-poll loop. Included by the events/season consoles; exposes
+window.WebAdminQueue = { post, watch, cancel }. All DOM writes by callers must
+use textContent/class swaps (never innerHTML) per the frontend rules.
+{% endcomment %}
+<script>
+(function () {
+    "use strict";
+
+    const csrftoken = "{{ csrf_token }}";
+    const statusUrl = "{% url 'webadmin_status' %}";
+    const cancelUrl = "{% url 'webadmin_cancel' %}";
+
+    // Commands execute on the game's next game-minute pulse; poll gently and
+    // flag "game may be down" after ~3 minutes of pending.
+    const POLL_MS = 2000;
+    const STALE_AFTER_MS = 3 * 60 * 1000;
+
+    function post(url, params) {
+        const body = new URLSearchParams(params);
+        body.append("csrfmiddlewaretoken", csrftoken);
+        return fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-CSRFToken": csrftoken,
+            },
+            body: body.toString(),
+        }).then(function (resp) {
+            return resp.json().then(function (data) {
+                return { status: resp.status, data: data };
+            }).catch(function () {
+                return { status: resp.status, data: {} };
+            });
+        });
+    }
+
+    // Poll one task until it leaves `pending`. Calls onUpdate(data, stale) on
+    // every poll and onDone(data) once terminal (done/error/cancelled).
+    function watch(taskId, onUpdate, onDone) {
+        const started = Date.now();
+        const timer = setInterval(function () {
+            post(statusUrl, { task_id: taskId }).then(function (r) {
+                if (r.status !== 200) {
+                    clearInterval(timer);
+                    onDone({ status: "error", result: r.data.message || ("HTTP " + r.status) });
+                    return;
+                }
+                const stale = (Date.now() - started) > STALE_AFTER_MS;
+                onUpdate(r.data, stale);
+                if (r.data.status !== "pending") {
+                    clearInterval(timer);
+                    onDone(r.data);
+                }
+            }).catch(function () { /* transient; keep polling */ });
+        }, POLL_MS);
+        return timer;
+    }
+
+    function cancel(taskId) {
+        return post(cancelUrl, { task_id: taskId });
+    }
+
+    window.WebAdminQueue = { post: post, watch: watch, cancel: cancel };
+})();
+</script>

--- a/apps/core/utils/staff.py
+++ b/apps/core/utils/staff.py
@@ -1,0 +1,20 @@
+"""Shared staff-attribution helper (used by feedback triage and the admin
+consoles' `web_admin_queue` rows)."""
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+def staff_name(account) -> str:
+    """
+    Best display name for a staff member's actions, matching the in-game
+    attribution (character name). Falls back to the account login name.
+    """
+    try:
+        immortal = account.players.order_by("-true_level").first()
+        if immortal and immortal.name:
+            return str(immortal.name)
+    except Exception:  # pragma: no cover - defensive; never block an action
+        log.warning("staff: could not resolve immortal name for %s", account)
+    return account.get_username()

--- a/apps/core/utils/webadmin.py
+++ b/apps/core/utils/webadmin.py
@@ -1,0 +1,43 @@
+"""
+Enqueue/cancel helpers for the `web_admin_queue` outbox.
+
+The consoles call `enqueue()` from their POST action views; the game drains
+the row on its next game-minute pulse and writes `status`/`result` back for
+the console's poll endpoint. `cancel()` is a guarded update that only lands
+while the row is still `pending` — it races safely against the game's own
+claim, which is guarded the same way.
+"""
+from django.db import transaction
+from django.utils import timezone
+
+from apps.core.models.webadmin import WebAdminStatus, WebAdminTask
+
+
+def enqueue(command: str, payload: dict, actor_account: int,
+            actor_name: str) -> WebAdminTask:
+    """Insert one pending command row and return it."""
+    with transaction.atomic():
+        return WebAdminTask.objects.create(
+            command=command,
+            payload=payload or None,
+            actor_account=actor_account,
+            actor_name=actor_name[:64],
+            status=WebAdminStatus.PENDING,
+            # The game table is NOT NULL DEFAULT CURRENT_TIMESTAMP; Django
+            # would otherwise send NULL.
+            created_at=timezone.now(),
+        )
+
+
+def cancel(task_id: int, actor_name: str) -> bool:
+    """Cancel a still-pending command. Returns whether anything was
+    cancelled (False = already claimed/processed by the game)."""
+    updated = WebAdminTask.objects.filter(
+        id=task_id,
+        status=WebAdminStatus.PENDING,
+    ).update(
+        status=WebAdminStatus.CANCELLED,
+        result=f"cancelled by {actor_name}"[:255],
+        processed_at=timezone.now(),
+    )
+    return bool(updated)

--- a/apps/core/views/webadmin.py
+++ b/apps/core/views/webadmin.py
@@ -1,0 +1,64 @@
+"""Shared poll/cancel endpoints for the `web_admin_queue` outbox.
+
+Both staff consoles (events: Eternal+, season: God) enqueue commands and then
+poll the same queue, so the read/cancel endpoints live once, here. The floor
+is Eternal; season rows are additionally God-guarded on cancel (matching the
+enqueue gate — an Eternal must not be able to cancel a God's pending season
+command, and the game re-checks privileges on execution anyway).
+"""
+from django.http import JsonResponse
+from django.views.generic.base import View
+
+from ..models.webadmin import WebAdminTask
+from ..utils import webadmin
+from ..utils.staff import staff_name
+from .mixins import EternalRequiredMixin, NeverCacheMixin
+
+
+def task_json(task: WebAdminTask) -> dict:
+    return {
+        "id": task.id,
+        "command": task.command,
+        "status": task.status,
+        "result": task.result or "",
+        "created_at": task.created_at.isoformat() if task.created_at else None,
+        "processed_at": (
+            task.processed_at.isoformat() if task.processed_at else None
+        ),
+    }
+
+
+def _get_task(request):
+    task_id = request.POST.get("task_id", "")
+    if not task_id.isdigit():
+        return None
+    return WebAdminTask.objects.filter(id=int(task_id)).first()
+
+
+class WebAdminStatusView(EternalRequiredMixin, NeverCacheMixin, View):
+    """POST-only status poll for one queued command."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        task = _get_task(request)
+        if task is None:
+            return JsonResponse({"message": "Unknown task."}, status=404)
+        return JsonResponse(task_json(task))
+
+
+class WebAdminCancelView(EternalRequiredMixin, NeverCacheMixin, View):
+    """POST-only cancel of a still-pending command (guarded update — races
+    safely against the game's own claim)."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        task = _get_task(request)
+        if task is None:
+            return JsonResponse({"message": "Unknown task."}, status=404)
+        if task.command.startswith("season_") and not request.user.is_god():
+            return JsonResponse({"message": "Unknown task."}, status=404)
+        cancelled = webadmin.cancel(task.id, staff_name(request.user))
+        task.refresh_from_db()
+        return JsonResponse({"cancelled": cancelled, **task_json(task)})

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -69,19 +69,17 @@ class GlobalEventAdmin(ModelAdmin):
             return request.user.is_eternal()
         return False
 
+    # Read-only: the game loads global_event at boot only, so admin writes
+    # would silently diverge from the running game's in-memory events until
+    # a reboot. Mutations go through the Events Console, which routes
+    # through the game (web_admin_queue).
     def has_add_permission(self, request, obj=None) -> bool:
-        if request.user and not request.user.is_anonymous:
-            return request.user.is_forger()
         return False
 
     def has_change_permission(self, request, obj=None) -> bool:
-        if request.user and not request.user.is_anonymous:
-            return request.user.is_forger()
         return False
 
     def has_delete_permission(self, request, obj=None) -> bool:
-        if request.user and not request.user.is_anonymous:
-            return request.user.is_forger()
         return False
 
     def has_view_permission(self, request, obj=None) -> bool:

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -2,25 +2,40 @@ from django.db import models
 
 
 class EventType(models.IntegerChoices):
-    """Ishar global event type choices."""
+    """Ishar global event type choices.
 
-    BONUS_XP = 0
-    TEST_SERVER = 1
-    CHALLENGE_XP = 2
-    CHALLENGE_CYCLE_XP = 3
-    CRASH_XP = 4
-    WINTER_FEST = 5
-    ST_PATRICK = 6
-    JULY_FOURTH = 7
-    HALLOWS_EVE = 8
-    HARVEST_FEST = 9
-    MAX_EVENT = 10
+    Mirrors the game's `enum global_event_t` (ishar-mud constants.h) — the
+    ordinals and display names must not drift. Types 10-13 are the automatic
+    season-end countdown events: the game starts those itself as the season
+    expiration approaches, so the events console offers to end but never to
+    start them (`WEB_STARTABLE_EVENTS`).
+    """
+
+    BONUS_XP = 0, "Bonus Experience"
+    TEST_SERVER = 1, "Test Server"
+    CHALLENGE_XP = 2, "Challenge Experience"
+    CHALLENGE_CYCLE_XP = 3, "Challenges Cycled"
+    CRASH_XP = 4, "Crash Experience"
+    WINTER_FEST = 5, "Festival of the Dancers"
+    ST_PATRICK = 6, "Fortune's Convergence"
+    JULY_FOURTH = 7, "July Fourth"
+    HALLOWS_EVE = 8, "Veilfall"
+    HARVEST_FEST = 9, "Harvest Fest"
+    FOUR_WEEK_CYCLE = 10, "Rymaras' Echo"
+    THREE_WEEK_CYCLE = 11, "The Comet's Wake"
+    TWO_WEEK_CYCLE = 12, "Twilight of Titans"
+    ONE_WEEK_CYCLE = 13, "Saorin's Reckoning"
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}: {self.__str__()} ({self.value})"
 
     def __str__(self) -> str:
-        return self.name.title()
+        return self.label
+
+
+# Event types staff may start/extend from the web. The four season-end cycle
+# events (10-13) are excluded: the game fires those automatically.
+WEB_STARTABLE_EVENTS = tuple(e for e in EventType if e.value < 10)
 
 
 class GlobalEvent(models.Model):

--- a/apps/events/templates/events.html
+++ b/apps/events/templates/events.html
@@ -59,7 +59,7 @@
                     {% widthratio 100 global_event.shop_bonus 1 %}% off shops
                 </span>
 {% endif %}
-{% if global_event.is_luck %}
+{% if global_event.celestial_luck %}
                 <span class="ac-pill ac-pill--accent" title="Shavar and Chenchir shine brightly: +50 gold!">
                     +50 gold
                 </span>

--- a/apps/events/templates/events_console.html
+++ b/apps/events/templates/events_console.html
@@ -1,0 +1,251 @@
+{% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
+{% block meta_title %}Events Console{% endblock meta_title %}
+{% block meta_description %}Staff console to start, extend, and end {{ WEBSITE_TITLE }} events.{% endblock meta_description %}
+{% block meta_url %}{% url 'events_console' %}#console{% endblock meta_url %}
+{% block title %}Events Console{% endblock title %}
+{% block breadcrumbs %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Events Console" "stars" urlname="events_console" anchor="console" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac">
+
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "stars" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Events Console</h2>
+            <p class="ac-hero__sub">
+                Start, extend, and end in-game events. Commands run on the
+                game's next minute pulse.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+{% if active_count > 0 %}
+            <span class="ac-pill ac-pill--status ac-pill--ok ac-pill--live">{{ active_count }} active</span>
+{% else %}
+            <span class="ac-pill ac-pill--status ac-pill--muted">none active</span>
+{% endif %}
+        </div>
+    </header>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "play-circle" %} Queue an event</div>
+        <p class="ac-panel__hint">
+            Starting an event that is already running extends it by the
+            duration instead.
+        </p>
+        <form id="startForm" onsubmit="return false;">
+            <div class="row g-2 align-items-end">
+                <div class="col-12 col-sm">
+                    <label class="ac-label" for="startEvent">Event</label>
+                    <select class="ac-field" id="startEvent">
+{% for event_type in startable_events %}
+                        <option value="{{ event_type.value }}">{{ event_type.label }}</option>
+{% endfor %}
+                    </select>
+                </div>
+                <div class="col-6 col-sm-2">
+                    <label class="ac-label" for="startAmount">Duration</label>
+                    <input class="ac-field" id="startAmount" type="number"
+                           inputmode="numeric" min="1" max="10080" value="4">
+                </div>
+                <div class="col-6 col-sm-3">
+                    <label class="ac-label" for="startUnit">Unit</label>
+                    <select class="ac-field" id="startUnit">
+                        <option value="minutes">minutes</option>
+                        <option value="hours" selected>hours</option>
+                        <option value="days">days</option>
+                        <option value="weeks">weeks</option>
+                    </select>
+                </div>
+                <div class="col-12 col-sm-auto">
+                    <button class="ac-cta" id="startBtn" type="submit">
+                        {% bi "play-circle" %} Queue start/extend
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "calendar-event" %} Events</div>
+        <div class="ac-rows">
+{% for row in event_rows %}
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "stars" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title">{{ row.type.label }}</div>
+                    <div class="ac-row__meta">
+{% if row.active %}
+                        <span title="Ends {{ row.active.end_time }}">
+                            {% bi "hourglass-split" %}
+                            ends
+                            <time datetime="{{ row.active.end_time|date:'c' }}">{{ row.active.end_time|naturaltime }}</time>
+                        </span>
+{% if row.active.xp_bonus %}
+                        <span>{% bi "graph-up-arrow" %} +{{ row.active.xp_bonus }}% XP</span>
+{% endif %}
+{% else %}
+                        <span class="text-secondary">inactive</span>
+{% endif %}
+                    </div>
+                </div>
+                <div class="ac-row__side">
+{% if not row.startable %}
+                    <span class="ac-pill ac-pill--muted" title="The game starts this event automatically as the season end approaches.">auto</span>
+{% endif %}
+{% if row.active %}
+                    <span class="ac-pill ac-pill--ok ac-pill--live">active</span>
+                    <button class="ac-btn ac-btn--danger" type="button"
+                            data-end-event="{{ row.type.value }}"
+                            data-event-label="{{ row.type.label }}">
+                        {% bi "stop-circle" %} End
+                    </button>
+{% endif %}
+                </div>
+            </div>
+{% endfor %}
+        </div>
+    </div>
+
+    <div class="ac-note d-none" id="queueNote" aria-live="polite">
+        <span id="queueNoteText"></span>
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "clock-history" %} Recent commands</div>
+        <p class="ac-panel__hint">
+            A command that stays pending for several minutes usually means the
+            game is down — it will run when the game returns, or it can be
+            cancelled.
+        </p>
+{% if recent_tasks %}
+        <div class="ac-rows">
+{% for task in recent_tasks %}
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "terminal" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title">{{ task.get_command_display }}</div>
+                    <div class="ac-row__meta">
+                        <span>{% bi "person" %} {{ task.actor_name }}</span>
+                        <span>
+                            {% bi "clock" %}
+                            <time datetime="{{ task.created_at|date:'c' }}">{{ task.created_at|naturaltime }}</time>
+                        </span>
+{% if task.result %}
+                        <span class="mono">{{ task.result }}</span>
+{% endif %}
+                    </div>
+                </div>
+                <div class="ac-row__side">
+{% if task.status == "pending" %}
+                    <span class="ac-pill ac-pill--warn ac-pill--live">pending</span>
+                    <button class="ac-btn" type="button" data-cancel-task="{{ task.id }}">
+                        {% bi "x-circle" %} Cancel
+                    </button>
+{% elif task.status == "done" %}
+                    <span class="ac-pill ac-pill--ok">done</span>
+{% elif task.status == "cancelled" %}
+                    <span class="ac-pill ac-pill--muted">cancelled</span>
+{% else %}
+                    <span class="ac-pill ac-pill--danger">error</span>
+{% endif %}
+                </div>
+            </div>
+{% endfor %}
+        </div>
+{% else %}
+        <div class="ac-empty">
+            {% bi "terminal" %}
+            <span>No event commands have been queued yet.</span>
+        </div>
+{% endif %}
+    </div>
+
+</div>
+{% include "partials/webadmin_js.html" %}
+<script>
+(function () {
+    "use strict";
+
+    const queue = window.WebAdminQueue;
+    const runUrl = "{% url 'events_console_run' %}";
+    const note = document.getElementById("queueNote");
+    const noteText = document.getElementById("queueNoteText");
+    const startBtn = document.getElementById("startBtn");
+
+    function showNote(text, kind) {
+        note.className = "ac-note" + (kind ? " ac-note--" + kind : "");
+        noteText.textContent = text;
+    }
+
+    function watchTask(taskId) {
+        showNote("Queued (#" + taskId + ") - waiting for the game's next minute pulse...", "");
+        queue.watch(taskId, function (data, stale) {
+            if (data.status === "pending" && stale) {
+                showNote("Still pending (#" + taskId + ") - the game may be down. " +
+                    "The command stays queued and runs when the game returns.", "warn");
+            }
+        }, function (data) {
+            if (data.status === "done") {
+                showNote("Done: " + (data.result || "command executed."), "ok");
+                setTimeout(function () { window.location.reload(); }, 1500);
+            } else {
+                showNote((data.status === "cancelled" ? "Cancelled: " : "Failed: ") +
+                    (data.result || "see recent commands."), "danger");
+                startBtn.disabled = false;
+            }
+        });
+    }
+
+    function run(params) {
+        startBtn.disabled = true;
+        queue.post(runUrl, params).then(function (r) {
+            if (r.status === 200 && r.data.queued) {
+                watchTask(r.data.task_id);
+            } else {
+                showNote("Rejected: " + (r.data.message || ("HTTP " + r.status)), "danger");
+                startBtn.disabled = false;
+            }
+        }).catch(function () {
+            showNote("Network error - nothing was queued.", "danger");
+            startBtn.disabled = false;
+        });
+    }
+
+    document.getElementById("startForm").addEventListener("submit", function () {
+        run({
+            action: "start",
+            event_type: document.getElementById("startEvent").value,
+            amount: document.getElementById("startAmount").value,
+            unit: document.getElementById("startUnit").value,
+        });
+    });
+
+    document.querySelectorAll("[data-end-event]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+            if (!window.confirm("End \"" + btn.dataset.eventLabel + "\" now?")) {
+                return;
+            }
+            run({ action: "end", event_type: btn.dataset.endEvent });
+        });
+    });
+
+    document.querySelectorAll("[data-cancel-task]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+            btn.disabled = true;
+            queue.cancel(btn.dataset.cancelTask).then(function (r) {
+                if (r.data.cancelled) {
+                    showNote("Cancelled #" + btn.dataset.cancelTask + ".", "ok");
+                    setTimeout(function () { window.location.reload(); }, 1000);
+                } else {
+                    showNote("Too late to cancel - the game already claimed it.", "warn");
+                }
+            });
+        });
+    });
+})();
+</script>
+{% endblock content %}

--- a/apps/events/urls.py
+++ b/apps/events/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
 
-from .views import GlobalEventsView
+from .views import EventActionView, EventsConsoleView, GlobalEventsView
 
 
 urlpatterns = [
     path("", GlobalEventsView.as_view(), name="events"),
+    path("console/", EventsConsoleView.as_view(), name="events_console"),
+    path("console/run/", EventActionView.as_view(), name="events_console_run"),
 ]

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -1,8 +1,26 @@
+from django.http import JsonResponse
 from django.utils.timezone import now
+from django.views.generic.base import TemplateView, View
 from django.views.generic.list import ListView
 
-from .models import GlobalEvent
-from apps.core.views.mixins import NeverCacheMixin
+from apps.core.models.webadmin import WebAdminCommand, WebAdminTask
+from apps.core.utils import webadmin
+from apps.core.utils.staff import staff_name
+from apps.core.views.mixins import EternalRequiredMixin, NeverCacheMixin
+
+from .models import EventType, GlobalEvent, WEB_STARTABLE_EVENTS
+
+
+# Duration units the console accepts, mirroring the in-game `event` command.
+DURATION_UNITS = {
+    "minutes": 60,
+    "hours": 3600,
+    "days": 86400,
+    "weeks": 604800,
+}
+# Bounds enforced again game-side (rust web_admin validation).
+DURATION_MIN_SECS = 60
+DURATION_MAX_SECS = 30 * 86400
 
 
 class GlobalEventsView(NeverCacheMixin, ListView):
@@ -18,3 +36,95 @@ class GlobalEventsView(NeverCacheMixin, ListView):
             start_time__lt=current,
             end_time__gt=current
         )
+
+
+class EventsConsoleView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
+    """Staff console: start/extend/end global events. The game executes the
+    commands via the web_admin_queue outbox (Eternal+ -> 404 for others)."""
+
+    template_name = "events_console.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        current = now()
+        active = {
+            event.event_type: event
+            for event in GlobalEvent.objects.filter(
+                start_time__lt=current, end_time__gt=current
+            )
+        }
+        context["event_rows"] = [
+            {
+                "type": event_type,
+                "active": active.get(event_type.value),
+                "startable": event_type in WEB_STARTABLE_EVENTS,
+            }
+            for event_type in EventType
+        ]
+        context["startable_events"] = WEB_STARTABLE_EVENTS
+        context["active_count"] = len(active)
+        context["recent_tasks"] = WebAdminTask.objects.filter(
+            command__in=(WebAdminCommand.EVENT_START, WebAdminCommand.EVENT_END)
+        )[:10]
+        return context
+
+
+class EventActionView(EternalRequiredMixin, NeverCacheMixin, View):
+    """POST-only: enqueue an event command. CSRF-protected; inputs are
+    allowlisted here and re-validated game-side."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        action = request.POST.get("action", "")
+        event_type = request.POST.get("event_type", "")
+        if not event_type.isdigit():
+            return JsonResponse({"message": "Unknown event type."}, status=400)
+        event_type = int(event_type)
+
+        if action == "start":
+            if event_type not in {e.value for e in WEB_STARTABLE_EVENTS}:
+                return JsonResponse(
+                    {"message": "That event cannot be started from the web."},
+                    status=400,
+                )
+            amount = request.POST.get("amount", "")
+            unit = request.POST.get("unit", "")
+            if not amount.isdigit() or int(amount) < 1:
+                return JsonResponse(
+                    {"message": "Duration must be a positive number."},
+                    status=400,
+                )
+            if unit not in DURATION_UNITS:
+                return JsonResponse(
+                    {"message": "Unit must be minutes, hours, days or weeks."},
+                    status=400,
+                )
+            duration = int(amount) * DURATION_UNITS[unit]
+            if not DURATION_MIN_SECS <= duration <= DURATION_MAX_SECS:
+                return JsonResponse(
+                    {"message": "Duration must be between 1 minute and 30 days."},
+                    status=400,
+                )
+            task = webadmin.enqueue(
+                command=WebAdminCommand.EVENT_START,
+                payload={
+                    "event_type": event_type,
+                    "duration_seconds": duration,
+                },
+                actor_account=request.user.account_id,
+                actor_name=staff_name(request.user),
+            )
+        elif action == "end":
+            if event_type not in {e.value for e in EventType}:
+                return JsonResponse({"message": "Unknown event type."}, status=400)
+            task = webadmin.enqueue(
+                command=WebAdminCommand.EVENT_END,
+                payload={"event_type": event_type},
+                actor_account=request.user.account_id,
+                actor_name=staff_name(request.user),
+            )
+        else:
+            return JsonResponse({"message": "Unknown action."}, status=400)
+
+        return JsonResponse({"queued": True, "task_id": task.id})

--- a/apps/feedback/services.py
+++ b/apps/feedback/services.py
@@ -21,6 +21,8 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
 
+from apps.core.utils.staff import staff_name  # noqa: F401 - shared, re-exported
+
 from .models import (
     CommentSource,
     Feedback,
@@ -42,20 +44,6 @@ INSTRUCTIONS_MAX = 2000
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
-
-def staff_name(account) -> str:
-    """
-    Best display name for a staff member's actions, matching the in-game
-    attribution (character name). Falls back to the account login name.
-    """
-    try:
-        immortal = account.players.order_by("-true_level").first()
-        if immortal and immortal.name:
-            return str(immortal.name)
-    except Exception:  # pragma: no cover - defensive; never block an action
-        log.warning("feedback: could not resolve immortal name for %s", account)
-    return account.get_username()
-
 
 # Bidirectional/direction-override codepoints that can spoof displayed order —
 # stripped to match the Rust `sanitize_text` (feedback.rs).

--- a/apps/players/contexts.py
+++ b/apps/players/contexts.py
@@ -1,4 +1,3 @@
-from django.db.models import F
 from .forms import PlayerSearchForm
 from .models.player import Player
 
@@ -10,10 +9,4 @@ def player_search_form(request):
 
 def players_online(request):
     # Context processor of count of number of players who are online.
-    return {
-        "PLAYERS_ONLINE": Player.objects.filter(
-                logon__gte=F("logout"),
-                is_deleted=False,
-                online__gt=0
-            ).count()
-    }
+    return {"PLAYERS_ONLINE": Player.objects.online().count()}

--- a/apps/players/management/commands/who.py
+++ b/apps/players/management/commands/who.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.db.models import F
 
 from apps.players.models.player import PlayerBase
 
@@ -11,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
 
-        players = PlayerBase.objects.filter(logon__gte=F("logout"))
+        players = PlayerBase.objects.online()
 
         if players and players.count() > 0:
             for player in players:

--- a/apps/players/models/base.py
+++ b/apps/players/models/base.py
@@ -23,6 +23,18 @@ class PlayerBaseManager(models.Manager):
         # Natural key is player name.
         return self.get(name=name)
 
+    def online(self):
+        # The single source of truth for "who is online". There is no live
+        # presence signal yet (isharmud/ishar-mud#1771): logon >= logout
+        # alone breaks once the game's 5-minute autosave refreshes logout
+        # mid-session, so a recent logout also counts. Just-quit players
+        # linger here for up to 10 minutes.
+        return self.filter(
+            models.Q(logon__gte=models.F("logout"))
+            | models.Q(logout__gte=now() - timedelta(minutes=10)),
+            is_deleted=False,
+        )
+
 
 class PlayerBase(models.Model):
     """Ishar player base model."""

--- a/apps/players/views/who.py
+++ b/apps/players/views/who.py
@@ -1,9 +1,4 @@
-from datetime import timedelta
-
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db.models import Q
-from django.db.models.expressions import F
-from django.utils.timezone import now
 from django.views.generic.list import ListView
 
 from apps.core.views.mixins import NeverCacheMixin
@@ -19,12 +14,4 @@ class PlayerWhoView(LoginRequiredMixin, NeverCacheMixin, ListView):
     template_name = "who.html"
 
     def get_queryset(self):
-        # There is no live presence signal yet (isharmud/ishar-mud#1771).
-        # "Online" is inferred: logon >= logout alone breaks once the game's
-        # 5-minute autosave refreshes logout mid-session, so a recent logout
-        # also counts. Just-quit players linger here for up to 10 minutes.
-        return super().get_queryset().filter(
-            Q(logon__gte=F("logout"))
-            | Q(logout__gte=now() - timedelta(minutes=10)),
-            is_deleted=False,
-        )
+        return Player.objects.online()

--- a/apps/seasons/templates/season_console.html
+++ b/apps/seasons/templates/season_console.html
@@ -1,0 +1,330 @@
+{% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
+{% block meta_title %}Season Console{% endblock meta_title %}
+{% block meta_description %}Staff console for {{ WEBSITE_TITLE }} season maintenance.{% endblock meta_description %}
+{% block meta_url %}{% url 'season_console' %}#console{% endblock meta_url %}
+{% block title %}Season Console{% endblock title %}
+{% block breadcrumbs %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Season Console" "hourglass-split" urlname="season_console" anchor="console" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac">
+
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "hourglass-split" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Season Console</h2>
+            <p class="ac-hero__sub">
+                Season {{ season.season_id }}
+                {% if season.enigma %}&middot; {{ season.enigma.enigma_name }}{% endif %}
+                &middot; commands run on the game's next minute pulse.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+{% if game_state_normal %}
+            <span class="ac-pill ac-pill--status ac-pill--ok ac-pill--live">{{ game_state_label }}</span>
+{% elif game_state_mid_cycle %}
+            <span class="ac-pill ac-pill--status ac-pill--warn ac-pill--live">{{ game_state_label }}</span>
+{% else %}
+            <span class="ac-pill ac-pill--status ac-pill--muted">{{ game_state_label }}</span>
+{% endif %}
+        </div>
+    </header>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "info-circle" %} Current season</div>
+        <dl class="ac-kv">
+            <dt>Started</dt>
+            <dd>
+                <time datetime="{{ season.effective_date|date:'c' }}">{{ season.effective_date|date:"l, F d, Y" }}</time>
+                ({{ season.effective_date|naturaltime }})
+            </dd>
+            <dt>Expires</dt>
+            <dd>
+                <time datetime="{{ season.expiration_date|date:'c' }}">{{ season.expiration_date|date:"l, F d, Y @ H:i e" }}</time>
+                ({{ season.expiration_date|naturaltime }})
+            </dd>
+            <dt>Auto-cycle</dt>
+            <dd>{% if season.auto_cycle %}on — the game cycles and starts the next season automatically at expiration{% else %}off — expiration passes without a cycle until one is requested{% endif %}</dd>
+            <dt>Next enigma</dt>
+            <dd>{% if season.next_enigma %}{{ season.next_enigma.enigma_name }}{% else %}not set{% endif %}</dd>
+        </dl>
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "calendar-week" %} Season-end events (automatic)</div>
+        <p class="ac-panel__hint">
+            The game fires these itself as expiration approaches; shown here
+            so date changes can be sanity-checked against them.
+        </p>
+        <div class="ac-rows">
+{% for step in season_end_ladder %}
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "stars" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title">{{ step.name }}</div>
+                    <div class="ac-row__meta">
+                        <span>{{ step.days }} days before season end</span>
+                        <span>
+                            {% bi "clock" %}
+                            <time datetime="{{ step.when|date:'c' }}">{{ step.when|date:"M d, Y" }}</time>
+                            ({{ step.when|naturaltime }})
+                        </span>
+                    </div>
+                </div>
+            </div>
+{% endfor %}
+        </div>
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "pencil-square" %} Adjust</div>
+        <form id="expirationForm" onsubmit="return false;">
+            <div class="row g-2 align-items-end">
+                <div class="col-12 col-sm">
+                    <label class="ac-label" for="expirationInput">
+                        Season expiration (your local time)
+                    </label>
+                    <input class="ac-field" id="expirationInput" type="datetime-local"
+                           data-iso="{{ season.expiration_date|date:'c' }}">
+                </div>
+                <div class="col-12 col-sm-auto">
+                    <button class="ac-btn ac-btn--accent" id="expirationBtn" type="submit">
+                        {% bi "calendar-check" %} Set expiration
+                    </button>
+                </div>
+            </div>
+        </form>
+        <hr>
+        <div class="ac-switch">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" role="switch"
+                       id="autoCycleSwitch" {% if season.auto_cycle %}checked{% endif %}>
+                <label class="form-check-label" for="autoCycleSwitch">
+                    <span class="ac-switch__text">Auto-cycle at expiration</span>
+                    <span class="ac-switch__note d-block">
+                        When on, the game cycles and starts the next season on
+                        its own once the expiration date passes.
+                    </span>
+                </label>
+            </div>
+        </div>
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "exclamation-octagon" %} Danger zone</div>
+        <div class="ac-note ac-note--danger">
+            {% bi "exclamation-octagon" %}
+            <span>
+                <strong>Cycling the season deletes every mortal player.</strong>
+                The cycle archives stats and backups first, then wipes mortals
+                and creates the next season row; a separate <em>start</em>
+                reopens the game. Both require your password and a typed
+                confirmation.
+            </span>
+        </div>
+        <form id="dangerForm" onsubmit="return false;">
+            <div class="row g-2 align-items-end">
+                <div class="col-12 col-sm-4">
+                    <label class="ac-label" for="dangerPassword">Password</label>
+                    <input class="ac-field" id="dangerPassword" type="password"
+                           autocomplete="current-password">
+                </div>
+                <div class="col-12 col-sm-4">
+                    <label class="ac-label" for="dangerConfirm">
+                        Type <span class="mono" id="confirmWord">cycle</span> to confirm
+                    </label>
+                    <input class="ac-field" id="dangerConfirm" type="text"
+                           autocomplete="off" autocapitalize="none">
+                </div>
+                <div class="col-12 col-sm-auto">
+{% if game_state_normal %}
+                    <button class="ac-btn ac-btn--danger" id="cycleBtn" type="button" data-danger="cycle">
+                        {% bi "arrow-repeat" %} Cycle season
+                    </button>
+{% elif game_state_mid_cycle %}
+                    <button class="ac-btn ac-btn--ok" id="startBtn" type="button" data-danger="start">
+                        {% bi "play-circle" %} Start season
+                    </button>
+{% else %}
+                    <span class="ac-pill ac-pill--muted">unavailable in this game state</span>
+{% endif %}
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="ac-note d-none" id="queueNote" aria-live="polite">
+        <span id="queueNoteText"></span>
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "clock-history" %} Recent commands</div>
+{% if recent_tasks %}
+        <div class="ac-rows">
+{% for task in recent_tasks %}
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "terminal" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title">{{ task.get_command_display }}</div>
+                    <div class="ac-row__meta">
+                        <span>{% bi "person" %} {{ task.actor_name }}</span>
+                        <span>
+                            {% bi "clock" %}
+                            <time datetime="{{ task.created_at|date:'c' }}">{{ task.created_at|naturaltime }}</time>
+                        </span>
+{% if task.result %}
+                        <span class="mono">{{ task.result }}</span>
+{% endif %}
+                    </div>
+                </div>
+                <div class="ac-row__side">
+{% if task.status == "pending" %}
+                    <span class="ac-pill ac-pill--warn ac-pill--live">pending</span>
+                    <button class="ac-btn" type="button" data-cancel-task="{{ task.id }}">
+                        {% bi "x-circle" %} Cancel
+                    </button>
+{% elif task.status == "done" %}
+                    <span class="ac-pill ac-pill--ok">done</span>
+{% elif task.status == "cancelled" %}
+                    <span class="ac-pill ac-pill--muted">cancelled</span>
+{% else %}
+                    <span class="ac-pill ac-pill--danger">error</span>
+{% endif %}
+                </div>
+            </div>
+{% endfor %}
+        </div>
+{% else %}
+        <div class="ac-empty">
+            {% bi "terminal" %}
+            <span>No season commands have been queued yet.</span>
+        </div>
+{% endif %}
+    </div>
+
+</div>
+{% include "partials/webadmin_js.html" %}
+<script>
+(function () {
+    "use strict";
+
+    const queue = window.WebAdminQueue;
+    const runUrl = "{% url 'season_console_run' %}";
+    const note = document.getElementById("queueNote");
+    const noteText = document.getElementById("queueNoteText");
+
+    function showNote(text, kind) {
+        note.className = "ac-note" + (kind ? " ac-note--" + kind : "");
+        noteText.textContent = text;
+    }
+
+    function watchTask(taskId) {
+        showNote("Queued (#" + taskId + ") - waiting for the game's next minute pulse...", "");
+        queue.watch(taskId, function (data, stale) {
+            if (data.status === "pending" && stale) {
+                showNote("Still pending (#" + taskId + ") - the game may be down. " +
+                    "The command stays queued and runs when the game returns.", "warn");
+            }
+        }, function (data) {
+            if (data.status === "done") {
+                showNote("Done: " + (data.result || "command executed."), "ok");
+                setTimeout(function () { window.location.reload(); }, 1500);
+            } else {
+                showNote((data.status === "cancelled" ? "Cancelled: " : "Failed: ") +
+                    (data.result || "see recent commands."), "danger");
+            }
+        });
+    }
+
+    function run(params, onRejected) {
+        queue.post(runUrl, params).then(function (r) {
+            if (r.status === 200 && r.data.queued) {
+                watchTask(r.data.task_id);
+            } else {
+                showNote("Rejected: " + (r.data.message || ("HTTP " + r.status)), "danger");
+                if (onRejected) { onRejected(); }
+            }
+        }).catch(function () {
+            showNote("Network error - nothing was queued.", "danger");
+            if (onRejected) { onRejected(); }
+        });
+    }
+
+    // Prefill the datetime-local input from the season's ISO expiration,
+    // rendered in the viewer's local timezone.
+    const expirationInput = document.getElementById("expirationInput");
+    (function prefill() {
+        const iso = expirationInput.dataset.iso;
+        if (!iso) { return; }
+        const d = new Date(iso);
+        const pad = function (n) { return String(n).padStart(2, "0"); };
+        expirationInput.value = d.getFullYear() + "-" + pad(d.getMonth() + 1) +
+            "-" + pad(d.getDate()) + "T" + pad(d.getHours()) + ":" +
+            pad(d.getMinutes());
+    })();
+
+    document.getElementById("expirationForm").addEventListener("submit", function () {
+        const value = expirationInput.value;
+        if (!value) {
+            showNote("Pick a date and time first.", "warn");
+            return;
+        }
+        // datetime-local is naive browser-local time; send UTC ISO.
+        run({ action: "set_expiration", expiration: new Date(value).toISOString() });
+    });
+
+    document.getElementById("autoCycleSwitch").addEventListener("change", function () {
+        run(
+            { action: "set_auto_cycle", enabled: this.checked ? "1" : "0" },
+            function () { /* revert the switch on rejection */
+                const sw = document.getElementById("autoCycleSwitch");
+                sw.checked = !sw.checked;
+            }
+        );
+    });
+
+    document.querySelectorAll("[data-danger]").forEach(function (btn) {
+        document.getElementById("confirmWord").textContent = btn.dataset.danger;
+        btn.addEventListener("click", function () {
+            const action = btn.dataset.danger;
+            const passwordEl = document.getElementById("dangerPassword");
+            const confirmEl = document.getElementById("dangerConfirm");
+            if (!passwordEl.value) {
+                showNote("Password is required.", "warn");
+                return;
+            }
+            if (confirmEl.value.trim().toLowerCase() !== action) {
+                showNote('Type "' + action + '" in the confirmation box first.', "warn");
+                return;
+            }
+            btn.disabled = true;
+            const params = {
+                action: action,
+                password: passwordEl.value,
+                confirm: confirmEl.value,
+            };
+            passwordEl.value = "";
+            confirmEl.value = "";
+            run(params, function () { btn.disabled = false; });
+        });
+    });
+
+    document.querySelectorAll("[data-cancel-task]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+            btn.disabled = true;
+            queue.cancel(btn.dataset.cancelTask).then(function (r) {
+                if (r.data.cancelled) {
+                    showNote("Cancelled #" + btn.dataset.cancelTask + ".", "ok");
+                    setTimeout(function () { window.location.reload(); }, 1000);
+                } else {
+                    showNote("Too late to cancel - the game already claimed it.", "warn");
+                }
+            });
+        });
+    });
+})();
+</script>
+{% endblock content %}

--- a/apps/seasons/urls.py
+++ b/apps/seasons/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
 
+from .views.console import SeasonActionView, SeasonConsoleView
 from .views.current import CurrentSeasonView
 from .views.season import SeasonView
 
 
 urlpatterns = [
     path("", CurrentSeasonView.as_view(), name="current_season"),
+    path("console/", SeasonConsoleView.as_view(), name="season_console"),
+    path(
+        "console/run/",
+        SeasonActionView.as_view(),
+        name="season_console_run",
+    ),
     path("<int:season_id>/", SeasonView.as_view(), name="season"),
 ]

--- a/apps/seasons/views/console.py
+++ b/apps/seasons/views/console.py
@@ -1,0 +1,145 @@
+"""God-gated season console.
+
+Season state (`seasons` table) is loaded by the game at boot only and held in
+memory, so mutations here never write the table directly — every action
+enqueues a `web_admin_queue` command the game executes itself (see
+`docs/web_bridge_contracts.md` in ishar-mud). `cycle`/`start` require
+password re-auth plus a typed confirmation word: a season cycle deletes every
+mortal player.
+"""
+from datetime import timedelta
+
+from django.http import JsonResponse
+from django.utils.dateparse import parse_datetime
+from django.utils.timezone import is_aware, now
+from django.views.generic.base import TemplateView, View
+
+from apps.core.models.webadmin import WebAdminCommand, WebAdminTask
+from apps.core.utils import webadmin
+from apps.core.utils.staff import staff_name
+from apps.core.views.mixins import GodRequiredMixin, NeverCacheMixin
+
+from ..utils.current import get_current_season
+
+
+# `seasons.game_state` values — the game's enum game_state_t (constants.h).
+GAME_STATES = {
+    0: "Normal",
+    1: "Season cycle (awaiting start)",
+    2: "Maintenance",
+    3: "Open beta",
+    4: "Closed beta",
+}
+
+# The automatic season-end countdown events (game-fired; display only here).
+SEASON_END_LADDER = (
+    (28, "Rymaras' Echo"),
+    (21, "The Comet's Wake"),
+    (14, "Twilight of Titans"),
+    (7, "Saorin's Reckoning"),
+)
+
+EXPIRATION_MAX_DAYS = 366
+
+
+class SeasonConsoleView(GodRequiredMixin, NeverCacheMixin, TemplateView):
+    """Render the season console. God-only (GodRequiredMixin -> 404)."""
+
+    template_name = "season_console.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        season = get_current_season()
+        context["season"] = season
+        context["game_state_label"] = GAME_STATES.get(
+            season.game_state, f"Unknown ({season.game_state})"
+        )
+        context["game_state_normal"] = season.game_state == 0
+        context["game_state_mid_cycle"] = season.game_state == 1
+        context["season_end_ladder"] = [
+            {
+                "days": days,
+                "name": name,
+                "when": season.expiration_date - timedelta(days=days),
+            }
+            for days, name in SEASON_END_LADDER
+        ]
+        context["recent_tasks"] = WebAdminTask.objects.filter(
+            command__in=(
+                WebAdminCommand.SEASON_SET_EXPIRATION,
+                WebAdminCommand.SEASON_SET_AUTO_CYCLE,
+                WebAdminCommand.SEASON_CYCLE,
+                WebAdminCommand.SEASON_START,
+            )
+        )[:10]
+        return context
+
+
+class SeasonActionView(GodRequiredMixin, NeverCacheMixin, View):
+    """POST-only: enqueue a season command. `set_*` need God + CSRF;
+    `cycle`/`start` additionally require password re-auth and a typed
+    confirmation word, validated server-side."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        action = request.POST.get("action", "")
+
+        if action == "set_expiration":
+            raw = request.POST.get("expiration", "")
+            when = parse_datetime(raw) if raw else None
+            if when is None or not is_aware(when):
+                return JsonResponse(
+                    {"message": "Expiration must be an ISO datetime with timezone."},
+                    status=400,
+                )
+            current = now()
+            if when <= current:
+                return JsonResponse(
+                    {"message": "Expiration must be in the future."}, status=400
+                )
+            if when > current + timedelta(days=EXPIRATION_MAX_DAYS):
+                return JsonResponse(
+                    {"message": "Expiration must be within a year."}, status=400
+                )
+            command = WebAdminCommand.SEASON_SET_EXPIRATION
+            # RFC-3339 with explicit offset, as the game-side validator expects.
+            payload = {"expiration_date": when.isoformat()}
+
+        elif action == "set_auto_cycle":
+            enabled = request.POST.get("enabled", "")
+            if enabled not in ("0", "1"):
+                return JsonResponse({"message": "Bad auto-cycle value."}, status=400)
+            command = WebAdminCommand.SEASON_SET_AUTO_CYCLE
+            payload = {"enabled": enabled == "1"}
+
+        elif action in ("cycle", "start"):
+            # Re-auth: password re-entry on the request itself, deploy-style.
+            password = request.POST.get("password", "")
+            if not password or not request.user.check_password(password):
+                return JsonResponse(
+                    {"message": "Re-authentication failed."}, status=403
+                )
+            # Typed confirmation, validated server-side: cycling deletes
+            # every mortal player.
+            if request.POST.get("confirm", "").strip().lower() != action:
+                return JsonResponse(
+                    {"message": f'Type "{action}" to confirm.'}, status=400
+                )
+            command = (
+                WebAdminCommand.SEASON_CYCLE
+                if action == "cycle"
+                else WebAdminCommand.SEASON_START
+            )
+            payload = {}
+
+        else:
+            return JsonResponse({"message": "Unknown action."}, status=400)
+
+        task = webadmin.enqueue(
+            command=command,
+            payload=payload,
+            actor_account=request.user.account_id,
+            actor_name=staff_name(request.user),
+        )
+        return JsonResponse({"queued": True, "task_id": task.id})

--- a/urls.py
+++ b/urls.py
@@ -9,6 +9,7 @@ from django.views.generic import RedirectView
 from apps.core.api.routers import api_router
 from apps.core.sitemaps import StaticViewSitemap
 from apps.core.views import ErrorView
+from apps.core.views.webadmin import WebAdminCancelView, WebAdminStatusView
 
 
 sitemaps = {
@@ -40,6 +41,16 @@ urlpatterns = [
     path("patches/", include("apps.patches.urls"), name="patches"),
     path("player/", include("apps.players.urls"), name="player"),
     path("portal/", include("apps.accounts.urls"), name="portal"),
+    path(
+        "portal/queue/status/",
+        WebAdminStatusView.as_view(),
+        name="webadmin_status",
+    ),
+    path(
+        "portal/queue/cancel/",
+        WebAdminCancelView.as_view(),
+        name="webadmin_cancel",
+    ),
     path("season/", include("apps.seasons.urls"), name="season"),
     path("wiki/", RedirectView.as_view(url=settings.WIKI_URL), name="wiki"),
 ]


### PR DESCRIPTION
Follow-up to #86 (merged): the two staff consoles on the new `web_admin_queue` command outbox, plus the who's-online badge de-dup. Closes the web half of #80 and #81. **Depends on isharmud/ishar-mud#1775 deploying first** — the game creates the queue table at boot and executes the commands.

## Who's-online badge (`f15c721`)

The nav/portal `PLAYERS_ONLINE` badge still showed 0 after #86's who-page fix because the `players_online` context processor carried its own copy of the old broken filter. The online test now lives once on `PlayerBaseManager.online()`, shared by the who page, the badge, and the `who` management command. When presence lands (isharmud/ishar-mud#1771 → #82), only that method changes.

## Consoles (`ab58205`)

Neither console writes `global_event`/`seasons` directly — the game loads those at boot, so every action enqueues a `web_admin_queue` row the game executes on its next minute pulse, then the page polls status/result back.

- **Shared plumbing (apps/core)**: `WebAdminTask` managed=False model + no-DDL migration, `enqueue`/`cancel` service (transactional, explicit `created_at`), Eternal-gated `portal/queue/status|cancel` endpoints (season rows God-guarded on cancel), shared JS partial (CSRF POST + poll loop, textContent-only), `staff_name` moved from feedback to core for shared actor attribution.
- **Events console** `/events/console/` (Eternal+): start-or-extend with duration picker (mirroring `cmd_event`'s units, bounded 1 min–30 days), end buttons on active events, recent-command strip with cancel-while-pending and a "game may be down — command stays queued" hint. `EventType` was stale at 10 entries — the game has 14; ids 10–13 (the automatic season-end countdown events) are listed but not web-startable. Also fixes the dead `is_luck` reference on the public events page.
- **Season console** `/season/console/` (God): current-season panel, season-end event ladder, live expiration editor (datetime-local → UTC ISO; game persists via its new `save_season_expiration()`), auto-cycle toggle, and a danger zone where cycle/start require password re-auth **plus** a server-validated typed confirmation — cycling deletes every mortal player.
- **Admin hardening**: `GlobalEvent` admin is now read-only (admin writes silently diverge from game memory until reboot; the console is the write path).
- Both tools wired into the Portal dropdown + portal cards.

## Verification

`py_compile`; full app-graph import under stub settings with clean system checks; all new URL names reverse; templates parse; `node --check` on every extracted script; headless-Chromium screenshots at 1280 px and 390 px with `scrollWidth == viewport` (mobile gate — one real bug caught and fixed there: the danger note needed the `.ac-note` icon+body markup). **Not runtime-verified**: the queue round-trip needs the game side deployed; rehearse `season_cycle` in the devcontainer before trusting the button on prod.

Relates to #80, #81, #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mh1C4q1vQ3vAhcJ1Q89mnP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mh1C4q1vQ3vAhcJ1Q89mnP)_