### PR TITLE
Staff dashboard (Eternal+): activity, engagement &amp; season history

### DIFF
--- a/apps/accounts/templates/dashboard.html
+++ b/apps/accounts/templates/dashboard.html
@@ -1,0 +1,323 @@
+{% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
+{% block meta_title %}Staff Dashboard{% endblock meta_title %}
+{% block meta_description %}Staff activity dashboard for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
+{% block meta_url %}{% url 'dashboard' %}#dashboard{% endblock meta_url %}
+{% block title %}Staff Dashboard{% endblock title %}
+{% block breadcrumbs %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Dashboard" "speedometer2" urlname="dashboard" anchor="dashboard" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac ac--wide">
+
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "speedometer2" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">Staff Dashboard</h2>
+            <p class="ac-hero__sub">
+                Who's playing, what they're doing, and how Season
+                {{ season.season_id }} compares — straight from the game's
+                tables, untruncated.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+{% if online_players %}
+            <span class="ac-pill ac-pill--status ac-pill--ok ac-pill--live">{{ online_players|length }} online</span>
+{% else %}
+            <span class="ac-pill ac-pill--status ac-pill--muted">0 online</span>
+{% endif %}
+        </div>
+    </header>
+
+    <!-- Pulse -->
+    <div class="ac-tiles">
+        <div class="ac-tile {% if active_accounts %}ac-tile--ok{% else %}ac-tile--muted{% endif %}">
+            <span class="ac-tile__n">{{ active_accounts|length }}<small class="text-secondary fs-6">/{{ total_accounts }}</small></span>
+            <span class="ac-tile__label">Accounts this week</span>
+        </div>
+        <div class="ac-tile {% if active_player_count %}ac-tile--info{% else %}ac-tile--muted{% endif %}">
+            <span class="ac-tile__n">{{ active_player_count }}</span>
+            <span class="ac-tile__label">Characters this week</span>
+        </div>
+        <div class="ac-tile {% if new_players %}ac-tile--accent{% else %}ac-tile--muted{% endif %}">
+            <span class="ac-tile__n">{{ new_players|length }}</span>
+            <span class="ac-tile__label">New players this week</span>
+        </div>
+        <div class="ac-tile {% if endgame_completions %}ac-tile--warn{% else %}ac-tile--muted{% endif %}">
+            <span class="ac-tile__n">{{ endgame_completions }}</span>
+            <span class="ac-tile__label">End-game quests this week</span>
+        </div>
+        <div class="ac-tile {% if season_accounts %}ac-tile--info{% else %}ac-tile--muted{% endif %}">
+            <span class="ac-tile__n">{{ season_accounts }}</span>
+            <span class="ac-tile__label">Accounts this season</span>
+        </div>
+        <div class="ac-tile {% if season.total_remorts %}ac-tile--info{% else %}ac-tile--muted{% endif %}">
+            <span class="ac-tile__n">{{ season.total_remorts }}</span>
+            <span class="ac-tile__label">Remorts this season</span>
+        </div>
+    </div>
+
+    <!-- Live now -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "broadcast" %} Live now</div>
+        <p class="ac-panel__hint">
+            Inferred from logon/logout until the game publishes its presence
+            heartbeat (ishar-mud#1771) — just-quit players can linger for up
+            to ten minutes.
+        </p>
+{% if online_players %}
+        <div class="ac-rows">
+    {% for player in online_players %}
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "person" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title">{{ player.player_link }}</div>
+                    <div class="ac-row__meta">
+                        <span title="Level {{ player.common.level }}">
+                            {% bi "bar-chart" %} level {{ player.common.level }}
+                        </span>
+                        <span title="{{ player.remorts }} remort{{ player.remorts|pluralize }}">
+                            {% bi "arrow-repeat" %} {{ player.remorts }} remort{{ player.remorts|pluralize }}
+                        </span>
+                        <span title="Online {{ player.online_time }}">
+                            {% bi "clock" %} {{ player.online_time }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+    {% endfor %}
+        </div>
+{% else %}
+        <div class="ac-empty">
+            {% bi "broadcast" %}
+            <span>No mortals in the game right now.</span>
+        </div>
+{% endif %}
+    </div>
+
+    <!-- This week -->
+    <div class="row g-3">
+        <div class="col-12 col-lg-6 d-flex flex-column">
+            <div class="ac-panel flex-grow-1">
+                <div class="ac-panel__h">{% bi "people" %} Active players <span class="text-secondary fw-normal">· 7 days</span></div>
+{% if active_accounts %}
+                <div class="ac-rows">
+    {% for entry in active_accounts %}
+                    <div class="ac-row">
+                        <span class="ac-row__icon">{% bi "person-badge" %}</span>
+                        <div class="ac-row__main">
+                            <div class="ac-row__title">{{ entry.account.account_name }}</div>
+                            <div class="ac-row__meta">
+        {% for player in entry.players %}
+                                <span>{{ player.player_link }} <small class="text-secondary">L{{ player.common.level }} R{{ player.remorts }}</small></span>
+        {% endfor %}
+                            </div>
+                        </div>
+                        <div class="ac-row__side">
+                            <span class="text-secondary" title="{{ entry.last_logon }}">
+                                <time datetime="{{ entry.last_logon|date:'c' }}">{{ entry.last_logon|naturaltime }}</time>
+                            </span>
+                        </div>
+                    </div>
+    {% endfor %}
+                </div>
+{% else %}
+                <div class="ac-empty">
+                    {% bi "people" %}
+                    <span>No mortal logins in the last week.</span>
+                </div>
+{% endif %}
+            </div>
+        </div>
+        <div class="col-12 col-lg-6 d-flex flex-column">
+            <div class="ac-panel flex-grow-1">
+                <div class="ac-panel__h">{% bi "person-plus" %} New players <span class="text-secondary fw-normal">· 7 days</span></div>
+{% if new_players %}
+                <div class="ac-rows">
+    {% for entry in new_players %}
+                    <div class="ac-row">
+                        <span class="ac-row__icon">{% bi "person-plus" %}</span>
+                        <div class="ac-row__main">
+                            <div class="ac-row__title">{{ entry.player.player_link }}</div>
+                            <div class="ac-row__meta">
+                                <span title="Account">{% bi "person-badge" %} {{ entry.player.account.account_name }}</span>
+                                <span title="Hours played">{% bi "clock" %} {{ entry.hours }}h played</span>
+        {% if entry.referrer %}
+                                <span title="Referred by {{ entry.referrer.account_name }}">{% bi "share" %} ref: {{ entry.referrer.account_name }}</span>
+        {% endif %}
+                            </div>
+                        </div>
+                        <div class="ac-row__side">
+                            <span class="text-secondary" title="{{ entry.player.birth }}">
+                                <time datetime="{{ entry.player.birth|date:'c' }}">{{ entry.player.birth|naturaltime }}</time>
+                            </span>
+                        </div>
+                    </div>
+    {% endfor %}
+                </div>
+{% else %}
+                <div class="ac-empty">
+                    {% bi "person-plus" %}
+                    <span>No new characters in the last week.</span>
+                </div>
+{% endif %}
+            </div>
+        </div>
+    </div>
+
+    <!-- Quest completions -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "bullseye" %} Quest completions <span class="text-secondary fw-normal">· 7 days</span></div>
+{% if quest_groups %}
+        <div class="ac-rows">
+    {% for group in quest_groups %}
+            <div class="ac-row">
+                <span class="ac-row__icon">{% bi "bullseye" %}</span>
+                <div class="ac-row__main">
+                    <div class="ac-row__title">{{ group.quest }}</div>
+                    <div class="ac-row__meta">
+        {% for player in group.players %}
+                        <span>{{ player.player_link }}</span>
+        {% endfor %}
+                    </div>
+                </div>
+                <div class="ac-row__side">
+    {% if group.endgame %}
+                    <span class="ac-pill ac-pill--accent" title="One of the end-game quests the weekly report tracks.">end-game</span>
+    {% endif %}
+                    <span class="ac-pill ac-pill--muted">×{{ group.players|length }}</span>
+                </div>
+            </div>
+    {% endfor %}
+        </div>
+{% else %}
+        <div class="ac-empty">
+            {% bi "bullseye" %}
+            <span>No quest completions in the last week.</span>
+        </div>
+{% endif %}
+    </div>
+
+    <!-- Engagement + roster mix -->
+    <div class="row g-3">
+        <div class="col-12 col-lg-6 d-flex flex-column">
+            <div class="ac-panel flex-grow-1">
+                <div class="ac-panel__h">{% bi "activity" %} Season engagement</div>
+                <p class="ac-panel__hint">
+                    The {{ season_accounts }} account{{ season_accounts|pluralize }}
+                    seen this season, by most recent login.
+                </p>
+{% if season_accounts %}
+                <div class="ac-bars">
+    {% for bar in recency_bars %}
+                    <div class="ac-bar" title="{{ bar.n }} account{{ bar.n|pluralize }}: {{ bar.label|lower }}">
+                        <span class="ac-bar__label">{{ bar.label }}</span>
+                        <span class="ac-bar__track"><span class="ac-bar__fill" style="width: {{ bar.pct }}%;{% if not bar.n %} display: none;{% endif %}"></span></span>
+                        <span class="ac-bar__n">{{ bar.n }}</span>
+                    </div>
+    {% endfor %}
+                </div>
+{% else %}
+                <div class="ac-empty">
+                    {% bi "activity" %}
+                    <span>No accounts seen this season yet.</span>
+                </div>
+{% endif %}
+            </div>
+        </div>
+        <div class="col-12 col-lg-6 d-flex flex-column">
+            <div class="ac-panel flex-grow-1">
+                <div class="ac-panel__h">{% bi "pie-chart" %} Active roster <span class="text-secondary fw-normal">· 30 days</span></div>
+                <p class="ac-panel__hint">
+                    The {{ roster_count }} mortal{{ roster_count|pluralize }}
+                    seen in the last month, by class and game type.
+                </p>
+{% if roster_count %}
+                <div class="ac-bars mb-3">
+    {% for bar in class_bars %}
+                    <div class="ac-bar" title="{{ bar.n }} {{ bar.label }}{{ bar.n|pluralize }}">
+                        <span class="ac-bar__label">{{ bar.label }}</span>
+                        <span class="ac-bar__track"><span class="ac-bar__fill" style="width: {{ bar.pct }}%;"></span></span>
+                        <span class="ac-bar__n">{{ bar.n }}</span>
+                    </div>
+    {% endfor %}
+                </div>
+                <div class="ac-bars">
+    {% for bar in type_bars %}
+                    <div class="ac-bar ac-bar--accent" title="{{ bar.n }} {{ bar.label }} character{{ bar.n|pluralize }}">
+                        <span class="ac-bar__label">{{ bar.label }}</span>
+                        <span class="ac-bar__track"><span class="ac-bar__fill" style="width: {{ bar.pct }}%;"></span></span>
+                        <span class="ac-bar__n">{{ bar.n }}</span>
+                    </div>
+    {% endfor %}
+                </div>
+{% else %}
+                <div class="ac-empty">
+                    {% bi "pie-chart" %}
+                    <span>No mortals seen in the last month.</span>
+                </div>
+{% endif %}
+            </div>
+        </div>
+    </div>
+
+    <!-- Season history -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "clock-history" %} Season history</div>
+        <p class="ac-panel__hint">
+            Snapshots the game takes as each season cycles. Returning counts
+            participants who also played the season before.
+        </p>
+{% if season_history %}
+        <div class="ac-bars mb-3">
+    {% for bar in participation_bars %}
+            <div class="ac-bar" title="{{ bar.n }} participant{{ bar.n|pluralize }} in {{ bar.label|lower }}">
+                <span class="ac-bar__label">{{ bar.label }}</span>
+                <span class="ac-bar__track"><span class="ac-bar__fill" style="width: {{ bar.pct }}%;"></span></span>
+                <span class="ac-bar__n">{{ bar.n }}</span>
+            </div>
+    {% endfor %}
+        </div>
+        <div class="ac-tablewrap">
+            <table class="ac-table">
+                <caption class="visually-hidden">
+                    Per-season participation, remorts, and play time.
+                </caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Season</th>
+                        <th class="ac-table__num" scope="col">Participants</th>
+                        <th class="ac-table__num" scope="col">Returning</th>
+                        <th class="ac-table__num" scope="col">Characters</th>
+                        <th class="ac-table__num" scope="col">Avg remorts</th>
+                        <th class="ac-table__num" scope="col">Max remorts</th>
+                        <th class="ac-table__num" scope="col">Hours played</th>
+                    </tr>
+                </thead>
+                <tbody>
+    {% for row in season_history %}
+                    <tr>
+                        <td>{{ row.season_id }}</td>
+                        <td class="ac-table__num">{{ row.participants }}</td>
+                        <td class="ac-table__num">{% if row.returning == None %}<span class="text-secondary">—</span>{% else %}{{ row.returning }}{% endif %}</td>
+                        <td class="ac-table__num">{{ row.characters }}</td>
+                        <td class="ac-table__num">{{ row.avg_remorts|floatformat:1 }}</td>
+                        <td class="ac-table__num">{{ row.max_remorts }}</td>
+                        <td class="ac-table__num">{{ row.hours|intcomma }}</td>
+                    </tr>
+    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+{% else %}
+        <div class="ac-empty">
+            {% bi "clock-history" %}
+            <span>No cycled seasons recorded yet.</span>
+        </div>
+{% endif %}
+    </div>
+
+</div>
+{% endblock content %}

--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -63,6 +63,13 @@
             </a>
     {% endif %}
     {% if user.is_eternal %}
+            <a class="ac-link" href="{% url 'dashboard' %}#dashboard" title="Dashboard">
+                <span class="ac-link__icon">{% bi "speedometer2" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Dashboard</span>
+                    <span class="ac-link__note d-block">Activity, engagement &amp; season history</span>
+                </span>
+            </a>
             <a class="ac-link" href="{% url 'events_console' %}#console" title="Events Console">
                 <span class="ac-link__icon">{% bi "stars" %}</span>
                 <span class="ac-link__body">

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from .views.dashboard import DashboardView
 from .views.deploy import (
     DeployActionView,
     DeployPingView,
@@ -15,6 +16,7 @@ from .views.private import SetPrivateView
 urlpatterns = [
     path("", PortalView.as_view(), name="portal"),
     path("account/", PortalView.as_view(), name="account"),
+    path("dashboard/", DashboardView.as_view(), name="dashboard"),
     path("password/", PasswordView.as_view(), name="password"),
     path("private/", SetPrivateView.as_view(), name="set_private"),
     path("deploy/", DeployView.as_view(), name="deploy"),

--- a/apps/accounts/views/dashboard.py
+++ b/apps/accounts/views/dashboard.py
@@ -1,0 +1,210 @@
+"""Eternal+ staff dashboard.
+
+The game's weekly summary report (`run_weekly_summary_report`, ishar-mud
+src/server/server.c) is clamped to Discord's message limits and only scratches
+what the shared database can answer. This page is the first-class version —
+the Discord post stays as the lite check-in. Everything here is a read of
+tables the game already owns: live activity, the 7-day window, account
+recency, the active-roster mix, the current season, and the
+`historic_season_stat` snapshots from every cycled season. No game-side
+dependency, no bridge, just the shared database.
+"""
+from datetime import timedelta
+
+from django.db.models import Avg, Count, Max, Sum
+from django.utils.timezone import now
+from django.views.generic.base import TemplateView
+
+from apps.core.views.mixins import EternalRequiredMixin, NeverCacheMixin
+
+from apps.accounts.models.account import Account
+from apps.players.models.base import PlayerBase
+from apps.players.models.game_type import GameType
+from apps.players.models.player import Player
+from apps.quests.models import PlayerQuest
+from apps.seasons.models import HistoricSeasonStat
+from apps.seasons.utils.current import get_current_season
+
+
+# The end-game quests the game's weekly report singles out — keep in sync
+# with the quest id list in `run_weekly_summary_report` (ishar-mud
+# src/server/server.c).
+ENDGAME_QUEST_IDS = (6, 7, 43, 52, 53)
+
+WEEK = timedelta(days=7)
+MONTH = timedelta(days=30)
+
+
+def _bars(counts):
+    """[(label, n), …] -> bar rows with widths scaled to the largest value."""
+    top = max((n for _, n in counts), default=0)
+    return [
+        {"label": label, "n": n, "pct": round(n / top * 100, 1) if top else 0}
+        for label, n in counts
+    ]
+
+
+class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
+    """Staff activity dashboard. Eternal+ (EternalRequiredMixin -> 404)."""
+
+    template_name = "dashboard.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        current = now()
+        week_ago = current - WEEK
+        month_ago = current - MONTH
+        season = get_current_season()
+        context["season"] = season
+
+        # Live now — the shared online queryset (logon/logout heuristic until
+        # the game's presence heartbeat lands: isharmud/ishar-mud#1771).
+        context["online_players"] = (
+            Player.objects.online()
+            .select_related("common")
+            .order_by("-logon")
+        )
+
+        # This week: active mortals, grouped per account, most recent first.
+        active_accounts = {}
+        active_player_count = 0
+        for player in (
+            Player.objects.filter(logon__gte=week_ago)
+            .select_related("account", "common")
+            .order_by("-logon")
+        ):
+            entry = active_accounts.setdefault(
+                player.account_id,
+                {"account": player.account, "players": [], "last_logon": player.logon},
+            )
+            entry["players"].append(player)
+            active_player_count += 1
+        context["active_accounts"] = list(active_accounts.values())
+        context["active_player_count"] = active_player_count
+        context["total_accounts"] = Account.objects.count()
+
+        # New players this week (all characters, matching the game report),
+        # with play time and referrer.
+        new_players = []
+        for player in (
+            PlayerBase.objects.filter(birth__gte=week_ago)
+            .select_related("account", "account__referrer_account", "statistics")
+            .order_by("-birth")
+        ):
+            stats = getattr(player, "statistics", None)
+            new_players.append({
+                "player": player,
+                "hours": round((stats.total_play_time if stats else 0) / 3600, 1),
+                "referrer": player.account.referrer_account,
+            })
+        context["new_players"] = new_players
+
+        # Quest completions this week — every quest, not just the five the
+        # Discord report has room for; the end-game five get flagged.
+        quest_groups = {}
+        for completion in (
+            PlayerQuest.objects.filter(last_completed_at__gte=week_ago)
+            .select_related("quest", "player")
+            .order_by("player__name")
+        ):
+            group = quest_groups.setdefault(
+                completion.quest_id,
+                {
+                    "quest": completion.quest,
+                    "endgame": completion.quest_id in ENDGAME_QUEST_IDS,
+                    "players": [],
+                },
+            )
+            group["players"].append(completion.player)
+        context["quest_groups"] = sorted(
+            quest_groups.values(),
+            key=lambda g: (g["endgame"], len(g["players"])),
+            reverse=True,
+        )
+        context["endgame_completions"] = sum(
+            len(g["players"]) for g in quest_groups.values() if g["endgame"]
+        )
+
+        # Season engagement funnel: of the accounts seen this season, how
+        # recently was each one's latest character logon?
+        season_lasts = (
+            PlayerBase.objects.filter(logon__gte=season.effective_date)
+            .values("account_id")
+            .annotate(last=Max("logon"))
+        )
+        context["season_accounts"] = len(season_lasts)
+        funnel = {"today": 0, "week": 0, "month": 0, "older": 0}
+        for row in season_lasts:
+            age = current - row["last"]
+            if age <= timedelta(days=1):
+                funnel["today"] += 1
+            elif age <= WEEK:
+                funnel["week"] += 1
+            elif age <= MONTH:
+                funnel["month"] += 1
+            else:
+                funnel["older"] += 1
+        context["recency_bars"] = _bars((
+            ("Today", funnel["today"]),
+            ("This week", funnel["week"]),
+            ("This month", funnel["month"]),
+            ("Earlier this season", funnel["older"]),
+        ))
+
+        # Active-roster mix: mortals seen in the last 30 days, by class and
+        # by game type.
+        roster = (
+            Player.objects.filter(logon__gte=month_ago)
+            .select_related("common__player_class")
+        )
+        class_counts = {}
+        type_counts = {}
+        for player in roster:
+            class_name = player.common.player_class.class_name.title()
+            class_counts[class_name] = class_counts.get(class_name, 0) + 1
+            type_label = GameType(player.game_type).title
+            type_counts[type_label] = type_counts.get(type_label, 0) + 1
+        context["class_bars"] = _bars(
+            sorted(class_counts.items(), key=lambda i: i[1], reverse=True)
+        )
+        context["type_bars"] = _bars(
+            sorted(type_counts.items(), key=lambda i: i[1], reverse=True)
+        )
+        context["roster_count"] = len(roster)
+
+        # Season-by-season history from the cycle-time snapshots, plus
+        # cross-season retention: how many of a season's participants also
+        # played the season before.
+        participant_sets = {}
+        for season_id, account_id in (
+            HistoricSeasonStat.objects.exclude(account_id=None)
+            .values_list("season_id", "account_id")
+            .distinct()
+        ):
+            participant_sets.setdefault(season_id, set()).add(account_id)
+
+        history = []
+        for row in (
+            HistoricSeasonStat.objects.values("season_id")
+            .annotate(
+                participants=Count("account_id", distinct=True),
+                characters=Count("id"),
+                avg_remorts=Avg("remorts"),
+                max_remorts=Max("remorts"),
+                play_time=Sum("play_time"),
+            )
+            .order_by("-season_id")
+        ):
+            mine = participant_sets.get(row["season_id"], set())
+            prior = participant_sets.get(row["season_id"] - 1, set())
+            history.append({
+                **row,
+                "hours": (row["play_time"] or 0) // 3600,
+                "returning": len(mine & prior) if prior else None,
+            })
+        context["season_history"] = history
+        context["participation_bars"] = _bars([
+            (f"Season {row['season_id']}", row["participants"])
+            for row in history
+        ])
+        return context

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -967,6 +967,51 @@ a.ac-link--featured:visited .ac-link__name { color: var(--ac-accent); }
 .ac-kv dt { color: var(--ac-dim); font-weight: 500; }
 .ac-kv dd { margin: 0; text-align: right; min-width: 0; overflow-wrap: anywhere; }
 
+/* -------------------------------------------------------- data bars --- */
+/* Single-series magnitude bars: one row per category — label, track+fill,
+   value. One hue only (info); identity lives in the row label and the value
+   in a text token at the tip, so the fill is the only colored ink. Rounded
+   data-end, square baseline; the track is recessive off-surface. */
+.ac-bars {
+    display: flex;
+    flex-direction: column;
+    gap: .45rem;
+}
+.ac-bar {
+    display: grid;
+    grid-template-columns: minmax(5.5rem, 10rem) 1fr auto;
+    align-items: center;
+    gap: .6rem;
+    font-size: .82rem;
+}
+.ac-bar__label {
+    color: var(--ac-dim);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ac-bar__track {
+    display: block;
+    height: 10px;
+    border-radius: 0 4px 4px 0;
+    background: var(--ac-elev);
+}
+.ac-bar__fill {
+    display: block;
+    height: 100%;
+    min-width: 2px;
+    border-radius: 0 4px 4px 0;
+    background: var(--ac-info);
+}
+.ac-bar--accent .ac-bar__fill { background: var(--ac-accent); }
+.ac-bar__n {
+    color: var(--ac-text);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+.ac-bar__n small { color: var(--ac-dim); }
+
 /* ----------------------------------------------------- CTA variants --- */
 /* Amber "go" primary for non-destructive consoles (the red default stays
    for destructive actions like deploys). */

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -245,6 +245,12 @@
         {% endif %}
     {% endif %}
     {% if user.is_eternal %}
+                                <li class="nav-item" title="Dashboard">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'dashboard' %}#dashboard">
+                                        {% bi "speedometer2" %}
+                                        Dashboard
+                                    </a>
+                                </li>
                                 <li class="nav-item" title="Events Console">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'events_console' %}#console">
                                         {% bi "stars" %}

--- a/apps/quests/models/__init__.py
+++ b/apps/quests/models/__init__.py
@@ -1,1 +1,2 @@
+from .completion import PlayerQuest
 from .quest import Quest

--- a/apps/quests/models/completion.py
+++ b/apps/quests/models/completion.py
@@ -1,0 +1,50 @@
+from django.db import models
+
+from .quest import Quest
+
+
+class PlayerQuest(models.Model):
+    """A player's per-quest state (`player_quests`), written by the game."""
+
+    pk = models.CompositePrimaryKey("quest_id", "player_id")
+    quest = models.ForeignKey(
+        to=Quest,
+        on_delete=models.DO_NOTHING,
+        related_name="player_quests",
+        related_query_name="player_quest",
+        help_text="Quest which the player has interacted with.",
+        verbose_name="Quest",
+    )
+    player = models.ForeignKey(
+        to="players.Player",
+        on_delete=models.DO_NOTHING,
+        related_name="quests",
+        related_query_name="quest",
+        help_text="Player character undertaking the quest.",
+        verbose_name="Player",
+    )
+    status = models.SmallIntegerField(
+        help_text="Game-side status of the quest for the player.",
+        verbose_name="Status",
+    )
+    last_completed_at = models.DateTimeField(
+        help_text="Date and time the player last completed the quest.",
+        verbose_name="Last Completed At",
+    )
+    num_completed = models.SmallIntegerField(
+        help_text="Number of times the player has completed the quest.",
+        verbose_name="Number Completed",
+    )
+
+    class Meta:
+        managed = False
+        db_table = "player_quests"
+        ordering = ("-last_completed_at",)
+        verbose_name = "Player Quest"
+        verbose_name_plural = "Player Quests"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {self.__str__()}"
+
+    def __str__(self) -> str:
+        return f"{self.quest} @ {self.player}"

--- a/apps/seasons/models/__init__.py
+++ b/apps/seasons/models/__init__.py
@@ -1,1 +1,2 @@
+from .historic import HistoricSeasonStat
 from .season import Season

--- a/apps/seasons/models/historic.py
+++ b/apps/seasons/models/historic.py
@@ -1,0 +1,127 @@
+from django.db import models
+
+from apps.classes.models.cls import Class
+from apps.players.models.game_type import GameType
+from apps.races.models.race import Race
+
+from .season import Season
+
+
+class HistoricSeasonStat(models.Model):
+    """Per-player snapshot of a completed season, written by the game's
+    season cycle (`cycle_season`, ishar-mud src/dbase/season.c) just before
+    it deletes the season's mortal players. Read-only season history."""
+
+    id = models.AutoField(
+        primary_key=True,
+        help_text="Auto-generated permanent historic season stat number.",
+        verbose_name="Historic Season Stat ID",
+    )
+    season = models.ForeignKey(
+        blank=True,
+        null=True,
+        to=Season,
+        on_delete=models.DO_NOTHING,
+        related_name="historic_stats",
+        related_query_name="historic_stat",
+        help_text="Season which the player snapshot was taken for.",
+        verbose_name="Season",
+    )
+    account = models.ForeignKey(
+        blank=True,
+        null=True,
+        to="accounts.Account",
+        on_delete=models.DO_NOTHING,
+        related_name="historic_season_stats",
+        related_query_name="historic_season_stat",
+        help_text="Account that owned the player character.",
+        verbose_name="Account",
+    )
+    player_name = models.CharField(
+        blank=True,
+        null=True,
+        max_length=100,
+        help_text="Name of the player character.",
+        verbose_name="Player Name",
+    )
+    remorts = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text="Number of remorts the player finished the season with.",
+        verbose_name="Remorts",
+    )
+    player_class = models.ForeignKey(
+        blank=True,
+        db_column="class_id",
+        null=True,
+        to=Class,
+        on_delete=models.DO_NOTHING,
+        related_query_name="+",
+        help_text="Class of the player character.",
+        verbose_name="Class",
+    )
+    race = models.ForeignKey(
+        blank=True,
+        null=True,
+        to=Race,
+        on_delete=models.DO_NOTHING,
+        related_query_name="+",
+        help_text="Race of the player character.",
+        verbose_name="Race",
+    )
+    total_renown = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text="Total renown the player earned in the season.",
+        verbose_name="Total Renown",
+    )
+    challenges_completed = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text="Number of challenges the player completed in the season.",
+        verbose_name="Challenges Completed",
+    )
+    quests_completed = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text="Number of quests the player completed in the season.",
+        verbose_name="Quests Completed",
+    )
+    deaths = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text="Number of times the player died in the season.",
+        verbose_name="Deaths",
+    )
+    game_type = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=GameType,
+        help_text="Game type of the player character (classic/hardcore/survival).",
+        verbose_name="Game Type",
+    )
+    play_time = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text="Seconds the player spent in-game during the season.",
+        verbose_name="Play Time",
+    )
+    level = models.PositiveSmallIntegerField(
+        blank=True,
+        null=True,
+        help_text="Level the player finished the season at.",
+        verbose_name="Level",
+    )
+
+    class Meta:
+        managed = False
+        db_table = "historic_season_stat"
+        ordering = ("-season_id", "-remorts")
+        verbose_name = "Historic Season Stat"
+        verbose_name_plural = "Historic Season Stats"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {self.__str__()} ({self.pk})"
+
+    def __str__(self) -> str:
+        return f"{self.player_name} @ Season {self.season_id}"

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -158,6 +158,24 @@ filter.
 Used: feedback dashboard. Status: **formalized** (supersedes the classic
 `display-6` card tile on admin surfaces).
 
