### PR TITLE
Hardcore characters: display player_stats hardcore_level/remorts/deaths

### DIFF
--- a/apps/accounts/templates/dashboard.html
+++ b/apps/accounts/templates/dashboard.html
@@ -75,11 +75,11 @@
                 <div class="ac-row__main">
                     <div class="ac-row__title">{{ player.player_link }}</div>
                     <div class="ac-row__meta">
-                        <span title="Level {{ player.common.level }}">
-                            {% bi "bar-chart" %} level {{ player.common.level }}
+                        <span title="Level {{ player.display_level }}">
+                            {% bi "bar-chart" %} level {{ player.display_level }}
                         </span>
-                        <span title="{{ player.remorts }} remort{{ player.remorts|pluralize }}">
-                            {% bi "arrow-repeat" %} {{ player.remorts }} remort{{ player.remorts|pluralize }}
+                        <span title="{{ player.display_remorts }} remort{{ player.display_remorts|pluralize }}">
+                            {% bi "arrow-repeat" %} {{ player.display_remorts }} remort{{ player.display_remorts|pluralize }}
                         </span>
                         <span title="Logged in {{ player.logon }}">
                             {% bi "clock" %} on for {{ player.logon|timesince }}
@@ -111,7 +111,7 @@
                             <div class="ac-row__title">{{ entry.account.account_name }}</div>
                             <div class="ac-row__meta">
         {% for player in entry.players %}
-                                <span>{{ player.player_link }} <small class="text-secondary">L{{ player.common.level }} R{{ player.remorts }}</small></span>
+                                <span>{{ player.player_link }} <small class="text-secondary">L{{ player.display_level }} R{{ player.display_remorts }}</small></span>
         {% endfor %}
                             </div>
                         </div>

--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -157,8 +157,8 @@
                         <span>{{ player.common.player_class.get_class_name }}</span>
                         <span>{{ player.common.race.display_name }}</span>
                         <span>{{ player.get_player_alignment }}</span>
-            {% if player.remorts > 0 %}
-                        <span title="Remorts">{% bi "arrow-repeat" %} {{ player.remorts }}</span>
+            {% if player.display_remorts > 0 %}
+                        <span title="Remorts">{% bi "arrow-repeat" %} {{ player.display_remorts }}</span>
             {% endif %}
             {% if player.statistics.total_renown > 0 %}
                         <span title="Total renown">{% bi "star" %} {{ player.statistics.total_renown }}</span>
@@ -169,8 +169,8 @@
             {% if player.statistics.total_challenges > 0 %}
                         <span title="Total challenges">{% bi "award" %} {{ player.statistics.total_challenges }}</span>
             {% endif %}
-            {% if player.statistics.total_deaths > 0 %}
-                        <span title="Total deaths">{% bi "heartbreak" %} {{ player.statistics.total_deaths }}</span>
+            {% if player.display_deaths > 0 %}
+                        <span title="Total deaths">{% bi "heartbreak" %} {{ player.display_deaths }}</span>
             {% endif %}
         {% else %}
                         <span>{{ player.name|title }} {{ player.get_player_phrase }} a {{ player.player_type }} character.</span>
@@ -181,7 +181,7 @@
         {% if player.is_immortal %}
                     <span class="ac-pill ac-pill--info">{{ player.player_type }}</span>
         {% else %}
-                    <span class="ac-pill ac-pill--accent" title="Level {{ player.common.level }}">lvl {{ player.common.level }}</span>
+                    <span class="ac-pill ac-pill--accent" title="Level {{ player.display_level }}">lvl {{ player.display_level }}</span>
         {% endif %}
                 </div>
             </div>

--- a/apps/accounts/views/dashboard.py
+++ b/apps/accounts/views/dashboard.py
@@ -66,7 +66,7 @@ class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
         # the game's presence heartbeat lands: isharmud/ishar-mud#1771).
         context["online_players"] = (
             Player.objects.online()
-            .select_related("common")
+            .select_related("common", "statistics")
             .order_by("-logon")
         )
 
@@ -75,7 +75,7 @@ class DashboardView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
         active_player_count = 0
         for player in (
             Player.objects.filter(logon__gte=week_ago)
-            .select_related("account", "common")
+            .select_related("account", "common", "statistics")
             .order_by("-logon")
         ):
             entry = active_accounts.setdefault(

--- a/apps/leaders/templates/leaders.html
+++ b/apps/leaders/templates/leaders.html
@@ -83,12 +83,12 @@
                         {{ leader.player_link }}
                         <span class="ac-table__sub">{{ leader.common.player_class }}</span>
                     </td>
-                    <td class="ac-table__num" data-key="{{ leader.common.level }}">{{ leader.common.level }}</td>
-                    <td class="ac-table__num" data-key="{{ leader.remorts }}">{{ leader.remorts }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.display_level }}">{{ leader.display_level }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.display_remorts }}">{{ leader.display_remorts }}</td>
                     <td class="ac-table__num" data-key="{{ leader.statistics.total_renown }}">{{ leader.statistics.total_renown|intcomma }}</td>
                     <td class="ac-table__num" data-key="{{ leader.statistics.total_challenges }}">{{ leader.statistics.total_challenges }}</td>
                     <td class="ac-table__num" data-key="{{ leader.statistics.total_quests }}">{{ leader.statistics.total_quests }}</td>
