### PR TITLE
Show agent diagnostics when log status probe fails

### DIFF
--- a/apps/accounts/templates/logs.html
+++ b/apps/accounts/templates/logs.html
@@ -62,6 +62,14 @@
     </div>
 {% endif %}
 
+    <!-- Populated by loadStatus() when the agent status probe fails, so the
+         failure carries the agent's own detail (e.g. an outdated agent) instead
+         of just a red "agent error" pill. -->
+    <div class="ac-note ac-note--warn" id="agentDiag" role="alert" hidden>
+        <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#exclamation-triangle"></use></svg>
+        <span id="agentDiagText"></span>
+    </div>
+
     <!-- Source + color + size -->
     <div class="ac-panel">
         <div class="ac-panel__h">
@@ -169,6 +177,8 @@
 
     const livePill = document.getElementById("livePill");
     const agentPill = document.getElementById("agentPill");
+    const agentDiag = document.getElementById("agentDiag");
+    const agentDiagText = document.getElementById("agentDiagText");
     const colorRow = document.getElementById("colorRow");
     const linesSel = document.getElementById("linesSel");
     const refreshBtn = document.getElementById("refreshBtn");
@@ -237,6 +247,14 @@
         });
     }
 
+    // Show/hide the diagnostic note that carries the agent's own error detail,
+    // so an agent failure explains itself rather than showing a bare red pill.
+    function setDiag(text) {
+        if (!agentDiag) { return; }
+        if (text) { agentDiagText.textContent = text; agentDiag.hidden = false; }
+        else { agentDiagText.textContent = ""; agentDiag.hidden = true; }
+    }
+
     function loadStatus() {
         if (!configured) { return; }
         post("{% url 'logs_status' %}", {}).then(function (r) {
@@ -250,12 +268,19 @@
                     markLive(null);
                 }
                 setPill(agentPill, "agent ok", "ok", false);
+                agentPill.title = "Log agent status";
+                setDiag("");
             } else {
+                const detail = (r.data && (r.data.message || r.data.detail)) ||
+                    ("Log agent returned HTTP " + r.status + ".");
                 setPill(livePill, "live color unknown", "muted", false);
                 setPill(agentPill, "agent error", "danger", false);
+                agentPill.title = detail;
+                setDiag(detail);
             }
         }, function () {
             setPill(agentPill, "agent unreachable", "danger", false);
+            setDiag("Could not reach the log agent — the status probe failed.");
         });
     }
 

--- a/apps/accounts/views/logs.py
+++ b/apps/accounts/views/logs.py
@@ -24,6 +24,25 @@ LINE_CHOICES = (200, 500, 1000, 2000, 5000)
 DEFAULT_LINES = 500
 COLORS = ("live", "blue", "green")
 
+# The host agent is a long-lived process that a deploy does NOT restart (it can't
+# deploy itself — see scripts/deploy-agent.py and the systemd unit). So a checkout
+# that has the log actions but a still-running old agent process answers `bad-action`
+# to log-status/log-tail. Turn that opaque rejection into an actionable message
+# instead of a bare "agent error", so the failure is self-diagnosing.
+_OUTDATED_AGENT_HINT = (
+    "The host log agent doesn't recognize the log actions — it's running an "
+    "outdated deploy-agent.py. On the host, update the checkout and restart it: "
+    "sudo systemctl restart ishar-deploy-agent"
+)
+
+
+def _agent_version_hint(payload):
+    """Return an actionable message when the agent rejected the action as unknown
+    (an outdated agent), else None."""
+    if isinstance(payload, dict) and payload.get("error") == "bad-action":
+        return _OUTDATED_AGENT_HINT
+    return None
+
 
 class LogViewerView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
     """Render the log viewer. Eternal-gated (staff); unauthorized -> 404."""
@@ -55,6 +74,9 @@ class LogStatusView(EternalRequiredMixin, NeverCacheMixin, View):
                 status=503,
             )
         status = int(result.get("http_status", 200 if result.get("ok") else 400))
+        hint = _agent_version_hint(result)
+        if hint:
+            result = {**result, "message": hint}
         return JsonResponse(result, status=status)
 
 
@@ -93,8 +115,9 @@ class LogFetchView(EternalRequiredMixin, NeverCacheMixin, View):
 
         if not data.get("ok"):
             status = int(data.get("http_status", 502))
+            hint = _agent_version_hint(data)
             return JsonResponse(
-                {"message": data.get("detail") or "Log unavailable.", **data},
+                {**data, "message": hint or data.get("detail") or "Log unavailable."},
                 status=status,
             )
 


### PR DESCRIPTION
## Summary

When the log agent status probe fails, surface the agent's own error detail (e.g., "outdated agent") in the UI instead of showing only a bare red "agent error" pill. This makes agent failures self-diagnosing and actionable for staff.

## Changes

**Frontend (`apps/accounts/templates/logs.html`)**
- Added a hidden diagnostic alert (`#agentDiag`) that displays detailed error messages from the agent
- Added `setDiag()` function to show/hide the diagnostic note based on agent status
- Updated `loadStatus()` to:
  - Extract error detail from the agent response (`r.data.message` or `r.data.detail`)
  - Set the pill's `title` attribute for hover tooltips
  - Call `setDiag()` with the detail message on failure, or empty string on success
  - Handle network failures with a specific "Could not reach the log agent" message

**Backend (`apps/accounts/views/logs.py`)**
- Added `_OUTDATED_AGENT_HINT` constant with actionable guidance when the agent rejects an action as unknown (indicates an outdated `deploy-agent.py`)
- Added `_agent_version_hint()` helper to detect `bad-action` errors and return the hint message
- Updated `LogStatusView.post()` to inject the hint into the response when detected
- Updated `LogTailView.post()` to prefer the hint message over generic fallback text

## Implementation Details

The agent returns `{"error": "bad-action"}` when it doesn't recognize a log action — a symptom of running an outdated deploy-agent process (which doesn't auto-restart on deploys). The new code detects this pattern and surfaces a specific, actionable message ("update the checkout and restart the systemd unit") instead of a generic "agent error" pill.

The diagnostic note is styled as a warning alert (`.ac-note--warn`) with an exclamation-triangle icon, positioned above the log viewer controls for visibility.

https://claude.ai/code/session_017ZMiZxkQphmHjmmqH5Tvya