### PR TITLE
Connect: auto-login from the portal session + reconnect-with-backoff

### DIFF
--- a/apps/connect/consumers.py
+++ b/apps/connect/consumers.py
@@ -2,13 +2,28 @@
 import asyncio
 import logging
 
+from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.conf import settings
 
 from . import tracker
+from .models import WebLoginToken
 
 
 logger = logging.getLogger(__name__)
+
+# Application close codes, so the browser can tell a *bridge* problem (retry
+# with backoff, the game or bridge may be mid-deploy) from the game cleanly
+# ending the session (a quit — don't fight it with an auto-reconnect loop).
+# 4000-4999 is the private-use range of RFC 6455.
+CLOSE_BRIDGE_FAILURE = 4502
+
+# The WAIT_ACCOUNT_NAME prompt the game prints when it is ready for a login
+# (src/server/output.c, send_prompt_other). Auto-login waits for it because
+# input sent while the game is still in its pre-login states (ident/proxy
+# lookups) is silently discarded — and minting on the prompt means none of
+# the token's 90 s TTL is spent on that latency.
+ACCOUNT_PROMPT = "please enter your account email"
 
 # Telnet protocol constants.
 IAC = 255    # Interpret As Command
@@ -38,6 +53,29 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         # Holds telnet bytes that arrived mid-sequence so a command or GMCP
         # subnegotiation split across socket reads is reassembled, not lost.
         self._inbuf = bytearray()
+        # Latest window size reported by the browser (cols, rows); used to
+        # answer the server's DO NAWS with the real terminal size.
+        self._naws = None
+        # Auto-login (#85 / ishar-mud#1773): a portal-authenticated player is
+        # logged in by this consumer writing `webauth <token>` into the telnet
+        # stream when the game shows its account prompt. The token is minted
+        # here and never sent to the browser. AuthMiddlewareStack has already
+        # resolved scope["user"] by this point.
+        user = self.scope.get("user")
+        account_id = (
+            getattr(user, "account_id", None)
+            if user is not None and user.is_authenticated
+            else None
+        )
+        # States: account id set = waiting for the account prompt;
+        # None = guest, already sent, or minting failed — leave manual login.
+        self._autologin_account_id = account_id
+        self._prompt_tail = ""
+
+        # Accept before dialing the game: a close code sent on a never-accepted
+        # socket surfaces in the browser as a bare handshake failure (1006),
+        # which would be indistinguishable from a network drop.
+        await self.accept()
 
         host = getattr(settings, "MUD_HOST", "localhost")
         port = getattr(settings, "MUD_PORT", 23)
@@ -51,10 +89,9 @@ class TelnetConsumer(AsyncWebsocketConsumer):
             logger.error(
                 "Failed to connect to MUD at %s:%s: %s", host, port, exc
             )
-            await self.close()
+            await self.close(code=CLOSE_BRIDGE_FAILURE)
             return
 
-        await self.accept()
         tracker.register(self)
 
         # Read from the MUD in the background.
@@ -73,11 +110,17 @@ class TelnetConsumer(AsyncWebsocketConsumer):
 
     async def receive(self, text_data=None, bytes_data=None):
         """Forward user input from WebSocket to telnet."""
+        if bytes_data:
+            # Binary frames carry raw telnet data (e.g. NAWS updates). Cache
+            # the reported size — even before the telnet side is up, since the
+            # browser sends its first NAWS the moment the socket opens — so a
+            # later server DO NAWS gets the real terminal size.
+            self._cache_naws(bytes_data)
+
         if not self._writer or self._writer.is_closing():
             return
 
         if bytes_data:
-            # Binary frames carry raw telnet data (e.g. NAWS updates).
             self._writer.write(bytes_data)
         elif text_data:
             self._writer.write(text_data.encode("utf-8", errors="replace"))
@@ -85,11 +128,67 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         try:
             await self._writer.drain()
         except (ConnectionError, OSError):