-                    <td class="ac-table__num" data-key="{{ leader.statistics.total_deaths }}">{{ leader.statistics.total_deaths }}</td>
+                    <td class="ac-table__num" data-key="{{ leader.display_deaths }}">{{ leader.display_deaths }}</td>
                 </tr>
 {% endfor %}
             </tbody>

--- a/apps/leaders/views.py
+++ b/apps/leaders/views.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Case, F, IntegerField, When
+from django.db.models.functions import Coalesce
 from django.http import Http404
 from django.views.generic.list import ListView
 
@@ -38,6 +40,47 @@ class LeadersView(LoginRequiredMixin, NeverCacheMixin, ListView):
         )
         if self.game_type is not None:
             qs = qs.filter(game_type__exact=self.game_type.value)
+
+        # Rank hardcore characters by their "player_stats" hardcore record
+        # (`hardcore_level`/`hardcore_remorts`/`hardcore_deaths`) rather than
+        # the live `common`/`remorts`/`statistics.total_deaths` fields, which
+        # reset on a hardcore character's permadeath. Mirrors the display
+        # properties on `Player` (`display_level`/`display_remorts`/
+        # `display_deaths`), expressed in SQL so ordering stays a single query.
+        int_field = IntegerField()
+        qs = qs.annotate(
+            rank_level=Case(
+                When(
+                    game_type=GameType.HARDCORE,
+                    then=Coalesce("statistics__hardcore_level", "common__level"),
+                ),
+                default=F("common__level"),
+                output_field=int_field,
+            ),
+            rank_remorts=Case(
+                When(
+                    game_type=GameType.HARDCORE,
+                    then=Coalesce("statistics__hardcore_remorts", "remorts"),
+                ),
+                default=F("remorts"),
+                output_field=int_field,
+            ),
+            rank_deaths=Case(
+                When(
+                    game_type=GameType.HARDCORE,
+                    then=Coalesce("statistics__hardcore_deaths", "statistics__total_deaths"),
+                ),
+                default=F("statistics__total_deaths"),
+                output_field=int_field,
+            ),
+        ).order_by(
+            "-rank_remorts",
+            "-statistics__total_renown",
+            "-statistics__total_challenges",
+            "-statistics__total_quests",
+            "rank_deaths",
+            "-rank_level",
+        )
         return qs
 
     def get_context_data(self, *, object_list=None, **kwargs):

--- a/apps/players/models/base.py
+++ b/apps/players/models/base.py
@@ -445,6 +445,41 @@ class PlayerBase(models.Model):
             return True
         return False
 
+    @property
+    @display(description="Level", ordering="common__level")
+    def display_level(self) -> int:
+        # Level to display. Hardcore characters keep their record level in
+        #   "player_stats" (their live/"common" level resets on permadeath),
+        #   so read "hardcore_level" for them instead.
+        if self.is_hardcore():
+            stats = getattr(self, "statistics", None)
+            if stats is not None and stats.hardcore_level:
+                return stats.hardcore_level
+        return self.common.level
+
+    @property
+    @display(description="Remorts", ordering="remorts")
+    def display_remorts(self) -> int:
+        # Remorts to display. Hardcore characters' live "remorts" resets on
+        #   permadeath, so read their "player_stats" record, "hardcore_remorts".
+        if self.is_hardcore():
+            stats = getattr(self, "statistics", None)
+            if stats is not None and stats.hardcore_remorts:
+                return stats.hardcore_remorts
+        return self.remorts
+
+    @property
+    @display(description="Deaths")
+    def display_deaths(self) -> int:
+        # Deaths to display, from "player_stats" — "hardcore_deaths" for
+        #   hardcore characters, "total_deaths" otherwise.
+        stats = getattr(self, "statistics", None)
+        if stats is None:
+            return 0
+        if self.is_hardcore() and stats.hardcore_deaths:
+            return stats.hardcore_deaths
+        return stats.total_deaths or 0
+
     @display(boolean=False, description="Online Timedelta")
     def online_timedelta(self) -> timedelta:
         # Online timedelta.

--- a/apps/players/templates/player.html
+++ b/apps/players/templates/player.html
@@ -72,10 +72,10 @@
                 {{ player.common.player_class.class_display }} of
                 {{ player.common.race.folk_name|lower }} origin.
             </li>
