### PR TITLE
Helptab overhaul: live re-parse, deterministic search, DB-driven skill pages

### DIFF
--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -156,6 +156,12 @@
                                         All Topics
                                     </a>
                                 </li>
+                                <li class="nav-item" title="Skills &amp; Spells">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'skills' %}#skills">
+                                        {% bi "mortarboard" %}
+                                        Skills &amp; Spells
+                                    </a>
+                                </li>
                                 <li class="nav-item" title="Basics">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'help_page' help_topic='MUD Basics' %}#topic">
                                         {% bi "collection-play" %}

--- a/apps/help/templates/help_page.html
+++ b/apps/help/templates/help_page.html
@@ -116,6 +116,18 @@
     </div>
 {% endif %}
 
+    <!-- Did you mean (shown on a 404 with near-matches) -->
+{% if suggestions %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "signpost-split" %} Did you mean</div>
+        <nav class="ac-filter" aria-label="Suggested topics">
+{% for label, url in suggestions %}
+            <a class="ac-chip" href="{{ url }}">{{ label }}</a>
+{% endfor %}
+        </nav>
+    </div>
+{% endif %}
+
     <!-- Search -->
     <div class="ac-panel">
         <div class="ac-panel__h">{% bi "search" %} Search Help</div>

--- a/apps/help/utils/__init__.py
+++ b/apps/help/utils/__init__.py
@@ -1,1 +1,1 @@
-from .helptab import HelpTab
+from .helptab import HelpTab, get_helptab

--- a/apps/help/utils/helptab.py
+++ b/apps/help/utils/helptab.py
@@ -1,6 +1,7 @@
 from logging import getLogger
 from pathlib import Path
 import re
+import threading
 
 from django.conf import settings
 from django.urls import reverse
@@ -362,8 +363,22 @@ class HelpTab:
         # Parse "helptab" sections into dictionary of help topic objects.
         topics = {}
 
+        # Parse report: silently-dropped topics are a recurring "why is X
+        # missing?" source (see #51/#84), so tally every skip reason and log a
+        # one-line summary — a topic that never shows up is now diagnosable.
+        counts = {
+            "sections": 0, "kept": 0, "unsplittable": 0,
+            "immortal": 0, "not_playing": 0, "headerless": 0,
+        }
+        dropped_playing = []  # (level, first header line) for non-"32 " drops
+
         # Iterate each "helptab" section in the list provided.
         for section in sections:
+
+            # Ignore blank trailing chunks left by the section split.
+            if not section.strip():
+                continue
+            counts["sections"] += 1
 
             # Sections contain a header, and a body, separated by "*".
             try:
@@ -371,7 +386,8 @@ class HelpTab:
 
             # Log any skipped "helptab" sections which could not be split.
             except ValueError as val_err:
-                logger.error(f"Skipping: {section.__repr__()}")
+                counts["unsplittable"] += 1
+                logger.error(f"Skipping unsplittable section: {section.__repr__()}")
                 logger.exception(val_err)
                 continue  # Next section.
 
@@ -379,82 +395,194 @@ class HelpTab:
             finally:
                 help_topic = None
 
-            # First header line is player level to which the section applies.
+            # First header line is the player level the section applies to.
             header_lines = header.split("\n")
-            topic_level = int(header_lines[0])
+            try:
+                topic_level = int(header_lines[0])
+            except (ValueError, IndexError):
+                counts["headerless"] += 1
+                logger.error(f"Skipping section with no level: {header.__repr__()}")
+                continue
 
             # Only consider helptab sections that are meant for mortal players.
-            if topic_level < settings.MIN_IMMORTAL_LEVEL:
+            if topic_level >= settings.MIN_IMMORTAL_LEVEL:
+                counts["immortal"] += 1
+                continue
 
-                # Only consider helptab sections for "32 " ("Playing") state.
-                first_line = header_lines[1].strip()
-                if first_line.startswith("32 "):
+            # Only consider helptab sections for "32 " ("Playing") state.
+            first_line = header_lines[1].strip() if len(header_lines) > 1 else ""
+            if not first_line.startswith("32 "):
+                counts["not_playing"] += 1
+                if first_line:
+                    dropped_playing.append((topic_level, first_line))
+                continue
 
-                    # Use anything after first space (after "32 ") as name.
-                    name = " ".join(first_line.split(" ")[1:]).strip()
+            # Use anything after first space (after "32 ") as name.
+            name = " ".join(first_line.split(" ")[1:]).strip()
 
-                    # Create a help topic object using the level and name.
-                    help_topic = self.HelpTopic()
-                    help_topic.level = topic_level
-                    help_topic.name = name
+            # Create a help topic object using the level and name.
+            help_topic = self.HelpTopic()
+            help_topic.level = topic_level
+            help_topic.name = name
 
-                    # Parse the rest of the help topic header, to get aliases.
-                    help_topic.parse_header(header_lines=header_lines[2:])
+            # Parse the rest of the help topic header, to get aliases.
+            help_topic.parse_header(header_lines=header_lines[2:])
 
-                    # Parse the content (below "*") within the topic section.
-                    help_topic.parse_content(content=content)
+            # Parse the content (below "*") within the topic section.
+            help_topic.parse_content(content=content)
 
             # Append newly created help topic object to list of help topics.
-            if help_topic is not None and help_topic.name:
+            if help_topic.name:
                 topics[help_topic.name] = help_topic
+                counts["kept"] += 1
+
+        # Emit the parse report so silently-dropped topics are diagnosable.
+        logger.info(
+            "helptab parse: %d topics kept from %d sections "
+            "(%d immortal, %d non-playing, %d unsplittable, %d headerless)",
+            counts["kept"], counts["sections"], counts["immortal"],
+            counts["not_playing"], counts["unsplittable"], counts["headerless"],
+        )
+        if dropped_playing:
+            logger.debug(
+                "helptab non-playing drops (level, first line): %s",
+                "; ".join(f"[{lvl}] {line}" for lvl, line in dropped_playing[:50]),
+            )
 
         # Return complete list of help topics parsed from "helptab" sections.
         return topics
 
     def search(self, search_name: str) -> dict[str:HelpTopic,]:
-        # Search help topic names and aliases for a string.
+        # Search help topic names and aliases via a deterministic ladder.
+        #
+        # The old search was a single substring sweep over every name and
+        # alias, so "heal" dragged in "Score" (whose "Health" alias contains
+        # "heal") and results had no relevance order. Instead, sort every
+        # topic into the *best* tier it matches and return the first non-empty
+        # tier, so a cleaner match always wins over a looser one. Name matches
+        # rank above alias matches, then exact > prefix > substring within each:
+        #
+        #   1. exact topic name      (case-insensitive)
+        #   2. exact alias           (case-insensitive)
+        #   3. topic-name prefix
+        #   4. topic-name substring
+        #   5. alias prefix
+        #   6. alias substring
+        #
+        # Name-before-alias is what fully fixes "heal" -> "Score": "Health" is
+        # a *prefix* of "heal", so a name/alias-blind ladder still surfaces
+        # Score at the alias tier; ranking name-substring (4) above alias-prefix
+        # (5) returns the actual "Spell Heal*" topics and drops Score entirely.
+        # Verified against the live helptab (see the PR / decisions.md).
+        query = (search_name or "").strip()
+        if not query:
+            return {}
+        q = query.casefold()
 
-        # Immediately return exact match.
-        if search_name in self.help_topics:
-            return {search_name: self.help_topics[search_name]}
-
-        # Set a variety of formats of the search string.
-        fmts = (
-            search_name.title(),
-            search_name.lower(),
-            search_name.upper(),
-            search_name.strip(),
-        )
-
-        # Iterate each help topic object to search their names and aliases.
-        search_results = {}
+        tiers = ({}, {}, {}, {}, {}, {})
+        exact_name, exact_alias, name_pfx, name_sub, alias_pfx, alias_sub = tiers
         for topic_name, topic in self.help_topics.items():
+            name_cf = topic_name.casefold()
+            aliases_cf = [alias.casefold() for alias in topic.aliases]
 
-            # Return direct alias match.
-            if search_name in topic.aliases:
-                return {topic_name: topic}
+            if name_cf == q:
+                exact_name[topic_name] = topic
+            elif q in aliases_cf:
+                exact_alias[topic_name] = topic
+            elif name_cf.startswith(q):
+                name_pfx[topic_name] = topic
+            elif q in name_cf:
+                name_sub[topic_name] = topic
+            elif any(alias.startswith(q) for alias in aliases_cf):
+                alias_pfx[topic_name] = topic
+            elif any(q in alias for alias in aliases_cf):
+                alias_sub[topic_name] = topic
 
-            # Iterate variety of formats of the string.
-            do_add = False
-            for name_fmt in fmts:
+        # Return the strongest non-empty tier, name-sorted for stable output.
+        for tier in tiers:
+            if tier:
+                return dict(sorted(tier.items()))
+        return {}
 
-                # Check if the topic name contains the string.
-                if name_fmt in topic_name:
-                    do_add = True
+    def suggest(self, search_name: str, limit: int = 6) -> list[str]:
+        # "Did you mean" fallback for a 404: closest topic names/aliases.
+        #
+        # difflib (stdlib) gives fuzzy suggestions for typos the prefix/
+        # substring tiers miss ("metero" -> "Meteor Swarm"), with no new
+        # dependency. Match against names *and* aliases but only ever suggest
+        # canonical topic names.
+        from difflib import get_close_matches
 
-                # Check for any alias exact matches.
-                elif name_fmt in topic.aliases:
-                    do_add = True
+        query = (search_name or "").strip().casefold()
+        if not query:
+            return []
 
-                # Check if the topic aliases contain the string.
-                else:
-                    for alias in topic.aliases:
-                        if name_fmt in alias:
-                            do_add = True
+        # Map every searchable handle (name or alias, folded) to its topic.
+        handles: dict[str, str] = {}
+        for topic_name, topic in self.help_topics.items():
+            handles.setdefault(topic_name.casefold(), topic_name)
+            for alias in topic.aliases:
+                handles.setdefault(alias.casefold(), topic_name)
 
-            #  Add the help topic to the search results, if necessary.
-            if do_add is True:
-                search_results[topic_name] = topic
+        # Ordered, de-duplicated topic names from the closest handles.
+        suggestions: list[str] = []
+        for handle in get_close_matches(query, handles.keys(), n=limit * 2, cutoff=0.6):
+            topic_name = handles[handle]
+            if topic_name not in suggestions:
+                suggestions.append(topic_name)
+            if len(suggestions) >= limit:
+                break
+        return suggestions
 
-        # Return the dictionary of any found help topics.
-        return search_results
+
+# Module-level cache so the helptab is parsed once and re-parsed only when the
+# file changes. The file is a live mount from the game, so the old
+# ``HELPTAB = HelpTab()`` at import pinned the parse to Daphne start — helptab
+# edits only appeared after the next web deploy. Now each request re-stats the
+# file and re-parses on mtime change, keeping the last good parse if a re-parse
+# ever fails (a bad edit degrades to stale, never to a 500).
+_helptab_lock = threading.Lock()
+_helptab_cache = {"helptab": None, "mtime": None, "path": None}
+
+
+def get_helptab(path: (Path, str) = None) -> HelpTab:
+    """Return a cached HelpTab, re-parsing when the file's mtime changes."""
+    if path is None:
+        path = settings.HELPTAB
+    path = Path(path)
+
+    # Stat the file; if it's momentarily unreadable (e.g. mid-deploy remount),
+    # serve the last good parse rather than erroring.
+    try:
+        mtime = path.stat().st_mtime
+    except OSError as os_err:
+        with _helptab_lock:
+            if _helptab_cache["helptab"] is not None:
+                logger.error("Could not stat helptab %s: %s", path, os_err)
+                return _helptab_cache["helptab"]
+        raise
+
+    with _helptab_lock:
+        cached = _helptab_cache["helptab"]
+        if (
+            cached is not None
+            and _helptab_cache["mtime"] == mtime
+            and _helptab_cache["path"] == path
+        ):
+            return cached
+
+        # Parse under the lock so a burst of concurrent requests doesn't each
+        # re-parse the same ~550KB file; the parse is fast and help traffic is
+        # light, so serializing is cheaper than a thundering herd.
+        try:
+            parsed = HelpTab(path=path)
+        except Exception:
+            if cached is not None:
+                logger.exception(
+                    "Re-parsing helptab %s failed; serving last good parse", path
+                )
+                return cached
+            raise
+
+        _helptab_cache.update(helptab=parsed, mtime=mtime, path=path)
+        return parsed

