### PR TITLE
Add desktop notifications for damage, beeps, and low health

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -329,6 +329,25 @@ body.connect-page #content { padding: .5rem !important; }
 .setting-row input:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: 2px; }
 @media (pointer: coarse) { .setting-row { min-height: 44px; } }
 
+/* Grouped settings (e.g. the notifications cluster) under a small heading. */
+.setting-group { margin-top: 4px; padding-top: 2px; border-top: 1px solid var(--ac-border); }
+.setting-group-h {
+    padding: 6px 10px 2px; font-size: .7rem; font-weight: 700;
+    letter-spacing: .04em; text-transform: uppercase; color: var(--ac-dim);
+}
+/* A row that mixes a checkbox with an inline numeric control — not a single
+   label, so its own cursor stays a default and each control labels itself. */
+.setting-row-inline { cursor: default; flex-wrap: wrap; }
+.setting-row-inline label { cursor: pointer; }
+.setting-num {
+    width: 3.6em; flex: none; text-align: right;
+    font-family: monospace; font-size: .85rem; padding: 3px 6px;
+    background: var(--ac-bg); color: var(--ac-text);
+    border: 1px solid var(--ac-border); border-radius: var(--ac-radius-sm);
+}
+.setting-num:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: 1px; }
+.setting-suffix { color: var(--ac-dim); }
+
 /* ----- Compass rose (bottom-left desktop) ----- */
 .rose-head { display: flex; flex-direction: column; padding: 6px 8px 2px; line-height: 1.2; }
 .rose-name { font-size: .74rem; font-weight: 700; color: var(--ac-accent); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -59,7 +59,7 @@
         }
     } catch (e) {}
 
-    var api = { send: function () {}, prefill: function () {}, onLayoutChange: function () {}, onComm: function () {} };
+    var api = { send: function () {}, prefill: function () {}, onLayoutChange: function () {}, onComm: function () {}, onVitals: function () {} };
     var dom = {};
     var hudOn = false;
     var activeTab = "status";
@@ -250,6 +250,9 @@
                 lastVitalsBody = body;
                 S.vitals = data;
                 updateVitals();
+                // Let the page decide on HP-based notifications (damage taken /
+                // low-health) — it owns the tab-visibility + settings state.
+                api.onVitals(data);
                 tickHotbar();          // mana gate re-evaluates each pulse
                 // The Abilities browser bakes the mana/position block state into
                 // each row, so it must rebuild when mana changes (combat regen)
@@ -1526,6 +1529,7 @@
         if (opts.prefill) api.prefill = opts.prefill;
         if (opts.onLayoutChange) api.onLayoutChange = opts.onLayoutChange;
         if (opts.onComm) api.onComm = opts.onComm;
+        if (opts.onVitals) api.onVitals = opts.onVitals;
 
         dom.app = document.getElementById("connect-app");
         dom.vitals = document.getElementById("vitals-bar");

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -92,14 +92,35 @@
                 <input type="checkbox" data-setting="stack">
                 <span>Chain commands with ; (see /help)</span>
             </label>
-            <label class="setting-row setting-notify">
-                <input type="checkbox" data-setting="notifyTells">
-                <span>Notify on tells while the tab is hidden</span>
-            </label>
             <label class="setting-row">
                 <input type="checkbox" data-setting="titleBadge">
                 <span>Unread count in the tab title</span>
             </label>