+### `.ac-bars` + `.ac-bar` — single-series magnitude bars
+Server-rendered horizontal bar rows: label · track+fill · value. One hue per
+group (`--ac-info` default; `.ac-bar--accent` for a second *group* on the same
+panel, never per-row rainbow); identity lives in the row label, the value in a
+text token at the tip — the fill is the only colored ink. Width is a
+server-computed percentage of the group's max. Rounded data-end, square
+baseline. Pair with a table when the data deserves exact columns.
+```html
+<div class="ac-bars">
+  <div class="ac-bar" title="12 accounts: today">
+    <span class="ac-bar__label">Today</span>
+    <span class="ac-bar__track"><span class="ac-bar__fill" style="width: 100%;"></span></span>
+    <span class="ac-bar__n">12</span>
+  </div>
+</div>
+```
+Used: staff dashboard. Status: **formalized.**
+
 ### `.ac-filter` + `.ac-chip` — filter bar
 Wrapping rows of pill chip links (one row per dimension, `.ac-filter__sep` as a
 group divider); active chip gets `--active` (amber wash). Compose with an inline

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -487,6 +487,20 @@ Accessibility and taste — the UI must be fully usable and calm without motion.
 `innerHTML`. Status pills carry their dot as a `::before` so labels can be
 swapped safely. **Why.** Removes an XSS foot-gun class and keeps updates cheap.
 