-            <li class="mb-1" title="Level: {{ player.common.level }}{% if player.remorts > 0 %} / Remorts: {{ player.remorts }}{% endif %}">
+            <li class="mb-1" title="Level: {{ player.display_level }}{% if player.display_remorts > 0 %} / Remorts: {{ player.display_remorts }}{% endif %}">
                 {% bi "dot" css="text-ishar" %}
                 {{ player.get_player_gender|title }} {{ player.get_player_phrase }}
-                level {{ player.common.level }}{% if player.remorts > 0 %} and {{ player.get_player_phrase_owns }} remorted {{ player.remorts }} time{{ player.remorts|pluralize }}{% endif %}.
+                level {{ player.display_level }}{% if player.display_remorts > 0 %} and {{ player.get_player_phrase_owns }} remorted {{ player.display_remorts }} time{{ player.display_remorts|pluralize }}{% endif %}.
             </li>
 {% if player.total_renown > 0 %}
             <li class="mb-1" title="Total Renown: {{ player.total_renown }}">
@@ -111,9 +111,9 @@
             </li>
             <li class="mb-1">
                 {% bi "dot" css="text-ishar" %}
-{% if player.statistics.total_deaths > 0 %}
+{% if player.display_deaths > 0 %}
                 {{ player.get_player_gender|title }} {{ player.get_player_phrase_owns }}
-                died {{ player.statistics.total_deaths }} time{{ player.statistics.total_deaths|pluralize }}.
+                died {{ player.display_deaths }} time{{ player.display_deaths|pluralize }}.
 {% else %}
                 {{ player.get_player_gender|title }} {{ player.get_player_phrase_owns }} never died!
 {% endif %}

--- a/apps/players/templates/who.html
+++ b/apps/players/templates/who.html
@@ -46,8 +46,8 @@
                     <span title="Level {{ player.true_level }}">
                         {% bi "bar-chart" %} level {{ player.true_level }}
                     </span>
-                    <span title="{{ player.remorts }} remort{{ player.remorts|pluralize }}">
-                        {% bi "arrow-repeat" %} {{ player.remorts }} remort{{ player.remorts|pluralize }}
+                    <span title="{{ player.display_remorts }} remort{{ player.display_remorts|pluralize }}">
+                        {% bi "arrow-repeat" %} {{ player.display_remorts }} remort{{ player.display_remorts|pluralize }}
                     </span>
                 </div>
 {% endif %}

--- a/apps/players/views/who.py
+++ b/apps/players/views/who.py
@@ -14,4 +14,4 @@ class PlayerWhoView(LoginRequiredMixin, NeverCacheMixin, ListView):
     template_name = "who.html"
 
     def get_queryset(self):
-        return Player.objects.online()
+        return Player.objects.online().select_related("statistics")


### PR DESCRIPTION
## Summary

Hardcore characters' live `common.level` / `remorts` / `statistics.total_deaths` reset on permadeath, but their achieved record is preserved separately in `player_stats` (`hardcore_level` / `hardcore_remorts` / `hardcore_deaths`). Every place that showed a character's level/remorts/deaths was reading only the live fields, so hardcore characters displayed stale/reset stats instead of their actual record.

- Added `display_level` / `display_remorts` / `display_deaths` properties on `PlayerBase` (`apps/players/models/base.py`) that read the `hardcore_*` fields for hardcore characters, falling back to the live fields when no hardcore record exists yet.
- Swapped these in everywhere a character's level/remorts/deaths are shown: the player profile (`player.html`), leaderboard (`leaders.html`), portal (`portal.html`), staff dashboard (`dashboard.html`), and the who list (`who.html`).
- The leaderboard's ranking query (`apps/leaders/views.py`) now sorts hardcore characters by their `player_stats` hardcore record via a `Case`/`Coalesce` SQL annotation, so ranking matches what's displayed.
- Added `select_related("statistics")` where needed to avoid N+1 queries from the new property.

Mirrors the existing precedent in `Account.seasonal_earned` (`apps/accounts/models/account.py`), which already computes `max(remorts, hardcore_remorts)`.

## Test plan

- [x] `python3 -m py_compile` on all changed Python files
- [x] `python3 manage.py check` — passes with no issues
- [x] Compiled all changed templates via Django's template engine (both a minimal stub engine and the real settings module) — no syntax errors
- [x] Verified the `display_level`/`display_remorts`/`display_deaths` property logic against mocked hardcore/classic/no-stats-yet scenarios
- [x] Printed the compiled SQL for the leaderboard's annotated/ordered queryset to confirm the `CASE`/`COALESCE` expressions are valid
- [ ] No live DB/game data available in this environment — owner should verify against production hardcore character data

Relates to #50


---
_Generated by [Claude Code](https://claude.ai/code/session_01QuiuamdtNHY7fC8bBiKngJ)_