+            {# Desktop notifications — the whole group hides when the browser
+               has no Notification API (e.g. iOS Safari outside a PWA). #}
+            <div class="setting-group setting-notify-group">
+                <div class="setting-group-h">Notify while the tab is hidden</div>
+                <label class="setting-row setting-notify">
+                    <input type="checkbox" data-setting="notifyTells">
+                    <span>On a tell, reply, or whisper</span>
+                </label>
+                <label class="setting-row setting-notify">
+                    <input type="checkbox" data-setting="notifyBeep">
+                    <span>On a game beep</span>
+                </label>
+                <label class="setting-row setting-notify">
+                    <input type="checkbox" data-setting="notifyHit">
+                    <span>When you take damage</span>
+                </label>
+                <div class="setting-row setting-notify setting-row-inline">
+                    <input type="checkbox" id="set-notifyHealth" data-setting="notifyHealth">
+                    <label for="set-notifyHealth">When HP falls below</label>
+                    <input type="number" class="setting-num" id="set-healthThreshold"
+                           data-setting-num="healthThreshold" min="1" max="99" step="5"
+                           inputmode="numeric" aria-label="Low-health notify threshold, percent">
+                    <label for="set-healthThreshold" class="setting-suffix">%</label>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -314,6 +335,21 @@
     }
     term.open(terminalContainer);
 
+    // Game beep → notification (while hidden). xterm parses the BEL (\x07) out
+    // of the stream for us, so this is independent of the HUD/GMCP and works
+    // even if hud.js failed to load. Throttled so a chatty prompt-bell can't
+    // machine-gun notifications.
+    var lastBeepAt = 0;
+    if (term.onBell) {
+        term.onBell(function() {
+            if (!settings.notifyBeep || !document.hidden) return;
+            var t = Date.now();
+            if (t - lastBeepAt < 15000) return;
+            lastBeepAt = t;
+            notify("Ishar MUD", "The game beeped you.", "ishar-beep");
+        });
+    }
+
     // Clicking the terminal returns focus to the command input, so you can get
     // straight back to typing without aiming for the small input bar. The
     // terminal is display-only (disableStdin), so nothing competes for focus.
@@ -391,15 +427,31 @@
     }
 
     // --- Client settings (persisted; surfaced in the gear menu) ---
-    var settings = { keepInput: true, stack: true, notifyTells: false, titleBadge: true };
+    // notify* fire a desktop Notification only while the tab is hidden (the HUD
+    // already surfaces this state when the tab is focused). healthThreshold is
+    // the percent for the low-health notify, stored as a number.
+    var HEALTH_MIN = 1, HEALTH_MAX = 99, HEALTH_DEFAULT = 25;
+    function clampThreshold(n) {
+        n = parseInt(n, 10);
+        if (isNaN(n)) return HEALTH_DEFAULT;
+        return Math.max(HEALTH_MIN, Math.min(HEALTH_MAX, n));
+    }
+    var settings = {
+        keepInput: true, stack: true, titleBadge: true,
+        notifyTells: false, notifyBeep: false, notifyHit: false,
+        notifyHealth: false, healthThreshold: HEALTH_DEFAULT
+    };
     try {
         var savedSettings = JSON.parse(localStorage.getItem("ishar.settings"));
         if (savedSettings && typeof savedSettings === "object") {
+            // Restore any saved key whose type matches the default (booleans and
+            // the numeric threshold alike).
             Object.keys(settings).forEach(function(k) {
-                if (typeof savedSettings[k] === "boolean") settings[k] = savedSettings[k];
+                if (typeof savedSettings[k] === typeof settings[k]) settings[k] = savedSettings[k];
             });
         }
     } catch (e) {}
+    settings.healthThreshold = clampThreshold(settings.healthThreshold);
     function saveSettings() {
         try { localStorage.setItem("ishar.settings", JSON.stringify(settings)); } catch (e) {}
     }
@@ -795,10 +847,15 @@
             }
             case "settings":
                 sysln("Client settings (change via the gear menu):");