-            await self.close()
+            await self.close(code=CLOSE_BRIDGE_FAILURE)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _cache_naws(self, frame):
+        """Remember the window size from a browser NAWS subnegotiation.
+
+        The client only sends one kind of binary frame — ``IAC SB NAWS w1 w0
+        h1 h0 IAC SE`` — so a strict shape check is enough. Anything else is
+        ignored (and still forwarded verbatim by the caller).
+        """
+        if (
+            len(frame) == 9
+            and frame[0] == IAC and frame[1] == SB and frame[2] == OPT_NAWS
+            and frame[7] == IAC and frame[8] == SE
+        ):
+            cols = (frame[3] << 8) | frame[4]
+            rows = (frame[5] << 8) | frame[6]
+            if 0 < cols < 1024 and 0 < rows < 1024:
+                self._naws = (cols, rows)
+
+    async def _maybe_autologin(self, display_data):
+        """Send ``webauth <token>`` once the game shows its account prompt.
+
+        The prompt is watched for in the displayable stream (with a small
+        carry-over tail so a prompt split across socket reads still matches).
+        On the first sighting, mint a single-use 90-second token for the
+        authenticated account and answer the prompt from here — the token
+        never reaches the browser. Any failure just leaves the player at the
+        normal manual prompt.
+        """
+        text = self._prompt_tail + display_data.decode(
+            "utf-8", errors="replace"
+        ).lower()
+        if ACCOUNT_PROMPT not in text:
+            self._prompt_tail = text[-(len(ACCOUNT_PROMPT) - 1):]
+            return
+
+        account_id = self._autologin_account_id
+        self._autologin_account_id = None  # one attempt per connection
+        self._prompt_tail = ""
+
+        try:
+            token = await database_sync_to_async(WebLoginToken.mint)(
+                account_id
+            )
+        except Exception as exc:
+            # E.g. the game-side migration hasn't run yet. Manual login works.
+            logger.warning(
+                "Auto-login mint failed for account %s: %s", account_id, exc
+            )
+            return
+
+        if self._writer and not self._writer.is_closing():
+            self._writer.write(b"webauth " + token.encode("ascii") + b"\r\n")
+            try:
+                await self._writer.drain()
+            except (ConnectionError, OSError):
+                await self.close(code=CLOSE_BRIDGE_FAILURE)
 
     async def _read_telnet(self):
         """Continuously read from the MUD and forward to the WebSocket."""
@@ -97,7 +196,9 @@ class TelnetConsumer(AsyncWebsocketConsumer):
             while True:
                 data = await self._reader.read(4096)
                 if not data:
-                    await self.close()
+                    # The game ended the session (quit, kick, or shutdown):
+                    # a clean close, not a bridge failure.
+                    await self.close(code=1000)
                     return
 
                 self._inbuf.extend(data)
@@ -134,11 +235,15 @@ class TelnetConsumer(AsyncWebsocketConsumer):
                             "utf-8", errors="replace"
                         )
                     )
+                    # Auto-login: when the game reaches its account prompt,
+                    # mint a token and answer for the authenticated player.
+                    if self._autologin_account_id is not None:
+                        await self._maybe_autologin(display_data)
         except asyncio.CancelledError:
             pass
         except Exception as exc:
             logger.error("Telnet read error: %s", exc)
