### PR TITLE
Dashboard data fixes: real session time, participant threshold, end-game quests by default

### DIFF
--- a/apps/accounts/templates/dashboard.html
+++ b/apps/accounts/templates/dashboard.html
@@ -81,8 +81,8 @@
                         <span title="{{ player.remorts }} remort{{ player.remorts|pluralize }}">
                             {% bi "arrow-repeat" %} {{ player.remorts }} remort{{ player.remorts|pluralize }}
                         </span>
-                        <span title="Online {{ player.online_time }}">
-                            {% bi "clock" %} {{ player.online_time }}
+                        <span title="Logged in {{ player.logon }}">
+                            {% bi "clock" %} on for {{ player.logon|timesince }}
                         </span>
                     </div>
                 </div>
@@ -168,8 +168,12 @@
     </div>
 
     <!-- Quest completions -->
-    <div class="ac-panel">
+    <div class="ac-panel" id="quests">
         <div class="ac-panel__h">{% bi "bullseye" %} Quest completions <span class="text-secondary fw-normal">· 7 days</span></div>
+        <div class="ac-filter" role="group" aria-label="Quest filter">
+            <a class="ac-chip{% if not show_all_quests %} ac-chip--active{% endif %}" href="?quests=endgame#quests">End-game</a>
+            <a class="ac-chip{% if show_all_quests %} ac-chip--active{% endif %}" href="?quests=all#quests">All quests{% if quest_group_total %} ({{ quest_group_total }}){% endif %}</a>
+        </div>
 {% if quest_groups %}
         <div class="ac-rows">
     {% for group in quest_groups %}
@@ -184,7 +188,7 @@
                     </div>
                 </div>
                 <div class="ac-row__side">
-    {% if group.endgame %}
+    {% if group.endgame and show_all_quests %}
                     <span class="ac-pill ac-pill--accent" title="One of the end-game quests the weekly report tracks.">end-game</span>
     {% endif %}
                     <span class="ac-pill ac-pill--muted">×{{ group.players|length }}</span>
@@ -195,7 +199,11 @@
 {% else %}
         <div class="ac-empty">
             {% bi "bullseye" %}
+{% if not show_all_quests and quest_group_total %}
+            <span>No end-game quest completions in the last week.</span>
+{% else %}
             <span>No quest completions in the last week.</span>
+{% endif %}
         </div>
 {% endif %}
     </div>
@@ -267,8 +275,10 @@
     <div class="ac-panel">
         <div class="ac-panel__h">{% bi "clock-history" %} Season history</div>
         <p class="ac-panel__hint">
-            Snapshots the game takes as each season cycles. Returning counts
-            participants who also played the season before.
+            Snapshots the game takes as each season cycles. Participants are
+            accounts with a character that reached level 10 or remorted —
+            throwaway registrations don't count. Returning counts participants
+            who also played the season before.
         </p>
 {% if season_history %}
         <div class="ac-bars mb-3">