--- a/apps/help/views.py
+++ b/apps/help/views.py
@@ -1,25 +1,31 @@
+from difflib import get_close_matches
+
 from django.contrib import messages
 from django.shortcuts import redirect
+from django.urls import reverse
 from django.views.generic.base import TemplateView
 
-from .utils.helptab import HelpTab
+from apps.skills.utils import find_skill_by_name
 
-
-HELPTAB = HelpTab()
+from .utils.helptab import get_helptab
 
 
 class HelpView(TemplateView):
     """Help view."""
 
     template_name = "help_page.html"
-    helptab = HELPTAB
+    helptab = None
     help_topic = None
     help_topics = {}
     http_method_names = ("get", "post")
     status = 200
+    suggestions = ()
 
     def setup(self, request, *args, **kwargs):
-        # Gather help topics from "helptab" file.
+        # Re-parse the helptab on demand — it is a live mount from the game,
+        # so get_helptab() serves the current file, not the parse pinned at
+        # process start.
+        self.helptab = get_helptab()
         self.help_topics = self.helptab.help_topics
         return super().setup(request, *args, **kwargs)
 
@@ -40,6 +46,14 @@ class HelpView(TemplateView):
                 if len(search_results) == 1:
                     search_result = next(iter(search_results.values()))
 
+                    # Deprecated per-spell helptab entries are superseded by the
+                    # live skill page: send "Spell X" topics to /skills/X/ when
+                    # that skill exists, rather than render stale text.
+                    if search_result.is_spell:
+                        skill = find_skill_by_name(search_result.display_name)
+                        if skill is not None:
+                            return redirect(to=skill.get_absolute_url())
+
                     # Return exact name match directly.
                     if help_topic == search_result.name:
                         self.help_topic = search_result
@@ -51,9 +65,16 @@ class HelpView(TemplateView):
                 # Set help topics to the search results.
                 self.help_topics = search_results
 
-            # Set response code and tell user if no search results were found.
+            # No helptab topic matched. Mirror the game's `help` fallback
+            # (ishar-mud src/dbase/help.c cmd_help): try a skill/spell name
+            # next, then offer "did you mean" suggestions.
             else:
+                skill = find_skill_by_name(help_topic)
+                if skill is not None:
+                    return redirect(to=skill.get_absolute_url())
+
                 self.status = 404
+                self.suggestions = self._suggest(help_topic)
                 messages.error(
                     request=request,
                     message="Sorry, but no such help topic could be found.",
@@ -61,11 +82,46 @@ class HelpView(TemplateView):
 
         return super().dispatch(request, *args, **kwargs)
 
+    def _suggest(self, query: str) -> list:
+        # "Did you mean" for a 404: closest helptab topics *and* skill names,
+        # each as a (label, url) pair so the template can route both kinds.
+        q = (query or "").strip().casefold()
+        if not q:
+            return []
+
+        pairs, seen = [], set()
+
+        # Helptab topic suggestions (link to their help pages).
+        for name in self.helptab.suggest(query, limit=6):
+            topic = self.help_topics.get(name)
+            if topic is not None and name not in seen:
+                pairs.append((name, topic.get_absolute_url()))
+                seen.add(name)
+
+        # Skill-name suggestions (link to their skill pages) — the way
+        # skill-only topics like "Earthquake" become findable from Help.
+        from apps.skills.models import Skill
+
+        folded = {
+            name.casefold(): name
+            for name in Skill.objects.filter(
+                skill_name__isnull=False
+            ).values_list("skill_name", flat=True)
+        }
+        for match in get_close_matches(q, folded.keys(), n=6, cutoff=0.6):
+            name = folded[match]
+            if name not in seen:
+                pairs.append((name, reverse("skill_page", args=(name,)) + "#skill"))
+                seen.add(name)
+
+        return pairs[:8]
+
     def get_context_data(self, **kwargs):
         # Include search form, help topics, and any chosen topic in context.
         context = super().get_context_data(**kwargs)
         context["help_topics"] = self.help_topics
         context["help_topic"] = self.help_topic
+        context["suggestions"] = self.suggestions
         return context
 
     def render_to_response(self, context, **response_kwargs):
@@ -84,16 +140,17 @@ class HelpView(TemplateView):
 class WorldView(TemplateView):
     """World (/world/) view."""
 
-    helptab = HELPTAB
     template_name = "world.html"
     http_method_names = ("get",)
 
     def get_context_data(self, **kwargs):
         # Include sorted "areas" context of "Area " topics from "helptab" file.
+        # Filter topics directly rather than via search() — the search ladder
+        # optimizes for relevance, not "give me every Area topic".
         context = super().get_context_data(**kwargs)
-        context["areas"] = []
-        for topic_name, topic in self.helptab.search("Area ").items():
-            if topic.is_area is True:
-                context["areas"].append(topic)
-        context["areas"] = sorted(context["areas"])
+        areas = [
+            topic for topic in get_helptab().help_topics.values()
+            if topic.is_area
+        ]
+        context["areas"] = sorted(areas)
         return context

--- a/apps/skills/models/force.py
+++ b/apps/skills/models/force.py
@@ -20,6 +20,13 @@ class Force(models.Model):
         help_text="Name of the force.",
         verbose_name="Force Name",
     )
+    display_name = models.CharField(
+        max_length=100,
+        blank=True,
+        null=True,
+        help_text="Friendly display name of the force.",
+        verbose_name="Display Name",
+    )
 
     class Meta:
         managed = False
@@ -31,7 +38,7 @@ class Force(models.Model):
         return f"{self.__class__.__name__}: {self.__str__()} ({self.pk})"
 
     def __str__(self) -> str:
-        return self.force_name
+        return self.display_name or self.force_name
 
     def natural_key(self) -> str:
         """Natural key by force name."""

--- a/apps/skills/models/skill.py
+++ b/apps/skills/models/skill.py
@@ -1,6 +1,9 @@
 from django.db import models
+from django.urls import reverse
+from django.utils.functional import cached_property
 
 from apps.core.models.textarea import NoStripTextareaField
+from apps.skills.utils import SKILL_TYPE_NAMES, stat_name, strip_color
 
 from .type.position import PlayerPosition
 from .type.save import SkillSaveType
@@ -208,3 +211,102 @@ class Skill(models.Model):
     def natural_key(self) -> str:
         """Natural key by skill name or ENUM symbol."""
         return self.skill_name
+
+    def get_absolute_url(self) -> str:
+        """URL to this skill's public page (anchored)."""
+        return reverse("skill_page", args=(self.skill_name,)) + "#skill"
+
+    # --- Display helpers (mirror the in-game ``skill`` command) -------------
+    # These reproduce the non-player-specific facts from display_skill_full
+    # (ishar-mud src/kernel/info.c) so the web page and the game agree.
+
+    @property
+    def type_name(self) -> str:
+        """Game-faithful skill-type label (``skill_types[]``)."""
+        return SKILL_TYPE_NAMES.get(self.skill_type, "")
+
+    @property
+    def is_spell(self) -> bool:
+        return self.skill_type == SkillType.SPELL
+
+    @property
+    def is_skill(self) -> bool:
+        return self.skill_type == SkillType.SKILL
+
+    @property
+    def description_display(self) -> str:
+        """Description with game color codes stripped for web display."""
+        return strip_color(self.description)
+
+    @property
+    def stat_pairing(self):
+        """``(stat1, stat2)`` names when the skill pairs two distinct stats,
+        else ``None`` — mirrors the 'Stat Pairing' line (skills only)."""
+        if not self.is_skill:
+            return None
+        first, second = stat_name(self.mod_stat_1), stat_name(self.mod_stat_2)
+        if first and second and first != second:
+            return (first, second)
+        return None
+
+    @property
+    def cooldown_display(self) -> str:
+        """Cooldown text, mirroring display_skill_full: 'N seconds' when the
+        size is 1, else 'NdM seconds'. Empty when there is no cooldown."""
+        num = self.cooldown_num or 0
+        if not num:
+            return ""
+        size = self.cooldown_size or 0
+        if size == 1:
+            return f"{num} second{'' if num == 1 else 's'}"
+        return f"{num}d{size} seconds"
+
+    @property
+    def spell_flag_names(self) -> list:
+        """Names of this skill's spell flags (via ``skills_spell_flags``)."""
+        return [
+            skill_flag.flag.name
+            for skill_flag in self.flags.select_related("flag")
+            if skill_flag.flag_id
+        ]
+
+    @cached_property
+    def _flag_haystack(self) -> str:
+        # Normalized (A-Z only) flag names joined for tolerant token checks —
+        # spell_flags.name is game-seeded and its exact casing/spacing varies.
+        import re
+
+        return " ".join(
+            re.sub(r"[^A-Z]", "", name.upper()) for name in self.spell_flag_names
+        )
+
+    @property
+    def is_quick_action(self) -> bool:
+        return "MELEE" in self._flag_haystack  # ALLOW_MELEE
+
+    @property
+    def movement_restricted(self) -> bool:
+        return "NOMOVEMENT" in self._flag_haystack
+
+    @property
+    def is_breath(self) -> bool:
+        return "BREATH" in self._flag_haystack
+
+    @property
+    def action_display(self) -> str:
+        """'Quick Action' / 'Standard Action' for skills; '' otherwise."""
+        if not self.is_skill:
+            return ""
+        return "Quick Action" if self.is_quick_action else "Standard Action"
+
+    @property
+    def command(self) -> str:
+        """The command to invoke this ability, mirroring display_skill_full."""
+        name = self.skill_name or ""
+        if self.is_spell:
+            return f"cast '{name}'"
+        if self.is_breath:
+            return f"breathe '{name}'"
+        if self.is_skill:
+            return f"action '{name}'"
+        return ""