-            await self.close()
+            await self.close(code=CLOSE_BRIDGE_FAILURE)
 
     def _process_telnet(self):
         """Parse buffered telnet data from ``self._inbuf``.
@@ -237,11 +342,14 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         elif command == DO:
             if option == OPT_NAWS:
                 responses.extend([IAC, WILL, OPT_NAWS])
-                # Send default window size 80x24.
+                # Answer with the browser's actual terminal size (cached from
+                # its NAWS frames, the first of which is sent the moment the
+                # websocket opens). 80x24 only as a last-resort default.
+                cols, rows = self._naws or (80, 24)
                 responses.extend([
                     IAC, SB, OPT_NAWS,
-                    0, 80,
-                    0, 24,
+                    (cols >> 8) & 0xFF, cols & 0xFF,
+                    (rows >> 8) & 0xFF, rows & 0xFF,
                     IAC, SE,
                 ])
             elif option == OPT_TTYPE:

--- a/apps/connect/models.py
+++ b/apps/connect/models.py
@@ -1,0 +1,91 @@
+"""Web auto-login tokens (isharmud/ishar-mud#1773, Contract 3).
+
+``web_login_token`` lets a portal-authenticated player land in the game from
+``/connect`` without retyping credentials. The table is owned by the game
+(``managed = False`` — its migration lives in ``ishar-mud``); the website is
+the writer, the game the consumer. Contract:
+``ishar-mud/docs/web_bridge_contracts.md``.
+
+The flow, and the two rules that make it safe:
+
+* The **Channels consumer** — never the page, never browser JS — mints
+  ``secrets.token_urlsafe(32)`` for the authenticated ``scope["user"]``,
+  stores **only its SHA-256 hex** here, and writes ``webauth <token>`` into
+  the telnet stream itself. The plaintext token never reaches the browser
+  (no DOM, no JS, no localStorage) and never reaches this table.
+* The game consumes the row with **one atomic guarded UPDATE** (single use +
+  TTL together), so a token grants exactly one login within 90 seconds, for
+  exactly the account it was minted for. Any failure degrades to the manual
+  login prompt.
+"""
+import hashlib
+import secrets
+
+from django.db import connection, models
+
+from apps.core.models.unsigned import UnsignedAutoField
+
+
+# Token lifetime, matching the game-side consumer's guard
+# (``expires_at > NOW()``) and the bridge contract ("mint + 90s").
+TOKEN_TTL_SECONDS = 90
+
+
+class WebLoginToken(models.Model):
+    """A single-use, short-lived auto-login token (hash only)."""
+
+    id = UnsignedAutoField(primary_key=True)
+    token_hash = models.CharField(
+        max_length=64,
+        unique=True,
+        help_text="SHA-256 hex of the token; the plaintext is never stored.",
+        verbose_name="Token Hash",
+    )
+    account_id = models.IntegerField(
+        db_column="account_id",
+        help_text="Account the token was minted for.",
+        verbose_name="Account ID",
+    )
+    created_at = models.DateTimeField(
+        auto_now_add=True,
+        help_text="When the token was minted.",
+        verbose_name="Created At",
+    )
+    expires_at = models.DateTimeField(
+        help_text="Mint time + 90 seconds; the game refuses the token after.",
+        verbose_name="Expires At",
+    )
+    used_at = models.DateTimeField(
+        null=True,
+        help_text="When the game consumed the token (single use).",
+        verbose_name="Used At",
+    )
+
+    class Meta:
+        managed = False
+        db_table = "web_login_token"
+        verbose_name = "Web Login Token"
+        verbose_name_plural = "Web Login Tokens"
+
+    def __str__(self) -> str:
+        return f"Web login token for account {self.account_id}"
+
+    @classmethod
+    def mint(cls, account_id: int) -> str:
+        """Mint a token for *account_id* and return the plaintext.
+
+        The row stores only the SHA-256; ``expires_at`` is computed **in the
+        database** (``NOW() + INTERVAL 90 SECOND``) so the same clock that
+        checks the TTL game-side also sets it — no Django/MariaDB timezone or
+        clock-skew coupling. Raises on any DB error (e.g. the game migration
+        has not run yet); the caller degrades to manual login.
+        """
+        token = secrets.token_urlsafe(32)
+        token_hash = hashlib.sha256(token.encode("ascii")).hexdigest()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO web_login_token (token_hash, account_id, expires_at)"
+                " VALUES (%s, %s, NOW() + INTERVAL %s SECOND)",
+                [token_hash, account_id, TOKEN_TTL_SECONDS],
+            )
+        return token

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -294,14 +294,55 @@
     });
 
     // --- WebSocket ---
+    // Reconnect-with-backoff is the primary recovery path (#85): the bridge
+    // re-authenticates each new socket server-side, so a reconnect lands a
+    // signed-in player back at character select without retyping anything.
+    // Only a clean close (code 1000 — the game ended the session, e.g. a
+    // quit) is left to the manual button; everything else retries on a
+    // 1s/2s/5s/10s ladder until the game comes back.
     var ws = null;
+    var BACKOFF_MS = [1000, 2000, 5000, 10000];
+    var CLOSE_BRIDGE_FAILURE = 4502;  // matches apps/connect/consumers.py
+    var reconnectAttempt = 0;
+    var reconnectTimer = null;
+    var countdownTimer = null;
+    var openedAt = 0;
+
     function setStatus(text, cls) {
         statusText.textContent = text;
         statusEl.className = cls;
     }
 
+    function clearReconnect() {
+        if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+        if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
+    }
+
+    function scheduleReconnect(reason) {
+        clearReconnect();
+        var delay = BACKOFF_MS[Math.min(reconnectAttempt, BACKOFF_MS.length - 1)];
+        reconnectAttempt++;
+        var until = Date.now() + delay;
+        reconnectBtn.style.display = "";
+        term.writeln("\r\n\x1b[1;33m--- " + reason + " — reconnecting in "
+            + Math.round(delay / 1000) + "s ---\x1b[0m");
+        function tick() {
+            var left = Math.max(0, Math.ceil((until - Date.now()) / 1000));
+            setStatus("Reconnecting in " + left + "s…", "status-connecting");
+        }
+        tick();
+        countdownTimer = setInterval(tick, 500);
+        reconnectTimer = setTimeout(connect, delay);
+    }
+
     function connect() {
-        if (ws && ws.readyState <= WebSocket.OPEN) ws.close();
+        clearReconnect();
+        if (ws) {
+            // Deliberate replacement: a stale socket's close must not race
+            // the new one into the reconnect scheduler.
+            ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+            if (ws.readyState <= WebSocket.OPEN) ws.close();
+        }
         if (window.IsharHUD) window.IsharHUD.reset();
 
         var protocol = location.protocol === "https:" ? "wss:" : "ws:";
@@ -314,6 +355,7 @@
         ws.binaryType = "arraybuffer";
 
         ws.onopen = function() {
+            openedAt = Date.now();
             setStatus("Connected", "status-connected");
             if (window.IsharHUD) window.IsharHUD.setConnected(true);
             sendNaws();
@@ -341,17 +383,28 @@
             term.write(d);
         };
 
-        ws.onclose = function() {
+        ws.onclose = function(event) {
             setStatus("Disconnected", "status-disconnected");
             if (window.IsharHUD) window.IsharHUD.setConnected(false);
-            reconnectBtn.style.display = "";
-            term.writeln("\r\n\x1b[1;31m--- Disconnected ---\x1b[0m");
+            // A session that lived a while proves the path works — restart
+            // the backoff ladder instead of climbing it forever.
+            if (openedAt && Date.now() - openedAt > 30000) reconnectAttempt = 0;
+            openedAt = 0;
+            if (event.code === 1000) {
+                // The game ended the session (e.g. quit) — don't fight a
+                // deliberate exit with an auto-reconnect loop.
+                reconnectBtn.style.display = "";
+                term.writeln("\r\n\x1b[1;31m--- Disconnected ---\x1b[0m");
+                return;
+            }
+            scheduleReconnect(event.code === CLOSE_BRIDGE_FAILURE
+                ? "Game server unreachable"
+                : "Connection lost");
         };
 
-        ws.onerror = function() {
-            setStatus("Disconnected", "status-disconnected");
-            reconnectBtn.style.display = "";
-        };
+        // A failed handshake also fires onclose (with a non-1000 code), so
+        // the reconnect scheduling lives there alone.
+        ws.onerror = function() {};
     }
 
     function sendCommand(cmd) {

--- a/asgi.py
+++ b/asgi.py
@@ -3,6 +3,7 @@ import os
 
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 
 from apps.connect.routing import websocket_urlpatterns
@@ -12,7 +13,14 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 application = ProtocolTypeRouter({
     "http": get_asgi_application(),
-    "websocket": AuthMiddlewareStack(
-        URLRouter(websocket_urlpatterns)
+    # The origin validator matters since connect auto-login (#85): the
+    # websocket now carries the portal session's authority into the game, so
+    # a cross-site page must not be able to open it with a rider's cookies.
+    # SESSION_COOKIE_SAMESITE=Strict already blocks that in modern browsers;
+    # this is the canonical second layer.
+    "websocket": AllowedHostsOriginValidator(
+        AuthMiddlewareStack(
+            URLRouter(websocket_urlpatterns)
+        )
     ),
 })


### PR DESCRIPTION
## Summary

Implements #85 — the web half of connect auto-login (game half: IsharMud/ishar-mud#1773, same-named branch). A player signed into the portal lands at character select from `/connect` without retyping credentials, and a dropped session walks itself back in with backoff.

## Auto-login

- **`apps/connect/models.py`** (new): `managed=False` `WebLoginToken` over the game-owned `web_login_token` table. `mint()` stores only the SHA-256 and computes `expires_at` **DB-side** (`NOW() + INTERVAL 90 SECOND`) so the same clock that checks the TTL game-side also sets it — no Django/MariaDB timezone coupling.
- **`apps/connect/consumers.py`**: the consumer — never the page, never browser JS — watches the display stream for the game's account prompt and then writes `webauth <token>` into the telnet stream itself. The token never reaches the browser (no DOM, no JS, no localStorage). Prompt-triggered rather than connect-triggered because the game **discards input** sent before its login state machine reaches `WAIT_ACCOUNT_NAME` (ident/proxy lookup states) — and the late mint spends none of the 90 s TTL on connect latency. One attempt per connection; every failure (guest, table missing, game refusal) leaves the ordinary manual prompt. `ConnectView` stays login-optional; guests see zero change.
- **`asgi.py`**: wraps the websocket router in `AllowedHostsOriginValidator` (exploit-review finding: auto-login turns the websocket into an authentication surface, so a cross-site page must not be able to open it with a rider's cookies; `SESSION_COOKIE_SAMESITE=Strict` already blocks this in modern browsers — this is the canonical second layer).

## Reconnect (the payoff)

- Abnormal closes auto-reconnect on a **1s/2s/5s/10s ladder** with a live countdown in the status pill; the ladder resets after a session that stayed healthy ≥30 s. Each new websocket re-mints server-side, so a reconnect lands back at character select untyped.
- **Bridge errors surface distinctly from clean closes:** the consumer now accepts the websocket *before* dialing the game (a pre-accept close reaches browsers as a bare 1006) and closes with `4502` when the game side is unreachable → "Game server unreachable — reconnecting in Ns". A clean `1000` (the game ended the session, i.e. a quit) shows the manual Reconnect button instead of fighting a deliberate exit with a retry loop.

## Rode along

- NAWS replies now use the browser's **real terminal size**, cached from its resize frames (the first arrives the moment the socket opens), instead of the hardcoded 80×24 in the consumer.

## Verification

- `manage.py check` clean; `connect.html` compiles under the template engine; extracted page script passes `node --check`; `py_compile` clean on all changed Python.
- **Left to the on-prod test:** the live login/reconnect round-trip (needs the shared DB and the game deploy). Deploy ordering per the bridge contract: game first (migration + `webauth` binary), then this. Until the game side is live, signed-in players just see the normal manual prompt.

Relates to #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kvx8GcuD7tq5bHDYBAkiyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kvx8GcuD7tq5bHDYBAkiyy)_