--- a/apps/accounts/views/dashboard.py
+++ b/apps/accounts/views/dashboard.py
@@ -11,7 +11,7 @@ dependency, no bridge, just the shared database.
 """
 from datetime import timedelta
 
-from django.db.models import Avg, Count, Max, Sum
+from django.db.models import Avg, Count, Max, Q, Sum
 from django.utils.timezone import now
 from django.views.generic.base import TemplateView
 
@@ -30,6 +30,11 @@ from apps.seasons.utils.current import get_current_season
 # with the quest id list in `run_weekly_summary_report` (ishar-mud
 # src/server/server.c).
 ENDGAME_QUEST_IDS = (6, 7, 43, 52, 53)
+
+# A season "participant" is an account with a character that got somewhere:
+# reached this level or remorted. Filters out bot/throwaway registrations
+# that rolled a character and never played it.
+PARTICIPANT_MIN_LEVEL = 10
 
 WEEK = timedelta(days=7)
 MONTH = timedelta(days=30)
@@ -99,8 +104,10 @@ class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
             })
         context["new_players"] = new_players
 
-        # Quest completions this week — every quest, not just the five the
-        # Discord report has room for; the end-game five get flagged.
+        # Quest completions this week. End-game quests are the quests of
+        # consequence, so the panel defaults to them; ?quests=all folds the
+        # minor-quest noise back in.
+        show_all_quests = self.request.GET.get("quests") == "all"
         quest_groups = {}
         for completion in (
             PlayerQuest.objects.filter(last_completed_at__gte=week_ago)
@@ -116,13 +123,19 @@ class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
                 },
             )
             group["players"].append(completion.player)
-        context["quest_groups"] = sorted(
+        all_groups = sorted(
             quest_groups.values(),
             key=lambda g: (g["endgame"], len(g["players"])),
             reverse=True,
         )
+        context["show_all_quests"] = show_all_quests
+        context["quest_group_total"] = len(all_groups)
+        context["quest_groups"] = (
+            all_groups if show_all_quests
+            else [g for g in all_groups if g["endgame"]]
+        )
         context["endgame_completions"] = sum(
-            len(g["players"]) for g in quest_groups.values() if g["endgame"]
+            len(g["players"]) for g in all_groups if g["endgame"]
         )
 
         # Season engagement funnel: of the accounts seen this season, how
@@ -174,10 +187,15 @@ class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
 
         # Season-by-season history from the cycle-time snapshots, plus
         # cross-season retention: how many of a season's participants also
-        # played the season before.
+        # played the season before. The snapshot has a row for every player
+        # that existed at cycle time — including bot/throwaway registrations
+        # that never progressed — so only characters that got somewhere count.
+        participated = HistoricSeasonStat.objects.filter(
+            Q(level__gte=PARTICIPANT_MIN_LEVEL) | Q(remorts__gte=1)
+        )
         participant_sets = {}
         for season_id, account_id in (
-            HistoricSeasonStat.objects.exclude(account_id=None)
+            participated.exclude(account_id=None)
             .values_list("season_id", "account_id")
             .distinct()
         ):
@@ -185,7 +203,7 @@ class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
 
         history = []
         for row in (
-            HistoricSeasonStat.objects.values("season_id")
+            participated.values("season_id")
             .annotate(
                 participants=Count("account_id", distinct=True),
                 characters=Count("id"),


### PR DESCRIPTION
Follow-up to #90 from the owner's prod review of `/portal/dashboard/`. Relates to #83.

## Fixes

1. **"On for days" session times.** The Live-now panel displayed the `players.online` column as session duration — but the game syncs that column from `player_stats.total_play_time` (ishar-mud `dbase.c:5621`), i.e. **lifetime play time**. Session time is now `now − logon`: the game sets `logon` once at login (`server.c:4627`) and its own in-game session display does the same subtraction (`info.c:4407`). Autosave refreshes `logout`, not `logon`, so the value stays stable through a session.

2. **111 participants.** `historic_season_stat` has a row for *every* player that existed at cycle time, including bot/throwaway registrations that rolled a character and never played it. A **participant** is now an account with a character that **reached level 10 or remorted** (remorted characters show low level at cycle time, so level alone would miss them). The same gate applies to the characters count, remort averages, hours, the participation bars, and the returning-participant retention sets. The panel hint states the rule. `PARTICIPANT_MIN_LEVEL = 10` is the one knob.

3. **Quest panel noise.** Completions now default to the **end-game five** — the quests of consequence — with an "All quests (N)" `.ac-chip` filter to fold the minor quests back in. The end-game pill only renders in all-quests mode (redundant when the filter already says it). The tile keeps counting end-game completions regardless of the filter.

## Presence-bridge status (verified)

The who/presence bridge has **not** shipped game-side: ishar-mud `main` has no `presence.rs` / `game_presence` — only the `web_admin_queue` drainer (isharmud/ishar-mud#1775) merged. ishar-mud#1771 is still open, so Live-now stays on the logon/logout heuristic (the panel hint already says so) and upgrades automatically via the shared `online()` queryset when it lands.

## Verification

`py_compile`, `manage.py check` (0 issues), template render populated + empty, screenshots at 1280/390 with `scrollWidth == viewport`. Not run against the shared DB — the participant threshold deserves one prod eyeball to confirm the counts now look sane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdgGVhHTgdyHwtU3YG2J2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdgGVhHTgdyHwtU3YG2J2L)_