### PR TITLE
Skills: gate /skills to what a mortal may see (hide deprecated/enchant/immortal/unreleased)

### DIFF
--- a/apps/help/views.py
+++ b/apps/help/views.py
@@ -100,13 +100,12 @@ class HelpView(TemplateView):
 
         # Skill-name suggestions (link to their skill pages) — the way
         # skill-only topics like "Earthquake" become findable from Help.
-        from apps.skills.models import Skill
+        # Restricted to mortal-visible skills so we never suggest a hidden one.
+        from apps.skills.utils import visible_skills
 
         folded = {
             name.casefold(): name
-            for name in Skill.objects.filter(
-                skill_name__isnull=False
-            ).values_list("skill_name", flat=True)
+            for name in visible_skills().values_list("skill_name", flat=True)
         }
         for match in get_close_matches(q, folded.keys(), n=6, cutoff=0.6):
             name = folded[match]

--- a/apps/skills/utils/__init__.py
+++ b/apps/skills/utils/__init__.py
@@ -38,25 +38,94 @@ def stat_name(index) -> str:
     return STAT_NAMES[index]
 
 
-def find_skill_by_name(query: str):
-    """Resolve a term to a Skill the way the game's ``is_skill_name`` does:
-    an exact (case-insensitive) name, else an abbreviation (name prefix) across
-    all skills — known or not. Returns a ``Skill`` or ``None``.
+# Skill types a normal mortal sees in the game's skill list. Values are the
+# game's ``skill_types_t`` enum (ishar-mud constants.h): TYPE=0, SKILL=1,
+# SPELL=2, CRAFT=3, ENCHANT=4, PASSIVE=5. The `skills` command shows only
+# SKILL/SPELL/PASSIVE — CRAFT and ENCHANT are professions surfaced elsewhere,
+# and TYPE is an internal marker (info.c). Excluding these is what keeps
+# deprecated enchants out of the class lists.
+VISIBLE_SKILL_TYPES = (1, 2, 5)  # SKILL_SKILL, SPELL_SKILL, PASSIVE_SKILL
+
+# Skills gated to a not-yet-live season while the active season's
+# ``new_features_on`` is off (ishar-mud person.c). Matched on ``enum_symbol``.
+SEASON_GATED_ENUM_SYMBOLS = (
+    "SPELL_VIVISECT", "SPELL_SYNAPSE_SHOCK", "SPELL_FRENZY", "SPELL_MIASMA",
+    "SPELL_CORPSE_EXPLOSION", "SPELL_PSYCHIC_HEMORRHAGE",
+    "SPELL_EYES_OF_THE_MASTER", "SPELL_AVOW", "METAMAGIC_CLARITY",
+    "METAMAGIC_HELD_SPELL", "METAMAGIC_EXPAND", "METAMAGIC_QUICKEN",
+    "METAMAGIC_RUINOUS",
+)
+
+
+def learnable_skill_ids() -> set:
+    """Skill IDs a *playable* class or race can currently learn, mirroring the
+    game's ``can_class_learn_skill`` / ``can_race_learn_skill`` >= 0: a class
+    row with ``min_level >= 0`` and ``max_learn > 0``, or a race row with
+    ``level >= 0``. Deprecated rows (``max_learn <= 0``) are excluded here, the
+    same way the game hides them from mortal skill lists.
     """
-    # Imported lazily to avoid a model/util import cycle.
+    from apps.classes.models.skill import ClassSkill
+    from apps.races.models.skill import RaceSkill
+
+    class_ids = ClassSkill.objects.filter(
+        player_class__is_playable=True, min_level__gte=0, max_learn__gt=0,
+    ).values_list("skill_id", flat=True)
+    race_ids = RaceSkill.objects.filter(
+        race__is_playable=True, level__gte=0,
+    ).values_list("skill_id", flat=True)
+    return set(class_ids) | set(race_ids)
+
+
+def _new_features_on() -> bool:
+    # Whether the active season has its gated new features enabled.
+    from apps.seasons.utils.current import get_current_season
+
+    try:
+        season = get_current_season()
+    except Exception:
+        # No season row (or DB hiccup): don't hide otherwise-released content.
+        return True
+    return bool(season and season.new_features_on)
+
+
+def visible_skills():
+    """Queryset of skills a normal mortal is allowed to see on the public site,
+    mirroring the game's ``mort_only`` predicate (ishar-mud info.c:8415-8436):
+    a Skill / Spell / Passive that some playable class or race can currently
+    learn, minus skills gated to a not-yet-live season. Immortal-only, mob-only,
+    craft, enchant, deprecated, and unreleased skills are all excluded.
+    """
     from apps.skills.models import Skill
 
+    qs = Skill.objects.filter(
+        skill_type__in=VISIBLE_SKILL_TYPES,
+        skill_name__isnull=False,
+        id__in=learnable_skill_ids(),
+    )
+    if not _new_features_on():
+        qs = qs.exclude(enum_symbol__in=SEASON_GATED_ENUM_SYMBOLS)
+    return qs
+
+
+def find_skill_by_name(query: str):
+    """Resolve a term to a mortal-visible Skill the way the game's
+    ``is_skill_name`` does: an exact (case-insensitive) name, else an
+    abbreviation (name prefix). Restricted to ``visible_skills()`` so the help
+    fallback and direct URLs never surface a skill players shouldn't see.
+    Returns a ``Skill`` or ``None``.
+    """
     query = (query or "").strip()
     if not query:
         return None
 
-    exact = Skill.objects.filter(skill_name__iexact=query).first()
+    visible = visible_skills()
+    exact = visible.filter(skill_name__iexact=query).first()
     if exact is not None:
         return exact
 
     # Abbreviation: the query is a prefix of the skill name (isabbrstring).
     return (
-        Skill.objects.filter(skill_name__istartswith=query)
+        visible.filter(skill_name__istartswith=query)
         .order_by("skill_name")
         .first()
     )

--- a/apps/skills/views.py
+++ b/apps/skills/views.py
@@ -7,7 +7,7 @@ from apps.classes.models.skill import ClassSkill
 from apps.races.models.skill import RaceSkill
 
 from .models import Skill
-from .utils import find_skill_by_name
+from .utils import find_skill_by_name, visible_skills
 
 
 class SkillIndexView(TemplateView):
@@ -19,12 +19,22 @@ class SkillIndexView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        # Group learnable skills under each playable class, ordered by the
-        # level a member of that class first learns them.
+        # The set of skills a mortal is allowed to see: Skill/Spell/Passive,
+        # learnable by a playable class or race, not season-gated.
+        visible_ids = set(visible_skills().values_list("id", flat=True))
+
+        # Group them under each playable class, ordered by learn level, using
+        # only non-deprecated class rows (min_level >= 0, max_learn > 0) so the
+        # game's hidden/deprecated skills stay out of the lists.
         class_skills = (
             ClassSkill.objects
             .select_related("skill", "player_class")
-            .filter(player_class__is_playable=True, skill__skill_name__isnull=False)
+            .filter(
+                player_class__is_playable=True,
+                min_level__gte=0,
+                max_learn__gt=0,
+                skill_id__in=visible_ids,
+            )
             .order_by("player_class__class_name", "min_level", "skill__skill_name")
         )
         groups: dict = {}
@@ -45,19 +55,22 @@ class SkillIndexView(TemplateView):
 
         class_groups = sorted(groups.values(), key=lambda g: g["name"].lower())
 
-        # A "Racial" bucket for skills a race grants but no playable class does,
-        # so racial abilities are still discoverable by browsing.
-        class_skill_ids = set(
-            ClassSkill.objects.values_list("skill_id", flat=True)
-        )
+        # A "Racial" bucket for skills a *playable* race grants but no playable
+        # class does, so racial abilities are still discoverable by browsing.
+        # Non-playable (immortal / mob-only) races are excluded, matching the
+        # mortal view of the game.
         racial_ids = (
-            set(RaceSkill.objects.values_list("skill_id", flat=True))
-            - class_skill_ids
+            set(
+                RaceSkill.objects
+                .filter(
+                    race__is_playable=True, level__gte=0, skill_id__in=visible_ids,
+                )
+                .values_list("skill_id", flat=True)
+            )
+            - shown_ids
         )
         racial_skills = list(
-            Skill.objects
-            .filter(id__in=racial_ids, skill_name__isnull=False)
-            .order_by("skill_name")
+            Skill.objects.filter(id__in=racial_ids).order_by("skill_name")
         )
         if racial_skills:
             class_groups.append(
@@ -106,9 +119,7 @@ class SkillDetailView(TemplateView):
     def _suggest(name: str) -> list:
         if not name:
             return []
-        names = Skill.objects.filter(
-            skill_name__isnull=False
-        ).values_list("skill_name", flat=True)
+        names = visible_skills().values_list("skill_name", flat=True)
         folded = {n.casefold(): n for n in names}
         return [
             folded[match]
@@ -124,15 +135,22 @@ class SkillDetailView(TemplateView):
         context["suggestions"] = self.suggestions
 
         if self.skill is not None:
+            # Only playable classes/races that can actually learn it, mirroring
+            # display_skill_full's mortal view: it hides non-playable (immortal
+            # / mob-only) classes/races and deprecated rows (can_learn == -1,
+            # i.e. min_level < 0 or max_learn <= 0).
             context["class_skills"] = (
                 ClassSkill.objects
-                .filter(skill=self.skill)
+                .filter(
+                    skill=self.skill, player_class__is_playable=True,
+                    min_level__gte=0, max_learn__gt=0,
+                )
                 .select_related("player_class")
                 .order_by("min_level", "player_class__class_name")
             )
             context["race_skills"] = (
                 RaceSkill.objects
-                .filter(skill=self.skill)
+                .filter(skill=self.skill, race__is_playable=True, level__gte=0)
                 .select_related("race")
                 .order_by("level", "race__display_name")
             )

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,30 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-13 — `/skills` shows only what a mortal may see (visibility gate)
+
+**Decision.** The public skill pages replicate the game's mortal-visibility
+predicate (ishar-mud `info.c` `stack_skills_by_type` mort_only path), not a raw
+read of `class_skills`. A skill is shown only if **(1)** its `skill_type` is
+Skill / Spell / Passive — Craft, Enchant, and the internal Type marker are
+excluded (`skill_types_t` enum: TYPE=0, SKILL=1, SPELL=2, CRAFT=3, ENCHANT=4,
+PASSIVE=5 → show 1/2/5); **(2)** some **playable** class can learn it
+(`class_skills.min_level >= 0 AND max_learn > 0`) or some **playable** race can
+(`races_skills.level >= 0`) — mirroring `can_class/race_learn_skill >= 0`; and
+**(3)** it isn't gated to a not-yet-live season (`seasons.new_features_on` off
+→ the 13 gated `enum_symbol`s are hidden). One predicate,
+`apps/skills/utils.visible_skills()`, gates the index, the detail page,
+`find_skill_by_name` (so the `help <skill>` fallback and direct URLs 404 for
+hidden skills), and every "did you mean" suggestion. Class/race associations on
+a detail page are likewise filtered to playable + learnable, mirroring
+`display_skill_full`'s mortal loops.
+
+**Why.** A public, crawlable page must not surface deprecated enchants,
+immortal / mob-only skills, or unreleased-season content the game deliberately
+hides from mortals (they were cluttering the Mage/Necromancer lists). Reading
+raw join rows exposed all of it; the centralized predicate is the single source
+of truth so the four entry points can't drift.
+
 ## 2026-07-13 — DB-driven skill/spell pages (`/skills`) and the help→skill merge
 
 **Decision.** The dormant `apps/skills` app is now a public surface: `/skills/`


### PR DESCRIPTION
Follow-up to #88. The skill pages read raw `class_skills` rows, so they surfaced skills the game deliberately hides from mortals — **deprecated enchants and other non-learnable rows were cluttering the Mage/Necromancer lists**, and immortal/mob-only and unreleased-season skills were reachable by direct URL or the `help <skill>` fallback.

## The game's rule (verified in `ishar-mud`)

`display_skill_full` and the `skills` command gate on the `mort_only` predicate (`info.c` `stack_skills_by_type`, `can_class/race_learn_skill`). A level‑1 mortal sees a skill only if:

1. **Type** is Skill / Spell / Passive — Craft, Enchant, and the internal Type marker are excluded (`skill_types_t`: TYPE=0, SKILL=1, SPELL=2, CRAFT=3, ENCHANT=4, PASSIVE=5 → show 1/2/5). ← the enchant clutter
2. Some **playable** class can learn it (`class_skills.min_level >= 0 AND max_learn > 0`) or some **playable** race can (`races_skills.level >= 0`). ← drops deprecated rows (`can_learn == -1`)
3. It isn't gated to a not‑yet‑live season (`seasons.new_features_on` off → the 13 gated `enum_symbol`s are hidden).

`display_skill_full`'s class/race loops additionally hide non‑playable associations from mortals.

## What changed

- **One predicate, `apps/skills/utils.visible_skills()`**, encodes rules 1–3. It gates the **index**, the **detail page**, **`find_skill_by_name`** (so the help fallback and direct URLs now **404** for hidden skills), and every **"did you mean"** suggestion (skills page *and* help page).
- **Index** groups only non‑deprecated playable-class rows (`min_level >= 0 AND max_learn > 0`); the Racial bucket only playable-race rows (`level >= 0`).
- **Detail** `Learnable By` filters class/race associations to playable + learnable, mirroring `display_skill_full`'s mortal loops.

## Verification

- ✅ `py_compile` on all changed modules.
- ✅ **Predicate logic validated** against synthetic data covering every case: deprecated-enchant (type 4) hidden, deprecated row (`max_learn=0`) hidden, immortal/non-playable-only hidden, craft hidden, unreleased-season skill hidden while `new_features_on` off / shown when on, playable-race passive shown, normal skills shown.
- ⚠️ **Not runtime-verified** (needs the shared MariaDB): the ORM translation of the predicate. The season gate reads the active season's `new_features_on`; if no season row is found it defaults to *showing* released content.

Relates to #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFvwkGzeYNwm4KP9tZn5oF)_