--- a/apps/skills/templates/skill_page.html
+++ b/apps/skills/templates/skill_page.html
@@ -1,0 +1,177 @@
+{% extends "layout.html" %}
+{% load ishar %}
+{% block meta_title %}{% if skill %}{{ skill.skill_name }} - {{ WEBSITE_TITLE }} {{ skill.type_name }}{% else %}Skill Not Found - {{ WEBSITE_TITLE }}{% endif %}{% endblock meta_title %}
+{% block meta_description %}{% if skill %}{{ skill.skill_name }} is a {{ skill.type_name|lower }} in {{ WEBSITE_TITLE }}, a free online MUD. See which classes and races learn it, at what level, and its full details.{% else %}That skill could not be found in {{ WEBSITE_TITLE }}.{% endif %}{% endblock meta_description %}
+{% block meta_url %}{% if skill %}{{ skill.get_absolute_url }}{% else %}{% url 'skills' %}{% endif %}{% endblock meta_url %}
+{% block title %}{% if skill %}{{ skill.skill_name }} - {{ WEBSITE_TITLE }} {{ skill.type_name }}{% else %}Skill Not Found{% endif %}{% endblock title %}
+{% block page_heading %}{% if skill %}{{ skill.skill_name }}{% else %}Skill Not Found{% endif %}{% endblock page_heading %}
+{% block scripts %}let focusTo = 'skill'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Skills" "mortarboard" urlname="skills" anchor="skills" %}
+{% if skill %}
+    {% crumb skill.skill_name skill.is_spell|yesno:"magic,lightning-charge" anchor="skill" active=True %}
+{% else %}
+    {% crumb "Not Found" "question-circle" anchor="skill" active=True %}
+{% endif %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac">
+
+{% if skill %}
+    <header class="ac-hero" id="skill">
+        <span class="ac-hero__badge">
+{% if skill.is_spell %}{% bi "magic" %}{% elif skill.skill_type == 3 %}{% bi "hammer" %}{% else %}{% bi "lightning-charge" %}{% endif %}
+        </span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">{{ skill.skill_name }}</h2>
+{% if skill.command %}
+            <p class="ac-hero__sub">Command: <code>{{ skill.command }}</code></p>
+{% endif %}
+        </div>
+{% if skill.type_name %}
+        <div class="ac-hero__status">
+            <span class="ac-pill{% if skill.is_spell %} ac-pill--accent{% endif %}">{{ skill.type_name }}</span>
+        </div>
+{% endif %}
+    </header>
+
+    <!-- Learnable by -->
+{% if class_skills or race_skills %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "mortarboard" %} Learnable By</div>
+{% if class_skills %}
+        <div class="ac-tablewrap">
+            <table class="ac-table">
+                <thead><tr>
+                    <th scope="col">Class</th>
+                    <th class="ac-table__num" scope="col">Level</th>
+                    <th class="ac-table__num" scope="col">Max</th>
+                </tr></thead>
+                <tbody>
+{% for class_skill in class_skills %}
+                    <tr>
+                        <td>{{ class_skill.player_class }}</td>
+                        <td class="ac-table__num">{{ class_skill.min_level }}</td>
+                        <td class="ac-table__num">{{ class_skill.max_learn }}</td>
+                    </tr>
+{% endfor %}
+                </tbody>
+            </table>
+        </div>
+{% endif %}
+{% if race_skills %}
+        <div class="ac-tablewrap{% if class_skills %} mt-2{% endif %}">
+            <table class="ac-table">
+                <thead><tr>
+                    <th scope="col">Race</th>
+                    <th class="ac-table__num" scope="col">Level</th>
+                </tr></thead>
+                <tbody>
+{% for race_skill in race_skills %}
+                    <tr>
+                        <td>{{ race_skill.race.display_name|default:race_skill.race.folk_name }}</td>
+                        <td class="ac-table__num">{{ race_skill.level }}</td>
+                    </tr>
+{% endfor %}
+                </tbody>
+            </table>
+        </div>
+{% endif %}
+    </div>
+{% endif %}
+
+    <!-- Details -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "list-ul" %} Details</div>
+        <dl class="ac-kv mb-0">
+            <dt>Type</dt>
+            <dd>{{ skill.type_name }}</dd>
+{% if skill.stat_pairing %}
+            <dt>Stat Pairing</dt>
+            <dd>{{ skill.stat_pairing.0 }} / {{ skill.stat_pairing.1 }}</dd>
+{% endif %}
+{% if skill.action_display %}
+            <dt>Action</dt>
+            <dd>{{ skill.action_display }}</dd>
+{% endif %}
+{% if min_posn_display %}
+            <dt>Position</dt>
+            <dd><code>{{ min_posn_display }}</code></dd>
+{% endif %}
+{% if skill.movement_restricted %}
+            <dt>Movement</dt>
+            <dd>Restricted</dd>
+{% endif %}
+{% if save_display %}
+            <dt>Save</dt>
+            <dd><code>{{ save_display }}</code></dd>
+{% endif %}
+{% if skill.cooldown_display %}
+            <dt>Cooldown</dt>
+            <dd><code>{{ skill.cooldown_display }}</code></dd>
+{% endif %}
+{% if parent_skill %}
+            <dt>Category</dt>
+            <dd><a href="{{ parent_skill.get_absolute_url }}">{{ parent_skill.skill_name }}</a></dd>
+{% endif %}
+        </dl>
+    </div>
+
+    <!-- Forces -->
+{% if forces %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "fire" %} Forces</div>
+        <nav class="ac-filter" aria-label="Damage forces">
+{% for force in forces %}
+            <span class="ac-chip">{{ force }}</span>
+{% endfor %}
+        </nav>
+    </div>
+{% endif %}
+
+    <!-- Components -->
+{% if components %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "box-seam" %} Components</div>
+        <ul class="list-unstyled mb-0">
+{% for component in components %}
+{% if component.component_type %}
+            <li>{{ component.component_count }}&times; <code>{{ component.get_component_type_display }}</code></li>
+{% endif %}
+{% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
+    <!-- Description -->
+{% if skill.description_display %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "card-text" %} Description</div>
+        <pre class="ac-quote">{{ skill.description_display }}</pre>
+    </div>
+{% endif %}
+
+{% else %}
+    <!-- Not found -->
+    <div class="ac-empty">
+        {% bi "search" %}
+        <span>No skill named &quot;{{ query }}&quot; could be found.</span>
+    </div>
+{% if suggestions %}
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "signpost-split" %} Did you mean</div>
+        <nav class="ac-filter" aria-label="Suggested skills">
+{% for suggestion in suggestions %}
+            <a class="ac-chip" href="{% url 'skill_page' skill_name=suggestion %}#skill">{{ suggestion }}</a>
+{% endfor %}
+        </nav>
+    </div>
+{% endif %}
+    <div class="ac-note">
+        {% bi "mortarboard" %}
+        <span>Browse <a href="{% url 'skills' %}#skills">all skills &amp; spells</a> or search the <a href="{% url 'help' %}#help">help files</a>.</span>
+    </div>
+{% endif %}
+
+</div>
+{% endblock content %}

