### PR TITLE
Enforce private profile access control; show account names

### DIFF
--- a/apps/players/templates/player.html
+++ b/apps/players/templates/player.html
@@ -42,6 +42,24 @@
     </div>
 {% endif %}
 
+{% if not player.account.is_private or request.user.is_artisan %}
+{% if player.account.account_name %}
+    <div class="ac-panel">
+        <div class="ac-panel__h" id="account">
+            {% bi "person-badge" %}
+            Account
+            <a class="anchor-link" href="#account" aria-label="Link to this section: Account"></a>
+        </div>
+        <ul class="list-unstyled mb-0">
+            <li class="mb-0" title="Account Name: {{ player.account.account_name }}">
+                {% bi "dot" css="text-ishar" %}
+                Account: <strong>{{ player.account.account_name }}</strong>
+            </li>
+        </ul>
+    </div>
+{% endif %}
+{% endif %}
+
 {% if not player.is_immortal %}
     <div class="ac-panel">
         <div class="ac-panel__h" id="details">
@@ -116,7 +134,7 @@
 {% endif %}
     </div>
 
-{% if not player.account.is_private or request.user.is_immortal %}
+{% if not player.account.is_private or request.user.is_artisan %}
 
 {% if player.upgrades %}
     <div class="ac-panel">

--- a/apps/players/templates/player.html
+++ b/apps/players/templates/player.html
@@ -42,7 +42,6 @@
     </div>
 {% endif %}
 
-{% if not player.account.is_private or request.user.is_artisan %}
 {% if player.account.account_name %}
     <div class="ac-panel">
         <div class="ac-panel__h" id="account">
@@ -57,7 +56,6 @@
             </li>
         </ul>
     </div>
-{% endif %}
 {% endif %}
 
 {% if not player.is_immortal %}
@@ -134,8 +132,6 @@
 {% endif %}
     </div>
 
-{% if not player.account.is_private or request.user.is_artisan %}
-
 {% if player.upgrades %}
     <div class="ac-panel">
         <div class="ac-panel__h" id="upgrades">
@@ -207,7 +203,6 @@
         </ul>
     </div>
 
-{% endif %}
 {% endif %}
 
 {% else %}

--- a/apps/players/views/player.py
+++ b/apps/players/views/player.py
@@ -1,7 +1,9 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
 from django.views.generic.detail import DetailView
 
+from apps.accounts.models import Account
 from apps.core.views.mixins import NeverCacheMixin
 
 from ..models.player import Player
@@ -15,15 +17,26 @@ class PlayerView(LoginRequiredMixin, NeverCacheMixin, DetailView):
     slug_field = slug_url_kwarg = query_pk_and_slug = "name"
     template_name = "player.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        # Tell immortals if they are viewing a private profile.
-        if request.user:
-            if request.user.is_authenticated and request.user.is_immortal():
-                obj = self.get_object()
-                if obj.account.is_private:
-                    messages.add_message(
-                        request=request,
-                        level=messages.INFO,
-                        message="This player has marked their profile private."
-                    )
-        return super().dispatch(request, *args, **kwargs)
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset=queryset)
+
+        # A character whose account link is dangling (deleted/orphaned
+        #   account row) is treated as private, rather than raising an
+        #   uncaught DoesNotExist when its privacy is checked below.
+        try:
+            is_private = obj.account.is_private
+        except Account.DoesNotExist:
+            is_private = True
+
+        if is_private:
+            # Same 404-for-everyone-else convention as GodRequiredMixin: a
+            #   private profile does not disclose its own existence to
+            #   anyone below Artisan.
+            if not self.request.user.is_artisan():
+                raise Http404
+            messages.add_message(
+                request=self.request,
+                level=messages.INFO,
+                message="This player has marked their profile private.",
+            )
+        return obj

--- a/apps/players/views/search.py
+++ b/apps/players/views/search.py
@@ -23,12 +23,10 @@ class PlayerSearchView(LoginRequiredMixin, NeverCacheMixin, FormView):
         if form.cleaned_data:
             search = form.cleaned_data.get("name")
             if search:
-                results = self.model.objects.filter(
-                    name__icontains=search,
-                    account__is_private__exact=False
-                ).order_by(
-                    "name"
-                )
+                results = self.model.objects.filter(name__icontains=search)
+                if not self.request.user.is_artisan():
+                    results = results.filter(account__is_private__exact=False)
+                results = results.order_by("name")
 
                 # Count any results.
                 if results:


### PR DESCRIPTION
## Summary

Refactor private profile access control to use a 404-for-everyone-else convention (consistent with `GodRequiredMixin`), and surface account names on player profiles. Non-Artisan users can no longer view private profiles; Artisans see them with an info banner.

## Changes

- **Access control:** Move privacy check from `dispatch()` to `get_object()`, raising `Http404` for non-Artisan users viewing private profiles (instead of showing the page with a banner visible only to immortals). Gracefully handle orphaned account rows (deleted accounts) by treating them as private.

- **Account name display:** Add a new "Account" panel to `player.html` that displays `player.account.account_name` when present, using the `.ac-panel` component pattern.

- **Search filtering:** Refactor player search to conditionally filter by `account.is_private` only for non-Artisan users, allowing Artisans to discover private profiles in search results.

- **Template cleanup:** Remove the conditional `{% if not player.account.is_private or request.user.is_immortal %}` wrapper around upgrades/skills sections, since access control now happens at the view layer (404 for non-Artisans).

## Implementation Details

- Handles `Account.DoesNotExist` gracefully (treats dangling account links as private).
- Maintains the 404-for-everyone-else convention from `GodRequiredMixin` for consistency.
- Artisans receive an info message when viewing a private profile, preserving staff visibility into privacy settings.
- Search results respect the same access tier: non-Artisans see only public profiles; Artisans see all.

https://claude.ai/code/session_01CBeUPdm4XXYh8wXcRMSPkz