+## 2026-07-13 — Data visualization: single-hue server-rendered bars
+
+**Decision.** Charts on staff surfaces are server-rendered `.ac-bars` —
+single-series horizontal magnitude bars, one hue per group (`--ac-info`
+default, amber only as a deliberate second group), widths computed
+server-side, values as text-token labels at the tip, always accompanied by
+the exact numbers (inline or a paired `.ac-table`). No charting library, no
+canvas, no client-side rendering. **Why.** The site's no-new-frontend-library
+rule already forbids chart libs; single-hue bars with direct labels are the
+one chart form that stays honest at this data scale (~10 players, ~14
+seasons), works at phone width, needs no legend, and degrades to nothing —
+the numbers are always present as text. Color encodes nothing per-row
+(identity is the label), so colorblindness cannot cost information.
+
 ---
 
 ## Open decisions / to record when made


### PR DESCRIPTION
Closes #83.

## What

`/portal/dashboard/` (`EternalRequiredMixin` + `NeverCacheMixin`) — a first-class staff dashboard, with the Discord weekly report staying as the lite check-in. All read-only queries against tables the game already owns; **no game-side dependency**.

### Sections

- **Pulse tiles** — accounts/characters/new players/end-game completions this week, accounts + total remorts this season (semantic tile colors, muted at zero).
- **Live now** — the shared `Player.objects.online()` queryset, so it upgrades for free when the presence heartbeat (isharmud/ishar-mud#1771 → #82) replaces the logon/logout heuristic. The heuristic caveat is stated on the panel.
- **This week, untruncated** — the weekly-report reads from `run_weekly_summary_report` (ishar-mud `src/server/server.c`) without the Discord clamps: active players grouped per account with character levels/remorts, new players with play hours and referrer, and quest completions across **every** quest (the end-game five get a flagged pill, not an exclusive filter).
- **Season engagement** — the season's accounts bucketed by most-recent login (today / week / month / earlier), as bars.
- **Active roster** — 30-day mortals by class and by game type.
- **Season history** — per-season `historic_season_stat` aggregates: participants (bars + table), characters, avg/max remorts, hours, and **returning participants** (accounts also present the season before) — cross-season retention the Discord report could never carry.

### New pieces

- `seasons.HistoricSeasonStat` and `quests.PlayerQuest` (`managed=False`; the latter uses Django 5.2's `CompositePrimaryKey` for the `(quest_id, player_id)` table).
- `.ac-bars` — server-rendered single-hue magnitude bars (label · track+fill · value; widths computed server-side, values in text tokens; no charting library). Catalog entry in `components.md`, dated decision in `decisions.md`.
- Wired into the Portal dropdown + portal card (Eternal group).

## Verification

- `python3 -m py_compile` on all changed Python; `manage.py check` → 0 issues.
- Real template render through the Django engine (context processors stubbed) with **populated and empty** contexts.
- Headless-Chromium screenshots at 1280 px and 390 px, both variants; `scrollWidth == viewport` asserted at both widths (mobile checklist #1).
- Caught & fixed in review: bar fills were inline `<span>`s and collapsed to zero width — now `display: block`.

**Not verified:** an end-to-end run against the shared MariaDB (unreachable from this environment). The queries mirror the game's weekly-report SQL; worth one look at prod data — especially `historic_season_stat` volume and the quest-completions panel — before relying on it.

`admin-console.css` was force-added (gitignored `static/`), so `collectstatic` picks it up on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdgGVhHTgdyHwtU3YG2J2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdgGVhHTgdyHwtU3YG2J2L)_