### PR TITLE
Web connector: ability invocation fixes, stable compass, moon phase icons

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -482,6 +482,9 @@ body.connect-page #content { padding: .5rem !important; }
 .ab-star { background: none; border: 0; color: var(--ac-dim); cursor: pointer; font-size: .9rem; padding: 0 2px; line-height: 1; }
 .ab-star.on { color: var(--hud-gold); }
 .ab-star:hover { color: var(--ac-accent); }
+/* Passive / craft / enchant abilities: tagged and visibly non-activatable. */
+.ab-type { font-size: .58rem; text-transform: uppercase; letter-spacing: .04em; color: var(--ac-dim); background: var(--ac-bg); border-radius: 3px; padding: 0 5px; }
+.ab-row.ab-passive .ab-name { color: var(--ac-dim); font-style: italic; }
 
 /* ----- Affects ----- */
 .aff-list { list-style: none; margin: 0; padding: 0; }

--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -166,6 +166,7 @@ body.connect-page #content { padding: .5rem !important; }
 .v-season { color: var(--ac-accent); font-weight: 700; white-space: nowrap; padding: 1px 8px; border: 1px solid rgba(255, 170, 119, .45); background: var(--ac-wash); border-radius: 999px; }
 .v-event { color: var(--hud-event); white-space: nowrap; }
 .v-moon { color: var(--hud-moon); white-space: nowrap; }
+.v-moon-icon { font-weight: 700; }
 
 @media (max-width: 767.98px) {
     #hud-topbar { gap: 8px; }
@@ -342,9 +343,13 @@ body.connect-page #content { padding: .5rem !important; }
     border-radius: 3px; font-size: .72rem; font-weight: 700; padding: 5px 0; cursor: pointer;
 }
 .exit:hover { border-color: var(--ac-accent); color: var(--ac-accent); }
-.exit.none { border-color: transparent; background: transparent; cursor: default; }
+/* Absent exit: still drawn (fixed layout) but clearly inactive. */
+.exit.none { color: var(--ac-dim); background: var(--ac-bg); border-color: var(--ac-border); cursor: default; opacity: .4; }
 .exit.hub { color: var(--ac-dim); cursor: default; }
 .ud-row, .named-row { display: flex; gap: 4px; justify-content: center; margin-top: 5px; flex-wrap: wrap; }
+/* Reserve the named-exit row's height so its presence/absence doesn't move the
+   fixed compass above it (the panel is pinned to the column bottom). */
+.named-row { min-height: 1.9rem; align-items: center; }
 .exit.ud, .exit.named { padding: 4px 8px; }
 
 /* ----- Mobile tap-to-move rose overlay ----- */
@@ -362,7 +367,7 @@ body.connect-page #content { padding: .5rem !important; }
     padding: 6px 0; font-size: .68rem; background: rgba(28, 28, 34, .8);
     border-color: rgba(255, 255, 255, .12);
 }
-#rose-overlay .exit.none { background: transparent; border-color: transparent; }
+#rose-overlay .exit.none { color: var(--ac-dim); background: rgba(28, 28, 34, .4); border-color: rgba(255, 255, 255, .06); opacity: .5; }
 #rose-overlay .exit.hub { background: transparent; border-color: transparent; }
 #rose-overlay .ud-row { margin-top: 2px; gap: 2px; }
 #rose-overlay .exit.ud { padding: 5px 8px; font-size: .64rem; }

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -199,6 +199,20 @@
         return { n: "N", s: "S", e: "E", w: "W", ne: "NE", nw: "NW", se: "SE", sw: "SW" }[d] || String(d);
     }
 
+    // Moons: per-moon colour (matching the game's @c tints) + an illumination
+    // glyph by phase. Ready for a richer Game.Time.moons feed
+    // ({name, phase 0-7, phase_name, up}); degrades to a plain glyph for the
+    // current name-only payload.
+    var MOON_COLOR = { shavar: "#cfd6e6", tregalien: "#e8c14b", fandaro: "#6fce7a", chenchir: "#d05a5a" };
+    var MOON_GLYPH = ["○", "◔", "◑", "◕", "●", "◕", "◑", "◔"];   // new → waning crescent
+    function moonColor(m) {
+        var key = String(m.name || "").toLowerCase().replace(/[^a-z].*$/, "");
+        return MOON_COLOR[key] || "var(--hud-moon)";
+    }
+    function moonGlyph(m) {
+        return (typeof m.phase === "number" && m.phase >= 0 && m.phase <= 7) ? MOON_GLYPH[m.phase] : "☽";
+    }
+
     function completions() {
         var out = [];
         function add(w) { if (w) out.push(String(w)); }
@@ -394,7 +408,11 @@
                 world.appendChild(el("span", { class: "v-event", title: "Global event", text: "⚑ " + e.name + (e.seconds ? " (" + fmtDur(e.seconds) + ")" : "") }));
             });
             (tm.moons || []).forEach(function (m) {
-                world.appendChild(el("span", { class: "v-moon", title: "Moon", text: "☽ " + m.name }));
+                var span = el("span", { class: "v-moon", title: "Moon" + (m.phase_name ? " — " + m.phase_name : "") }, [
+                    el("span", { class: "v-moon-icon", style: "color:" + moonColor(m), text: moonGlyph(m) }),
+                    " " + m.name + (m.phase_name ? " (" + m.phase_name + ")" : "")
+                ]);
+                world.appendChild(span);
             });
         } else {
             world.appendChild(el("span", { class: "v-clock dim", text: "☾ —" }));
@@ -443,32 +461,39 @@
         // single-word name would be misread as a command and silently fail.
         return "go " + dir;
     }
