### PR TITLE
Handle unavailable patch PDFs gracefully in patches list

### DIFF
--- a/apps/patches/templates/patches.html
+++ b/apps/patches/templates/patches.html
@@ -35,11 +35,17 @@
             <span class="ac-row__icon">{% bi "file-earmark-pdf" %}</span>
             <div class="ac-row__main">
                 <div class="ac-row__title">
+{% if patch.file_size is not None %}
                     <a class="ac-row__link" href="{{ patch.patch_file.url }}" target="_blank"
                        title="Open the &quot;{{ patch.patch_name }}&quot; patch PDF in a new window.">
                         {{ patch.patch_name }}
                     </a>
                     {% bi "box-arrow-up-right" css="text-secondary" label="Opens in a new window." %}
+{% else %}
+                    <span class="ac-row__link" title="The &quot;{{ patch.patch_name }}&quot; patch PDF is currently unavailable.">
+                        {{ patch.patch_name }}
+                    </span>
+{% endif %}
                 </div>
                 <div class="ac-row__meta">
                     <span title="{{ patch.account.get_username|title }}">


### PR DESCRIPTION
## Summary

Add conditional rendering in the patches template to handle cases where a patch PDF file is unavailable. When `patch.file_size` is `None`, the patch name is displayed as plain text instead of a broken link, with an appropriate title attribute indicating unavailability.

## Changes

- **Conditional link rendering:** Wrap the existing PDF link in an `{% if patch.file_size is not None %}` block
- **Fallback UI:** When a patch file is unavailable, render the patch name as a `<span>` with class `ac-row__link` (preserving visual consistency) and a descriptive title attribute
- **Removed external link indicator:** The "Opens in a new window" icon only appears when the link is actually available

## Implementation Details

The check uses `patch.file_size` as the availability sentinel — a field that should be populated when a patch PDF exists and `None` when it doesn't. This approach:
- Maintains visual consistency (unavailable patches still use `.ac-row__link` styling)
- Provides user feedback via the title attribute
- Follows the existing `.ac-*` component patterns from the design system
- Requires no new CSS or JavaScript

https://claude.ai/code/session_01HfFErtShbrqjm6zeVWazJN