### PR TITLE
Players: stop 500 on malformed player titles

### DIFF
--- a/apps/players/models/base.py
+++ b/apps/players/models/base.py
@@ -500,8 +500,15 @@ class PlayerBase(models.Model):
     @property
     @display(boolean=False, description="Title", ordering="title")
     def player_title(self):
-        # Player title.
-        return self.title % self.name
+        # Player title. The game stores titles with a "%s" placeholder for
+        #   the player's name, but the column is free-form game data: a title
+        #   may carry a bare "%", omit the "%s", or hold extra conversions,
+        #   any of which makes "%"-formatting raise (TypeError/ValueError) and,
+        #   uncaught, 500s the player page. Fall back to the raw title.
+        try:
+            return self.title % self.name
+        except (TypeError, ValueError):
+            return self.title
 
     @display(boolean=False, description="Type", ordering="game_type")
     def player_type(self) -> str:


### PR DESCRIPTION
PlayerBase.player_title did a bare "self.title % self.name". The title
column is free-form game data — a title may carry a stray "%", omit the
"%s" name placeholder, or hold extra conversions. Any of those makes the
"%"-format raise TypeError/ValueError, which propagates out of template
rendering and 500s the player detail page (player.html renders
player.player_title in the hero for every player).

Wrap the format in a try/except and fall back to the raw title so a
non-standard title degrades to plain text instead of crashing the page.

Relates to player/<name>/ 500 report (e.g. Logain).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B3DEwDnJ6A4GnY7WWRReFc