+    // Every cardinal cell is always drawn — a live button when the exit exists,
+    // a greyed label when it doesn't — so the click target for a direction sits
+    // at a fixed spot and never moves as you travel (Mudlet-style stable rose).
     function roseGrid(exits, overlay) {
         function cell(dir) {
-            if (exits[dir] == null) return el("span", { class: "exit none" });
+            if (exits[dir] == null) return el("span", { class: "exit none", text: dirLabel(dir) });
             return el("button", { class: "exit", "data-cmd": dir, title: dir + " → " + exits[dir], text: dirLabel(dir) });
         }
-        var grid = el("div", { class: "compass" + (overlay ? " overlay" : "") }, [
+        return el("div", { class: "compass" + (overlay ? " overlay" : "") }, [
             cell("nw"), cell("n"), cell("ne"),
             cell("w"), el("span", { class: "exit hub", text: "◈" }), cell("e"),
             cell("sw"), cell("s"), cell("se")
         ]);
-        return grid;
     }
     function renderRose(container, overlay) {
         var r = S.room, exits = (r && r.exits) || {};
-        var kids = [roseGrid(exits, overlay)];
-        var ud = [];
-        ["u", "d"].forEach(function (dir) {
-            if (exits[dir] != null) ud.push(el("button", { class: "exit ud", "data-cmd": dir, text: dir === "u" ? "↑ Up" : "↓ Down" }));
+        // Up/Down are also always drawn (greyed when absent), same stability
+        // guarantee as the cardinal grid.
+        var ud = ["u", "d"].map(function (dir) {
+            var lbl = dir === "u" ? "↑ Up" : "↓ Down";
+            if (exits[dir] != null) return el("button", { class: "exit ud", "data-cmd": dir, text: lbl });
+            return el("span", { class: "exit ud none", text: lbl });
         });
-        if (ud.length) kids.push(el("div", { class: "ud-row" }, ud));
+        var kids = [roseGrid(exits, overlay), el("div", { class: "ud-row" }, ud)];
         if (!overlay) {
             var named = [];
             Object.keys(exits).forEach(function (k) {
                 if (!STD_DIRS[k]) named.push(el("button", { class: "exit named", "data-cmd": exitCmd(k), text: k }));
             });
-            if (named.length) kids.push(el("div", { class: "named-row" }, named));
+            // Always present (a reserved, min-height strip) so a room with named
+            // exits and one without don't change the pane height and shift the
+            // fixed compass on the bottom-pinned desktop layout.
+            kids.push(el("div", { class: "named-row" }, named));
         }
         fill(container, kids);
     }
@@ -1586,7 +1611,7 @@
         var feeds = {
             "Char.Status": { name: "Aelwyn", "class": "Magician", race: "Elf", position: "Standing", level: 45, align: 350, xp: 1250000, tnl: 48000, gold: 18230, bank: 500000, remort: 3 },
             "Char.Vitals": { hp: 412, maxhp: 480, mp: 255, maxmp: 300, move: 198, maxmove: 240, position: "Standing", opponent_hp_pct: 35, metamagic: 60, metamagic_max: 100, metamagic_regen: 5 },
-            "Game.Time": { hour: 21, hour12: 9, ampm: "pm", day: 14, day_name: "Sunday", month: 6, month_name: "the Long Shadows", year: 1247, night: true, season_id: 15, season_end: 0, events: [{ name: "Double Essence", seconds: 5400 }, { name: "Festival of Flames" }], moons: [{ name: "Lune (waxing)" }, { name: "Sable (full)" }] },
+            "Game.Time": { hour: 21, hour12: 9, ampm: "pm", day: 14, day_name: "Sunday", month: 6, month_name: "the Long Shadows", year: 1247, night: true, season_id: 15, season_end: 0, events: [{ name: "Double Essence", seconds: 5400 }, { name: "Festival of Flames" }], moons: [{ name: "Shavar", phase: 4, phase_name: "full", up: true }, { name: "Chenchir", phase: 6, phase_name: "last quarter", up: true }] },
             "Room.Info": { num: 3001, name: "The Grand Concourse", area: "Ishar Nexus", environment: "City", exits: { n: 3002, e: 3005, s: 3008, w: 3010, u: 3100, d: 3200, into: 3500 } },
             "Room.Occupants": { occupants: [
                 { keyword: "guard", short_desc: "a towering city guard", handle: "1.guard", is_player: false, is_dead: false, is_shopkeeper: false, hostile_hint: "neutral" },

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -856,16 +856,28 @@
     // ------------------------------------------------------------------
     // Abilities: the target-aware command + shared usability logic.
     // ------------------------------------------------------------------
+    // The exact command to invoke an ability, or null if it can't be actively
+    // used (passive / craft / enchant). Mirrors the game's real syntax rather
+    // than reconstructing a bare verb from the name.
     function abilityCommand(s) {
         var nm = nameOf(s.name);
+        // Metamagic modes: the skill is named "Metamagic: Clarity" but invoked
+        // as "metamagic clarity".
+        var mm = nm.match(/^Metamagic:\s*(.+)$/i);
+        if (mm) return "metamagic " + mm[1].toLowerCase();
+        if (s.type === "passive" || s.type === "craft" || s.type === "enchant") return null;
         if (s.type === "spell") {
             var base = "cast '" + nm + "'";
             if (s.target_type === "offensive" && S.tgtHostile) return base + " " + S.tgtHostile.handle;
             if (s.target_type === "defensive" && S.tgtFriendly) return base + " " + S.tgtFriendly.handle;
             return base;
         }
-        return nm;   // non-spell skills are bare verbs (target auto/optional)
+        // Multi-word skills ("Shield Slam") must go through the "action" parser
+        // (the one spells use) or they're misread as command "shield" + arg
+        // "slam"; single-word skills work as a bare verb.
+        return /\s/.test(nm) ? "action " + nm : nm;
     }
+    function abilityUsable(s) { return abilityCommand(s) != null; }
     // Why a skill is unusable right now (or null). cd in seconds.
     function abilityBlock(s) {
         var t = now();
@@ -1026,16 +1038,19 @@
         } else {
             var ul = el("ul", { class: "ab-list" });
             rows.forEach(function (s) {
-                var blk = abilityBlock(s);
+                var passive = !abilityUsable(s);   // passive / craft / enchant
+                var blk = passive ? null : abilityBlock(s);
                 var fav = !!favorites[nameOf(s.name).toLowerCase()];
                 var right = [];
                 if (blk) right.push(el("span", { class: "ab-block", text: blk.cd > 0 ? blk.cd + "s" : blk.reason }));
+                if (passive) right.push(el("span", { class: "ab-type", text: s.type }));
                 right.push(el("span", { class: "ab-pct", text: s.percent + "%" }));
                 right.push(el("button", { type: "button", class: "ab-star" + (fav ? " on" : ""), "data-fav": nameOf(s.name), "aria-label": fav ? "Remove from favorites" : "Add to favorites", title: fav ? "Remove from favorites" : "Add to favorites", text: fav ? "★" : "☆" }));
                 right.push(el("button", { type: "button", class: "row-more", "aria-label": "More actions", text: "⋯" }));
                 ul.appendChild(el("li", {
-                    class: "ab-row " + catClass(s) + (blk ? " off" : ""),
-                    "data-ability": s.id, "data-menu": "ability", title: castHint(s)
+                    class: "ab-row " + catClass(s) + (blk ? " off" : "") + (passive ? " ab-passive" : ""),
+                    "data-ability": s.id, "data-menu": "ability",
+                    title: passive ? s.name + " — " + s.type + " (not usable)" : castHint(s)
                 }, [
                     el("span", { class: "ab-name", text: s.name }),
                     el("span", { class: "ab-right" }, right)
@@ -1218,11 +1233,12 @@
     function abilityActions(s) {
         if (!s) return [];
         var fav = !!favorites[nameOf(s.name).toLowerCase()];
-        return [
-            { label: s.type === "spell" ? "Cast" : "Use", fn: function () { sendCmd(abilityCommand(s)); } },
-            { label: "Look up", cmd: "skill search " + nameOf(s.name) },
-            { label: fav ? "★ Remove from favorites" : "☆ Add to favorites", fn: function () { toggleFavorite(s.name); } }
-        ];
+        var acts = [];
+        var cmd = abilityCommand(s);
+        if (cmd) acts.push({ label: s.type === "spell" ? "Cast" : "Use", fn: function () { sendCmd(cmd); } });
+        acts.push({ label: "Look up", cmd: "skill search " + nameOf(s.name) });
+        acts.push({ label: fav ? "★ Remove from favorites" : "☆ Add to favorites", fn: function () { toggleFavorite(s.name); } });
+        return acts;
     }
 
     // ------------------------------------------------------------------
@@ -1257,9 +1273,13 @@
             var s = skillById(ab.getAttribute("data-ability"));
             if (s) {
                 if (abilityBlock(s) && ab.classList.contains("skill")) return;   // hotbar: inert when blocked
-                sendCmd(abilityCommand(s));
+                var acmd = abilityCommand(s);
+                if (acmd) { sendCmd(acmd); return; }
+                // Not invocable (passive/craft/enchant): fall through to the
+                // context menu below rather than firing a dead command.
+            } else {
+                return;
             }
-            return;
         }
 
         // 4) Context-menu openers (row body or its ⋯ button).
@@ -1556,7 +1576,9 @@
             { id: 7, name: "bless", type: "spell", percent: 70, usable: true, category: "misc", target_type: "defensive", mana_pct: 15, min_position: "Standing" },
             { id: 8, name: "sanctuary", type: "spell", percent: 60, usable: true, category: "misc", target_type: "defensive", mana_pct: 50, min_position: "Standing" },
             { id: 9, name: "disarm", type: "skill", percent: 45, usable: true, category: "damage", target_type: "none", min_position: "Fighting" },
-            { id: 10, name: "second attack", type: "passive", percent: 75, usable: false, category: "misc", target_type: "none", min_position: "Standing" }
+            { id: 10, name: "second attack", type: "passive", percent: 75, usable: false, category: "misc", target_type: "none", min_position: "Standing" },
+            { id: 91, name: "Metamagic: Clarity", type: "skill", percent: 100, usable: true, category: "misc", target_type: "none", min_position: "Standing" },
+            { id: 92, name: "Shield Slam", type: "skill", percent: 72, usable: true, category: "damage", target_type: "none", min_position: "Fighting" }
         ];
         // Pad to demonstrate the immortal overflow the browser now bounds.
         for (var i = 11; i <= 90; i++) bigSkills.push({ id: i, name: "spell " + i, type: (i % 3 ? "spell" : "skill"), percent: 40 + (i % 60), usable: (i % 4 !== 0), category: ["damage", "heal", "misc"][i % 3], target_type: ["offensive", "defensive", "none"][i % 3], mana_pct: 20 + (i % 40), min_position: "Standing" });


### PR DESCRIPTION
Follow-up to the merged #110, addressing reported issues. Two commits on top of `main`.

## Ability invocation + passives (closes #111)
The HUD reconstructed the run command from a skill's name/type, which didn't match the game's real syntax:
- **Metamagic** — `"Metamagic: Clarity"` now invokes as `metamagic clarity`, not `cast '<name>'`.
- **Multi-word skills** — `"Shield Slam"` routes through the `action` parser (`action Shield Slam`) so it resolves instead of being read as command `shield` + arg `slam`; single-word skills stay bare verbs.
- **Passives / craft / enchant** — non-invocable: tagged + italicized in the Abilities browser, and a click no-ops (falls through to the info menu, which omits Cast) instead of sending a dead command.

## Compass rose stability
Every cardinal cell and Up/Down are now always drawn (greyed when the exit is absent), and the named-exit row is height-reserved, so a direction's click target never moves as you travel — repeated clicks across room changes no longer require repositioning (matches Mudlet's fixed rose).

## Moon phase icons
`Game.Time.moons` renders as per-moon colour-coded phase glyphs (Shavar silver / Tregalien gold / Fandaro green / Chenchir crimson; `○ ◔ ◑ ◕ ●` by phase), degrading to a plain glyph for a name-only payload. Pairs with the game-side emission of real risen moons (see the ishar-mud follow-up PR).

## Verification
`node --check` on `hud.js`; the real `hud.js` driven in headless Chromium via `/connect?demo=1` with scripted assertions — `metamagic clarity`, `action Shield Slam`, `cast 'fireball'`, passive → no-op, the compass grid staying 9 cells + fixed position across room changes, and moons rendering as colour-coded phase glyphs. Not exercised against the live game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTCQJQoHWcDBb21kjdMYzN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTCQJQoHWcDBb21kjdMYzN)_