--- a/apps/skills/templates/skills.html
+++ b/apps/skills/templates/skills.html
@@ -1,0 +1,102 @@
+{% extends "layout.html" %}
+{% load ishar %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Skills &amp; Spells | MUD Abilities Guide{% endblock meta_title %}
+{% block meta_description %}Browse every skill and spell in {{ WEBSITE_TITLE }}, a free online MUD — grouped by class, with the classes, races, levels, and details for each ability.{% endblock meta_description %}
+{% block meta_url %}{% url 'skills' %}{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Skills &amp; Spells{% endblock title %}
+{% block page_heading %}{{ WEBSITE_TITLE }} Skills &amp; Spells{% endblock page_heading %}
+{% block scripts %}let focusTo = 'skills'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Skills" "mortarboard" anchor="skills" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac ac--wide">
+
+    <header class="ac-hero" id="skills">
+        <span class="ac-hero__badge">{% bi "mortarboard" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Skills &amp; Spells</h2>
+            <p class="ac-hero__sub">Every skill and spell in {{ WEBSITE_TITLE }}, grouped by class — the same facts the in-game <code>skill</code> command shows.</p>
+        </div>
+        <div class="ac-hero__status">
+            <span class="ac-pill ac-pill--accent">{{ skill_count }}</span>
+        </div>
+    </header>
+
+{% if groups %}
+    <!-- Filter + jump nav -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "search" %} Find a Skill</div>
+        <div class="ac-inputgroup">
+            <span class="ac-inputgroup__icon">{% bi "search" %}</span>
+            <input class="ac-input" type="search" id="skill-filter" autocomplete="off" aria-label="Filter skills by name" placeholder="Filter by name…">
+        </div>
+        <nav class="ac-filter mt-2" aria-label="Jump to class">
+{% for group in groups %}
+            <a class="ac-chip" href="#{{ group.id }}" data-group="{{ group.id }}">{{ group.name }} <span class="text-body-secondary">{{ group.skills|length }}</span></a>
+{% endfor %}
+        </nav>
+    </div>
+
+    <!-- Groups -->
+{% for group in groups %}
+    <div class="ac-panel" id="{{ group.id }}" data-group-panel>
+        <div class="ac-panel__h">
+            {% bi "mortarboard" %} {{ group.name }}
+            <span class="text-body-secondary" data-group-count>{{ group.skills|length }}</span>
+        </div>
+        <ul class="two-col list-unstyled mb-0">
+{% for row in group.skills %}
+            <li data-name="{{ row.skill.skill_name|lower }}" title="{{ row.skill.skill_name }}">
+                <a href="{{ row.skill.get_absolute_url }}">{{ row.skill.skill_name }}</a>{% if row.level %} <small class="text-body-secondary">Lv&nbsp;{{ row.level }}</small>{% endif %}
+            </li>
+{% endfor %}
+        </ul>
+    </div>
+{% endfor %}
+
+    <div class="ac-empty" id="skills-empty" hidden>
+        {% bi "search" %}
+        <span>No skills match your filter.</span>
+    </div>
+{% else %}
+    <div class="ac-empty">
+        {% bi "search" %}
+        <span>No skills were found.</span>
+    </div>
+{% endif %}
+
+</div>
+
+<script>
+(() => {
+    const filter = document.getElementById("skill-filter")
+    if (!filter) return
+    const panels = [...document.querySelectorAll("[data-group-panel]")]
+    const chips = [...document.querySelectorAll("[data-group]")]
+    const empty = document.getElementById("skills-empty")
+
+    filter.addEventListener("input", () => {
+        const q = filter.value.trim().toLowerCase()
+        let total = 0
+        for (const panel of panels) {
+            let shown = 0
+            for (const item of panel.querySelectorAll("li[data-name]")) {
+                const hit = !q || item.dataset.name.includes(q)
+                item.hidden = !hit
+                if (hit) shown += 1
+            }
+            panel.hidden = shown === 0
+            const count = panel.querySelector("[data-group-count]")
+            if (count) count.textContent = shown
+            total += shown
+        }
+        for (const chip of chips) {
+            const panel = document.getElementById(chip.dataset.group)
+            chip.hidden = panel ? panel.hidden : false
+        }
+        if (empty) empty.hidden = total > 0
+    })
+})()
+</script>
+{% endblock content %}

--- a/apps/skills/urls.py
+++ b/apps/skills/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import SkillDetailView, SkillIndexView
+
+
+urlpatterns = [
+    path("", SkillIndexView.as_view(), name="skills"),
+    path("<str:skill_name>/", SkillDetailView.as_view(), name="skill_page"),
+]

--- a/apps/skills/utils/__init__.py
+++ b/apps/skills/utils/__init__.py
@@ -1,0 +1,62 @@
+"""Helpers for the public skill/spell pages.
+
+Constants here mirror the game engine (ishar-mud) so the web renders the same
+facts the in-game ``skill`` command (``display_skill_full``) shows.
+"""
+import re
+
+
+# Primary stats, 0-indexed to match the game's ``statnames[]``
+# (ishar-mud src/kernel/constants.c). ``skills.mod_stat_1`` / ``mod_stat_2``
+# index into this array.
+STAT_NAMES = (
+    "Strength", "Perception", "Focus", "Agility", "Endurance", "Willpower",
+)
+
+# ``skill_type`` -> label, matching the game's ``skill_types[]`` (same file).
+# The DB column is a tinyint that ranges wider than the Django ``SkillType``
+# enum (0..3), so map the full game range for display.
+SKILL_TYPE_NAMES = {
+    0: "Passive", 1: "Skill", 2: "Spell", 3: "Craft", 4: "Enchant", 5: "Passive",
+}
+
+# Ishar in-band color codes are "@c" followed by one code character.
+_COLOR_RE = re.compile(r"@c.")
+
+
+def strip_color(text: str) -> str:
+    """Strip Ishar ``@cX`` color codes from game text for clean web display."""
+    if not text:
+        return ""
+    return _COLOR_RE.sub("", text).replace("@@", "@")
+
+
+def stat_name(index) -> str:
+    """Name of a primary stat by its 0-based index, or '' if out of range."""
+    if index is None or index < 0 or index >= len(STAT_NAMES):
+        return ""
+    return STAT_NAMES[index]
+
+
+def find_skill_by_name(query: str):
+    """Resolve a term to a Skill the way the game's ``is_skill_name`` does:
+    an exact (case-insensitive) name, else an abbreviation (name prefix) across
+    all skills — known or not. Returns a ``Skill`` or ``None``.
+    """
+    # Imported lazily to avoid a model/util import cycle.
+    from apps.skills.models import Skill
+
+    query = (query or "").strip()
+    if not query:
+        return None
+
+    exact = Skill.objects.filter(skill_name__iexact=query).first()
+    if exact is not None:
+        return exact
+
+    # Abbreviation: the query is a prefix of the skill name (isabbrstring).
+    return (
+        Skill.objects.filter(skill_name__istartswith=query)
+        .order_by("skill_name")
+        .first()
+    )

--- a/apps/skills/views.py
+++ b/apps/skills/views.py
@@ -1,0 +1,166 @@
+from difflib import get_close_matches
+
+from django.shortcuts import redirect
+from django.views.generic.base import TemplateView
+
+from apps.classes.models.skill import ClassSkill
+from apps.races.models.skill import RaceSkill
+
+from .models import Skill
+from .utils import find_skill_by_name
+
+
+class SkillIndexView(TemplateView):
+    """Public, searchable index of every skill/spell, grouped by class."""
+
+    template_name = "skills.html"
+    http_method_names = ("get",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # Group learnable skills under each playable class, ordered by the
+        # level a member of that class first learns them.
+        class_skills = (
+            ClassSkill.objects
+            .select_related("skill", "player_class")
+            .filter(player_class__is_playable=True, skill__skill_name__isnull=False)
+            .order_by("player_class__class_name", "min_level", "skill__skill_name")
+        )
+        groups: dict = {}
+        shown_ids: set = set()
+        for class_skill in class_skills:
+            group = groups.setdefault(
+                class_skill.player_class_id,
+                {
+                    "id": f"class-{class_skill.player_class_id}",
+                    "name": str(class_skill.player_class),
+                    "skills": [],
+                },
+            )
+            group["skills"].append(
+                {"skill": class_skill.skill, "level": class_skill.min_level}
+            )
+            shown_ids.add(class_skill.skill_id)
+
+        class_groups = sorted(groups.values(), key=lambda g: g["name"].lower())
+
+        # A "Racial" bucket for skills a race grants but no playable class does,
+        # so racial abilities are still discoverable by browsing.
+        class_skill_ids = set(
+            ClassSkill.objects.values_list("skill_id", flat=True)
+        )
+        racial_ids = (
+            set(RaceSkill.objects.values_list("skill_id", flat=True))
+            - class_skill_ids
+        )
+        racial_skills = list(
+            Skill.objects
+            .filter(id__in=racial_ids, skill_name__isnull=False)
+            .order_by("skill_name")
+        )
+        if racial_skills:
+            class_groups.append(
+                {
+                    "id": "racial",
+                    "name": "Racial",
+                    "skills": [{"skill": s, "level": None} for s in racial_skills],
+                }
+            )
+            shown_ids.update(s.id for s in racial_skills)
+
+        context["groups"] = class_groups
+        context["skill_count"] = len(shown_ids)
+        return context
+
+
+class SkillDetailView(TemplateView):
+    """Public page for one skill/spell, mirroring the in-game ``skill``
+    command (``display_skill_full``) minus per-player state."""
+
+    template_name = "skill_page.html"
+    http_method_names = ("get",)
+    skill = None
+    status = 200
+    query = ""
+    suggestions = ()
+
+    def dispatch(self, request, *args, **kwargs):
+        name = (kwargs.get("skill_name") or "").strip()
+        skill = find_skill_by_name(name)
+
+        if skill is None:
+            # No match: 404 with "did you mean" from the closest skill names.
+            self.status = 404
+            self.query = name
+            self.suggestions = self._suggest(name)
+        elif skill.skill_name != name:
+            # Case difference or abbreviation: send to the canonical URL.
+            return redirect(skill.get_absolute_url())
+        else:
+            self.skill = skill
+
+        return super().dispatch(request, *args, **kwargs)
+
+    @staticmethod
+    def _suggest(name: str) -> list:
+        if not name:
+            return []
+        names = Skill.objects.filter(
+            skill_name__isnull=False
+        ).values_list("skill_name", flat=True)
+        folded = {n.casefold(): n for n in names}
+        return [
+            folded[match]
+            for match in get_close_matches(
+                name.casefold(), folded.keys(), n=6, cutoff=0.6
+            )
+        ]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["skill"] = self.skill
+        context["query"] = self.query
+        context["suggestions"] = self.suggestions
+
+        if self.skill is not None:
+            context["class_skills"] = (
+                ClassSkill.objects
+                .filter(skill=self.skill)
+                .select_related("player_class")
+                .order_by("min_level", "player_class__class_name")
+            )
+            context["race_skills"] = (
+                RaceSkill.objects
+                .filter(skill=self.skill)
+                .select_related("race")
+                .order_by("level", "race__display_name")
+            )
+            context["forces"] = [
+                skill_force.force
+                for skill_force in self.skill.forces.select_related("force")
+            ]
+            context["components"] = list(self.skill.components.all())
+
+            # Facts that need get_FOO_display() or safe FK handling are resolved
+            # here so the template stays presentational.
+            skill = self.skill
+            context["min_posn_display"] = (
+                skill.get_min_posn_display()
+                if skill.min_posn is not None and skill.min_posn > 0
+                else ""
+            )
+            context["save_display"] = (
+                skill.get_req_save_display()
+                if skill.req_save is not None and skill.req_save >= 0
+                else ""
+            )
+            parent_id = skill.parent_skill_id or -1
+            context["parent_skill"] = (
+                Skill.objects.filter(id=parent_id).first() if parent_id > 0 else None
+            )
+        return context
+
+    def render_to_response(self, context, **response_kwargs):
+        response_kwargs["status"] = self.status
+        return super().render_to_response(context, **response_kwargs)

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,49 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-13 — DB-driven skill/spell pages (`/skills`) and the help→skill merge
+
+**Decision.** The dormant `apps/skills` app is now a public surface: `/skills/`
+(a searchable index grouped by class, plus a "Racial" bucket) and
+`/skills/<name>/` (one skill/spell), built entirely on existing `.ac-*`
+components — `.ac-hero`, `.ac-panel`, `.ac-tablewrap`/`.ac-table` for the
+"Learnable By" class/race levels, `.ac-kv` for details, `.ac-filter`/`.ac-chip`
+for forces + the class jump-nav, `.ac-quote` for the description, `.ac-empty` +
+a did-you-mean chip row for 404s. No new CSS. Wired into the Help nav dropdown.
+The detail page mirrors the in-game `skill` command (`display_skill_full`),
+minus per-player state: type, classes/races with learn levels, stat pairing,
+quick/standard action, position, save, cooldown, category, forces, description.
+
+Help and skills are **merged** the way the game's `help` does
+(`ishar-mud src/dbase/help.c`): a help lookup with no helptab topic falls back
+to a skill-name match and redirects to `/skills/<name>/`, and deprecated
+`Spell *`-prefixed helptab topics redirect to their live skill page instead of
+rendering stale text. **Why.** The game retired per-skill helpfiles for the
+dynamic `skill` command; the website only ever parsed `helptab`, so skill-only
+topics (Earthquake, Meteor Swarm — issue #51) were simply missing. Reading the
+shared DB the game already owns closes that gap with no bridge, and routing
+deprecated spell topics to the live data reduces entropy (one source of truth).
+
+**Notes.** Flag-derived fields (quick/standard action, movement) read
+`spell_flags` names heuristically and should be spot-checked on prod. Managed
+= False models; two harmless read-only field additions (`Force.display_name`,
+skill display helpers).
+
+## 2026-07-13 — Deterministic help search ladder (name before alias)
+
+**Decision.** `HelpTab.search` sorts each topic into the single strongest tier
+it matches and returns the first non-empty tier: **exact name → exact alias →
+name prefix → name substring → alias prefix → alias substring** (all
+case-insensitive), name matches ranked above alias matches. This supersedes the
+old single substring sweep over every name and alias. **Why.** The old sweep
+had no relevance order and over-matched: searching "heal" returned "Score"
+because its "Health" alias *contains* (and even prefixes) "heal". Ranking
+name-substring above alias-prefix returns the actual `Spell Heal*` topics and
+drops Score entirely — verified against the live 563 KB helptab. The ladder
+also gives 404s "did you mean" suggestions (stdlib `difflib`) drawn from both
+topic names and skill names. Deliberately one tier finer than the original
+5-tier sketch, because real data showed a 5-tier ladder still surfaced Score.
+
 ## 2026-07-12 — Featured clients (`.ac-link--featured`) and a browser-first clients page
 
 **Decision.** `/clients` now leads with an **In Your Browser** panel — hint

--- a/urls.py
+++ b/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
         name="webadmin_cancel",
     ),
     path("season/", include("apps.seasons.urls"), name="season"),
+    path("skills/", include("apps.skills.urls"), name="skills"),
     path("wiki/", RedirectView.as_view(url=settings.WIKI_URL), name="wiki"),
 ]
 


### PR DESCRIPTION
Implements the helptab overhaul (#84) and fixes the help curiosities (#51). No web↔game bridge needed — skill data is pure reads of tables the game already owns.

## The bug, precisely (#51)

Diagnosed against the live 563 KB `helptab`:

- **"heal" → "Score".** The `Score` topic has an alias **`Health`**, and the old search was a single substring sweep over every name/alias, so `"heal" ⊂ "health"` matched Score.
- **"Earthquake" / "Meteor Swarm" missing.** They have **no `helptab` topic at all** — only list items inside class spell-list topics. The game deprecated per-skill helpfiles for the dynamic `skill` command (`display_skill_full`), which renders live DB data the website never showed. In-game, `help earthquake` still works because `cmd_help` falls back to a skill-name match.

## What changed

### 1. Live helptab re-parse (`apps/help/utils/helptab.py`, `views.py`)
`HELPTAB = HelpTab()` at import pinned the parse to Daphne start. Replaced with `get_helptab()`, which re-parses on **mtime change** (cached, locked; a bad edit degrades to the last good parse + logs, never a 500). Helptab edits now land on the next request, not the next deploy.

### 2. Deterministic search ladder (fixes #51 over-matching)
`HelpTab.search` now sorts each topic into the single strongest tier and returns the first non-empty one: **exact name → exact alias → name prefix → name substring → alias prefix → alias substring** (case-insensitive), **name matches ranked above alias matches**. That last point is what fully kills "heal → Score" — `Health` is even a *prefix* of "heal", so a name/alias-blind ladder still surfaces Score; ranking name-substring above alias-prefix returns the real `Spell Heal*` topics instead. A **parse report** logs why sections are dropped (immortal / non-playing / unsplittable), so a missing topic is diagnosable. 404s get **"did you mean"** suggestions (stdlib `difflib`) from topic *and* skill names.

### 3. DB-driven skill pages (`apps/skills`, previously models-only)
- **`/skills/`** — searchable index grouped by class (+ a Racial bucket), vanilla-JS name filter.
- **`/skills/<name>/`** — mirrors `display_skill_full` minus per-player state: type, classes/races with learn levels (`.ac-table`), stat pairing, quick/standard action, position, save, cooldown, category, forces, description. Abbreviation + case canonicalization; did-you-mean 404.
- Display helpers on the `Skill` model mirror the game (`statnames[]` / `skill_types[]` from `constants.c`); `Force.display_name` added for friendly labels.

### 4. Help ↔ skills merge (mirrors `src/dbase/help.c`)
- No helptab match → **skill-name fallback** → redirect to `/skills/<name>/` (this is how "Earthquake"/"Meteor Swarm" become reachable from Help).
- Deprecated **`Spell *`** topics redirect to their live skill page instead of rendering stale text.

Built entirely on existing `.ac-*` components (**no new CSS**); `/skills` wired into the Help nav dropdown.

## Verification

Django isn't installed in this environment, so this is verified as far as it can be short of a live run:

- ✅ `py_compile` on every changed module; template `{% %}` tag balance checked.
- ✅ **Search ladder validated against the real `helptab`**: `search("heal")` → `["Spell Heal"]` (Score excluded); `search("Earthquake")`/`"Meteor Swarm"` → 0 topics (confirmed skill-only); case-insensitive exact/prefix all correct.
- ✅ **Mobile gate**: rendered all four surfaces with headless Chromium; at a true 390px column `scrollWidth == 390`, no horizontal overflow.
- ⚠️ **Not runtime-verified** (needs the shared MariaDB): the skill queries and the help→skill redirects. Flag-derived fields (quick/standard action, movement) read `spell_flags` names heuristically — **spot-check on prod**.

Closes #84
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFvwkGzeYNwm4KP9tZn5oF)_