-                sysln("  keep input after send: " + (settings.keepInput ? "on" : "off"));
-                sysln("  ; command stacking:    " + (settings.stack ? "on" : "off"));
-                sysln("  notify on tells:       " + (settings.notifyTells ? "on" : "off"));
-                sysln("  unread title badge:    " + (settings.titleBadge ? "on" : "off"));
+                sysln("  keep input after send:  " + (settings.keepInput ? "on" : "off"));
+                sysln("  ; command stacking:     " + (settings.stack ? "on" : "off"));
+                sysln("  unread title badge:     " + (settings.titleBadge ? "on" : "off"));
+                sysln("  notify (while hidden):");
+                sysln("    tells/replies:        " + (settings.notifyTells ? "on" : "off"));
+                sysln("    game beeps:           " + (settings.notifyBeep ? "on" : "off"));
+                sysln("    taking damage:        " + (settings.notifyHit ? "on" : "off"));
+                sysln("    low health:           " + (settings.notifyHealth
+                    ? "below " + settings.healthThreshold + "%" : "off"));
                 break;
             default:
                 sysln("Unknown client command /" + cleanText(cmd) + " — try /help.");
@@ -861,7 +918,8 @@
                 fitAppHeight();
                 scheduleFit();
             },
-            onComm: onComm
+            onComm: onComm,
+            onVitals: onVitals
         });
     }
 
@@ -1081,14 +1139,19 @@
     // --- Settings (gear) popover ---
     var settingsBtn = document.getElementById("settings-btn");
     var settingsPop = document.getElementById("settings-pop");
