### PR TITLE
Feedback: allow promoting private reports to the private GitHub tracker

### DIFF
--- a/apps/feedback/migrations/0010_alter_feedback_is_private_help_text.py
+++ b/apps/feedback/migrations/0010_alter_feedback_is_private_help_text.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Private reports are now promotable to the private GitHub tracker; refresh
+    the ``is_private`` help text to match. The ``feedback`` table is owned by the
+    game (``managed = False``), so this only updates Django's model state and the
+    admin display — no DDL runs against the database."""
+
+    dependencies = [
+        ("feedback", "0009_feedback_feedbackcomment_feedbacksynctask_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="feedback",
+            name="is_private",
+            field=models.BooleanField(
+                db_column="is_private",
+                default=False,
+                help_text=(
+                    "Private reports never reach Discord (likely-exploit "
+                    "reports). They can still be promoted to the private GitHub "
+                    "tracker, where issues stay admin-only."
+                ),
+                verbose_name="Private?",
+            ),
+        ),
+    ]

--- a/apps/feedback/models/feedback.py
+++ b/apps/feedback/models/feedback.py
@@ -202,8 +202,9 @@ class Feedback(models.Model):
         db_column="is_private",
         default=False,
         help_text=(
-            "Private reports never reach Discord and cannot be promoted to a "
-            "public GitHub issue (likely-exploit reports)."
+            "Private reports never reach Discord (likely-exploit reports). They "
+            "can still be promoted to the private GitHub tracker, where issues "
+            "stay admin-only."
         ),
         verbose_name="Private?",
     )

--- a/apps/feedback/services.py
+++ b/apps/feedback/services.py
@@ -312,13 +312,10 @@ def promote(feedback, actor) -> str:
     """
     `reports promote` — file a GitHub issue. The website has no GitHub token, so
     it enqueues the intent for the daemon (which creates the issue and writes
-    back `github_issue_url`). Private reports are hard-blocked, matching
-    `promote_internal`.
+    back `github_issue_url`). Private reports promote too: the tracker repo is
+    private, so its issues are admin-only. The daemon's `build_issue_body`
+    flags the private origin on the issue.
     """
-    if feedback.is_private:
-        raise ValidationError(
-            "Private reports are not promoted to public GitHub issues."
-        )
     if feedback.is_promoted():
         return f"Report #{feedback.pk} already has a GitHub issue: {feedback.github_issue_url}"
     with transaction.atomic():
@@ -332,12 +329,9 @@ def assign_claude(feedback, actor, instructions="") -> str:
     `reports claude` — ensure a GitHub issue exists and post the `@claude`
     assignment comment. Gods-only (enforced by the caller). Enqueued for the
     daemon, which owns the token, the issue creation, and the injection-guarded
-    comment body (`assign_claude_comment`).
+    comment body (`assign_claude_comment`). Private reports are eligible — the
+    tracker repo is private, so the issue and the `@claude` run stay admin-only.
     """
-    if feedback.is_private:
-        raise ValidationError(
-            "Private reports cannot be assigned to Claude on GitHub."
-        )
     instructions = _clean(instructions, INSTRUCTIONS_MAX)
     payload = {"instructions": instructions} if instructions else {}
     with transaction.atomic():

--- a/apps/feedback/templates/feedback_detail.html
+++ b/apps/feedback/templates/feedback_detail.html
@@ -31,7 +31,7 @@
         <div class="ac-hero__status d-flex flex-wrap gap-1 justify-content-end">
             <span class="ac-pill ac-pill--status ac-pill--{{ report.status_pill }}" id="status-badge">{{ report.status_label }}</span>
 {% if report.is_private %}
-            <span class="ac-pill ac-pill--warn" title="Never reaches Discord; not promotable to GitHub">{% bi "lock-fill" %} private</span>
+            <span class="ac-pill ac-pill--warn" title="Never reaches Discord; promotes only to the private GitHub tracker">{% bi "lock-fill" %} private</span>
 {% endif %}
 {% if report.bountied %}
             <span class="ac-pill ac-pill--warn" title="Bounty awarded by {{ report.bountied_by }}">{% bi "coin" %} bounty</span>
@@ -141,7 +141,12 @@
                         <button class="ac-btn" data-action="dupe">Mark&nbsp;Duplicate</button>
                     </div>
 
-{% if can_promote %}
+{% if report.is_private %}
+                    <div class="ac-note ac-note--warn" role="note">
+                        {% bi "lock-fill" %}
+                        <span>Private report — promotes only to the private GitHub tracker, where the issue stays admin-only.</span>
+                    </div>
+{% endif %}
                     <button class="ac-btn ac-btn--info" data-action="promote" {% if report.github_issue_url %}disabled title="Already promoted"{% endif %}>
                         {% bi "github" %} Promote to GitHub
                     </button>
@@ -149,12 +154,6 @@
                     <div class="d-flex gap-1">
                         <input class="ac-field" id="instructions" placeholder="Claude instructions (optional)" aria-label="Claude instructions">
                         <button class="ac-btn ac-btn--warn" data-action="assign_claude">{% bi "robot" %} Assign&nbsp;Claude</button>
-                    </div>
-{% endif %}
-{% else %}
-                    <div class="ac-note ac-note--warn" role="note">
-                        {% bi "lock-fill" %}
-                        <span>Private report — not promotable to a public GitHub issue.</span>
                     </div>
 {% endif %}
 

--- a/apps/feedback/views/detail.py
+++ b/apps/feedback/views/detail.py
@@ -23,6 +23,5 @@ class FeedbackDetailView(EternalRequiredMixin, NeverCacheMixin, DetailView):
         )
         # Reports this one has been marked a duplicate of / by.
         context["duplicates"] = self.object.duplicates.all().order_by("-id")
-        context["can_promote"] = not self.object.is_private
         context["is_god"] = self.request.user.is_god()
         return context


### PR DESCRIPTION
Closes #97

## Why

The feedback triage surface hard-blocked private reports from the **Promote to GitHub** and **Assign Claude** actions. Since the tracker repo is private, its issues are already admin-only, so the block is unnecessary. This mirrors the game-side change in isharmud/ishar-mud#1780.

## What changed

- **`apps/feedback/services.py`** — removed the `is_private` `ValidationError` guards in `promote()` and `assign_claude()`.
- **`apps/feedback/views/detail.py`** — dropped the `can_promote` context flag (every report is promotable now).
- **`apps/feedback/templates/feedback_detail.html`** — always render the promote / assign-Claude controls; for private reports show an informational note that promotion goes only to the private tracker (admin-only). Refreshed the private-pill tooltip.
- **`apps/feedback/models/feedback.py`** — refreshed the `is_private` help text.
- **`apps/feedback/migrations/0010_alter_feedback_is_private_help_text.py`** — state-only `AlterField` for the help-text change. The `feedback` table is `managed = False`, so no DDL runs against the database.

## Verification

- `python3 -m py_compile` on all changed Python — clean.
- Template block structure compiles under Django's template engine.
- The migration `help_text` was verified byte-identical to the model's, so no phantom pending migration remains.

Left to on-prod test by the owner: the end-to-end promote → daemon → issue flow (needs the shared MariaDB + host daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01879cGvjkbpeBTQAQq49mpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01879cGvjkbpeBTQAQq49mpm)_