### PR TITLE
Connect auto-login: fix NameError that silently disabled webauth

### DIFF
--- a/apps/connect/consumers.py
+++ b/apps/connect/consumers.py
@@ -64,7 +64,6 @@ class TelnetConsumer(AsyncWebsocketConsumer):
     """Proxy WebSocket connections to the MUD telnet server."""
 
     async def connect(self):
-        from .models import WebLoginToken
         self._reader = None
         self._writer = None
         self._read_task = None
@@ -216,6 +215,15 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         account_id = self._autologin_account_id
         self._autologin_account_id = None  # one attempt per connection
         self._prompt_tail = ""
+
+        # Imported at point of use, not module level: consumers.py is imported
+        # during ASGI startup, where a top-level model import can hit the app
+        # registry before it is ready. The earlier fix moved this import into
+        # connect()'s *local* scope — but the mint happens here, in a different
+        # method that never saw that name, so every attempt raised NameError,
+        # was swallowed by the except below as a "mint failed", and auto-login
+        # silently never fired. Import it where it is actually used.
+        from .models import WebLoginToken
 
         try:
             token = await database_sync_to_async(WebLoginToken.mint)(


### PR DESCRIPTION
## Summary

Auto-login (#85) never fired on prod: a signed-in player always landed on the manual account-email page. Root cause is a one-line scope bug introduced by a later refactor — not auth, not the prompt matcher, not the DB (all of which tested fine in isolation).

## Root cause

A later change moved the `WebLoginToken` import out of module scope — to dodge an app-registry-not-ready error at ASGI import time (the same change added `django.setup()` to `asgi.py`) — but parked it as a **local import inside `connect()`**, which never uses the model. The token is minted in `_maybe_autologin`, a *different* method that cannot see `connect()`'s locals. So every mint raised `NameError: name 'WebLoginToken' is not defined`, the broad `except Exception` swallowed it, logged "Auto-login mint failed…", and fell back to the manual prompt.

Net effect: `scope["user"]` resolved correctly, the account prompt matched, `WebLoginToken.mint()` worked when called directly — yet `webauth` was never written to the telnet stream, and the only trace was a warning in the **Daphne** log (not the game log).

## Fix

Import `WebLoginToken` at its point of use inside `_maybe_autologin`, and drop the dead local import from `connect()`. A comment documents the trap so it can't regress. One-line behavioral change; no debug logging left behind.

## Verification

- `python3 -m py_compile` and `manage.py check` clean.
- Confirmed at runtime that `WebLoginToken` is **not** a module global (the exact reason the old reference `NameError`'d from `_maybe_autologin`) and that the fixed method imports it in its own body; `WebLoginToken.mint` is importable/callable.
- The pre-fix failure is observable on the current deployment: `docker logs ishar-prod-web 2>&1 | grep "mint failed"` → `name 'WebLoginToken' is not defined`.
- Live end-to-end (land at character select from `/connect`; `WEBAUTH:` in the game log) is the on-deploy test. No game-side change needed — ishar-mud is correct as shipped.

Relates to #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kvx8GcuD7tq5bHDYBAkiyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kvx8GcuD7tq5bHDYBAkiyy)_