+    var NOTIFY_KEYS = ["notifyTells", "notifyBeep", "notifyHit", "notifyHealth"];
     if (!("Notification" in window)) {
-        // No Notification API (e.g. iOS Safari outside a PWA): hide the row.
-        var notifyRow = settingsPop.querySelector(".setting-notify");
-        if (notifyRow) notifyRow.style.display = "none";
+        // No Notification API (e.g. iOS Safari outside a PWA): hide the whole
+        // notifications group — none of it can work.
+        var notifyGroup = settingsPop.querySelector(".setting-notify-group");
+        if (notifyGroup) notifyGroup.style.display = "none";
     }
     function syncSettingsPop() {
         settingsPop.querySelectorAll("input[data-setting]").forEach(function(cb) {
             cb.checked = !!settings[cb.getAttribute("data-setting")];
+        });
+        settingsPop.querySelectorAll("input[data-setting-num]").forEach(function(num) {
+            num.value = String(settings[num.getAttribute("data-setting-num")]);
         });
     }
     function closeSettingsPop() {
@@ -1106,15 +1169,26 @@
         }
     });
     settingsPop.addEventListener("change", function(e) {
+        // The numeric threshold input.
+        var num = e.target.closest("input[data-setting-num]");
+        if (num) {
+            var nkey = num.getAttribute("data-setting-num");
+            var val = clampThreshold(num.value);
+            settings[nkey] = val;
+            num.value = String(val);   // reflect any clamping back to the field
+            saveSettings();
+            return;
+        }
         var cb = e.target.closest("input[data-setting]");
         if (!cb) return;
         var key = cb.getAttribute("data-setting");
-        if (key === "notifyTells" && cb.checked && Notification.permission !== "granted") {
+        if (NOTIFY_KEYS.indexOf(key) !== -1 && cb.checked
+                && "Notification" in window && Notification.permission !== "granted") {
             // Flip on only once the browser actually grants permission.
-            settings.notifyTells = false;
+            settings[key] = false;
             cb.checked = false;
             Notification.requestPermission().then(function(p) {
-                settings.notifyTells = p === "granted";
+                settings[key] = p === "granted";
                 saveSettings();
                 syncSettingsPop();
             });
@@ -1130,16 +1204,25 @@
         closeSettingsPop();
     });
 
-    // --- Unread title badge + tell notifications ---
+    // --- Desktop notifications (title badge + tells/beep/damage/low-health) ---
+    // Every trigger below fires only while the tab is hidden: when it's focused
+    // the HUD already shows tells, vitals, and the terminal directly.
     var baseTitle = document.title;
     var unread = 0;
     function clearTitleBadge() {
         unread = 0;
         document.title = baseTitle;
     }
-    document.addEventListener("visibilitychange", function() {
-        if (!document.hidden) clearTitleBadge();
-    });
+    // One guarded path for raising a Notification. tag lets the OS collapse
+    // repeats of the same kind (a second low-health note replaces the first).
+    function notify(title, body, tag) {
+        if (!("Notification" in window) || Notification.permission !== "granted") return;
+        try {
+            var n = new Notification(title, { body: String(body || "").slice(0, 140), tag: tag });
+            n.onclick = function() { window.focus(); this.close(); };
+        } catch (e) {}
+    }
+
     // Called by the HUD for every Comm.Channel message (text already
     // color-stripped there).
     function onComm(channel, text) {
@@ -1148,18 +1231,65 @@
             unread++;
             document.title = "(" + unread + ") " + baseTitle;
         }
-        if (settings.notifyTells && "Notification" in window
-                && Notification.permission === "granted"
-                && /^(tell|reply|whisper)/i.test(channel || "")) {
-            try {
-                var n = new Notification("Ishar MUD", {
-                    body: String(text || "").slice(0, 140),
-                    tag: "ishar-tell"
-                });
-                n.onclick = function() { window.focus(); this.close(); };
-            } catch (e) {}
+        if (settings.notifyTells && /^(tell|reply|whisper)/i.test(channel || "")) {
+            notify("Ishar MUD", text, "ishar-tell");
         }
     }
+
+    // HP-based notifications, fed Char.Vitals by the HUD. Two independent
+    // triggers, each one-shot and re-armed on tab-return (see visibilitychange):
+    //   • notifyHit    — HP dropped below where it stood when you tabbed out.
+    //   • notifyHealth — HP fell to/under the configured percent.
+    var lastVitals = null;      // most recent vitals, for the visibility handler
+    var hitAnchorHp = null;     // HP captured when the tab went hidden
+    var hitNotified = false;    // damage note already sent this hidden stretch
+    var lowHealthNotified = false;
+    function onVitals(v) {
+        lastVitals = v;
+        if (!v || v.hp == null) return;
+        var hp = Number(v.hp), maxhp = Number(v.maxhp) || 0;
+        var pctHp = maxhp > 0 ? (hp / maxhp * 100) : null;
+
+        // Low health: fire once when at/under the threshold; re-arm above it.
+        if (pctHp != null && pctHp <= settings.healthThreshold) {
+            if (settings.notifyHealth && document.hidden && !lowHealthNotified) {
+                notify("Ishar MUD — low health",
+                    "HP " + hp + " / " + maxhp + " (" + Math.round(pctHp) + "%)", "ishar-health");
+                lowHealthNotified = true;
+            }
+        } else if (pctHp != null) {
+            lowHealthNotified = false;
+        }
+
+        // Took damage while hidden: anchor at the hide, fire once on any dip
+        // below it. Lazily anchor if the toggle was flipped on mid-stretch.
+        if (settings.notifyHit && document.hidden) {
+            if (hitAnchorHp == null) hitAnchorHp = hp;
+            else if (!hitNotified && hp < hitAnchorHp) {
+                notify("Ishar MUD — taking damage",
+                    "HP " + hp + " / " + maxhp, "ishar-hit");
+                hitNotified = true;
+            }
+        }
+    }
+
+    document.addEventListener("visibilitychange", function() {
+        if (!document.hidden) {
+            clearTitleBadge();
+            // Returning to the tab acknowledges everything — re-arm so the next
+            // time you tab out, a fresh event can alert again.
+            hitAnchorHp = null;
+            hitNotified = false;
+            lowHealthNotified = false;
+        } else {
+            // Tabbing out: anchor "took damage" at the HP we're leaving on, and
+            // evaluate low-health right now in case we're already hurt (no new
+            // Char.Vitals may arrive while idle).
+            hitAnchorHp = (lastVitals && lastVitals.hp != null) ? Number(lastVitals.hp) : null;
+            hitNotified = false;
+            if (settings.notifyHealth && lastVitals) onVitals(lastVitals);
+        }
+    });
 
     // --- Keyboard shortcuts (documented in /help) ---
     document.addEventListener("keydown", function(e) {


### PR DESCRIPTION
Expand the notification system beyond tells to cover game beeps, damage taken, and low-health alerts — all firing only while the tab is hidden (the HUD surfaces these when focused).

## Summary

This change adds three new notification triggers to the web client's notification suite:
- **Game beeps** (`notifyBeep`) — triggered by xterm's `onBell` event, throttled to 15s to prevent machine-gunning
- **Damage taken** (`notifyHit`) — fires once when HP drops below the value at tab-hide time
- **Low health** (`notifyHealth`) — fires when HP falls to/under a configurable percent threshold (default 25%, range 1–99%)

The notification UI is reorganized into a grouped settings panel with a small heading, and the `/help settings` output is updated to reflect the new options.

## Key Changes

- **Settings UI** (`connect.html`):
  - Reorganized notifications into a `.setting-group` with a heading
  - Added three new checkbox toggles for beep, damage, and low-health notifications
  - Added an inline numeric input for the low-health threshold (with `%` suffix label)
  - Entire group hides if the browser lacks the Notification API (e.g., iOS Safari outside a PWA)

- **Settings state** (`connect.html` script):
  - Extended `settings` object with `notifyBeep`, `notifyHit`, `notifyHealth` (booleans) and `healthThreshold` (number, clamped 1–99, default 25)
  - Updated localStorage restore logic to handle numeric settings alongside booleans
  - Added `clampThreshold()` helper to validate the health threshold on load and input

- **Notification triggers**:
  - **Game beep**: New `term.onBell()` handler that fires `notify()` when `notifyBeep` is on and the tab is hidden; throttled to 15s per beep
  - **Damage & low health**: New `onVitals()` callback from the HUD (fed `Char.Vitals` GMCP data) that evaluates both triggers independently with one-shot re-arming logic
  - **Visibility handler**: Enhanced to re-arm damage/low-health triggers on tab return and to anchor the damage baseline when tabbing out

- **Unified notify function** (`notify(title, body, tag)`):
  - Single guarded path for raising notifications with permission checks
  - Uses `tag` parameter to let the OS collapse repeats (e.g., a second low-health note replaces the first)
  - Focuses the window and closes the notification on click

- **HUD integration** (`hud.js`):
  - Added `onVitals` to the HUD API surface
  - Calls `api.onVitals(data)` after each vitals update so the page can drive HP-based notifications

- **Help text** (`/help settings`):
  - Reorganized to group all notification options under a "notify (while hidden):" section
  - Shows the low-health threshold value when enabled

- **CSS** (`hud.css`):
  - Added `.setting-group` and `.setting-group-h` for grouped settings with a small uppercase heading
  - Added `.setting-row-inline` for mixed checkbox + numeric input rows (flex-wrap, cursor handling)
  - Added `.setting-num` for the numeric input (monospace, right-aligned, 3.6em wide)
  - Added `.setting-suffix` for the `%` label (dimmed color)

## Implementation Notes

- **Damage trigger logic**: Anchors HP at tab-hide time; fires once on any dip below that anchor; re-arms on tab return. Lazily anchors if the toggle is flipped on mid-stretch.
- **Low-health trigger logic**: Fires once when at/under the threshold; re-arms when HP rises above it. Evaluated immediately on tab-hide in case no new vitals arrive while idle.
- **Beep throttling**: 15s minimum between beep notifications to prevent a chatty prompt-bell from spamming the user.
- **Permission flow**: All notify toggles request permission on first enable (via `Notification.request

https://claude.ai/code/session_01R5MgyDJBwRin9qeF8gPLch