### PR TITLE
HUD equipment/inventory: one-line rows, condition dots, collapsed packs, auto-stack

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -439,17 +439,38 @@ body.connect-page #content { padding: .5rem !important; }
 .row-more:hover { color: var(--ac-accent); background: var(--ac-bg); }
 
 /* ----- Generic rows (equipment / inventory) ----- */
+/* The row class is `.item-row`, NOT `.row`: Bootstrap's grid `.row` is loaded
+   globally, and its `.row > * { width: 100% }` would stack every cell (slot,
+   name, condition, ⋯) onto its own line. flex-wrap:nowrap keeps a row a row. */
 .row-list { list-style: none; margin: 0; padding: 0; }
-.row-list.sub { margin: 1px 0 3px 12px; }
-.row {
+.row-list.sub { margin: 1px 0 3px 14px; }
+.item-row {
     display: flex; align-items: center; gap: 6px; padding: 3px 4px; border-radius: 3px;
-    cursor: pointer; font-size: .82rem;
+    cursor: pointer; font-size: .82rem; flex-wrap: nowrap;
 }
-.row:hover { background: var(--ac-elev); }
-.row.sub { font-size: .78rem; color: var(--ac-dim); }
-.row.comp { color: var(--ac-text); }
-.row-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.item-row:hover { background: var(--ac-elev); }
+.item-row.sub { font-size: .78rem; color: var(--ac-dim); }
+.item-row.comp { color: var(--ac-text); }
+.row-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .slot { color: var(--ac-dim); font-size: .68rem; width: 56px; flex: none; text-transform: capitalize; }
+
+/* Condition as a single colour-coded dot (numeric % lives in the title).
+   Fixed width so it shares the lead column with a container's expand caret,
+   keeping item names aligned down the list. */
+.cond-dot { flex: none; width: .9rem; text-align: center; font-size: .55rem; line-height: 1; color: var(--ac-dim); }
+.cond-dot.cond-ok { color: var(--ac-ok); }
+.cond-dot.cond-mid { color: var(--hud-edge); }
+.cond-dot.cond-low { color: var(--ac-danger); }
+
+/* Expand caret on an open container row; toggles its contents (packs start
+   collapsed). Shares the lead column's width with .cond-dot. */
+.row-caret {
+    flex: none; width: .9rem; padding: 0; background: none; border: 0;
+    color: var(--ac-dim); cursor: pointer; font-size: .7rem; line-height: 1; text-align: center;
+}
+.row-caret:hover { color: var(--ac-accent); }
+/* Container state glyph (🔒 / 📦) for a closed or empty container. */
+.row-glyph { flex: none; color: var(--ac-dim); font-size: .82em; }
 .coins { margin: 5px 8px; font-size: .78rem; color: var(--hud-gold); }
 .comp-section { margin-top: 2px; }
 
@@ -760,8 +781,11 @@ body.connect-page #content { padding: .5rem !important; }
     #hud-tabs button { padding: 9px 3px; }
     .who-act button { padding: 7px 12px; }
     .skill { min-height: 44px; padding: 6px 10px; }
-    .row, .occ-row, .ab-row { min-height: 44px; padding: 8px 6px; }
+    .item-row, .occ-row, .ab-row { min-height: 44px; padding: 8px 6px; }
     .row-more { min-width: 40px; min-height: 40px; padding: 6px 8px; }
+    /* Taller (full row height) tap zone for the caret without widening the
+       lead column and shoving container names out of line with dotted rows. */
+    .row-caret { width: 1.6rem; min-height: 40px; }
     .action-btn { padding: 10px; }
     .sheet-close { padding: 8px 10px; }
     .panel-h-toggle { padding: 10px 8px; }

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -50,6 +50,10 @@
     // panels + Abilities-browser filters.
     var favorites = loadSet("ishar.favs");
     var collapsed = loadSet("ishar.collapsed");
+    // Which containers the player has expanded to view. Packs start COLLAPSED
+    // (default absent = closed): a carried bag shouldn't spill its whole
+    // contents into the inventory view unasked.
+    var expanded = loadSet("ishar.itemsExpanded");
     var abilityFilter = { q: "", type: "all", usableOnly: false };
     try {
         var af = JSON.parse(localStorage.getItem("ishar.abilityFilter"));
@@ -685,16 +689,43 @@
     // ------------------------------------------------------------------
     // Equipment
     // ------------------------------------------------------------------
-    function conditionNode(c) {
+    // Condition as one colour-coded dot — the numeric % and its word
+    // ("pristine"/"worn"/…) ride in the title rather than eating a whole row.
+    function conditionDot(c) {
         if (c == null) return null;
         // Real feed: int 0-100. Older/demo: a word. Colour numeric by value.
         var n = Number(c);
         if (!isNaN(n) && String(c).match(/^\s*\d/)) {
             var cls = n >= 90 ? "cond-ok" : n >= 50 ? "cond-mid" : "cond-low";
             var lbl = n >= 95 ? "pristine" : n >= 75 ? "good" : n >= 40 ? "worn" : n > 0 ? "battered" : "ruined";
-            return el("span", { class: "tag " + cls, title: "Condition " + n + "%", text: lbl });
+            return el("span", { class: "cond-dot " + cls, title: "Condition " + n + "% — " + lbl, "aria-hidden": "true", text: "●" });
         }
-        return el("span", { class: "tag", text: String(c) });
+        return el("span", { class: "cond-dot", title: "Condition " + String(c), "aria-hidden": "true", text: "●" });
+    }
+    // A stable key for a container's expand state (vnum when the game sends
+    // one, else its target keyword).
+    function containerKey(it) {
+        return it.vnum != null ? "v" + it.vnum : "k" + targetOf(it.keywords || it.name);
+    }
+    // Fold identical stackable items into one row with a ×count. The game
+    // often emits duplicate rows instead of a count (two "a glyph of
+    // teleportation"), so we default to stacking: same name + type +
+    // condition merges. Containers are always distinct (each may hold
+    // different things) and are never merged.
+    function groupStackables(items) {
+        var out = [], seen = {};
+        (items || []).forEach(function (it) {
+            if (it.type === "container" || (it.contents && it.contents.length)) { out.push(it); return; }
+            var key = stripColor(it.name || "") + "\x1f" + (it.type || "") + "\x1f" + (it.condition == null ? "" : it.condition);
+            var qty = Number(it.count) || 1;
+            if (seen[key] != null) { out[seen[key]].count += qty; return; }
+            var copy = {};
+            for (var k in it) if (Object.prototype.hasOwnProperty.call(it, k)) copy[k] = it[k];
+            copy.count = qty;
+            seen[key] = out.length;
+            out.push(copy);
+        });
+        return out;
     }
     function itemDataset(it, kind, container) {
         return {
@@ -707,33 +738,65 @@
             "data-closed": it.closed ? "1" : ""
         };
     }
+    // One inventory/equipment row. Everything stays on a single line: an
+    // optional lead cell (an expand caret for an open container, else a
+    // condition dot), the name, a ×count, a container state glyph, and the
+    // ⋯ actions button.
     function itemRow(it, kind, container) {
         var ds = itemDataset(it, kind, container);
+        var isContainer = it.type === "container";
+        var hasContents = !!(it.contents && it.contents.length);
         var kids = [];
         if (kind === "equip") kids.push(el("span", { class: "slot", text: it.location || it.slot || "" }));
+        // Lead cell (fixed-width so names align): caret for an expandable
+        // container, otherwise the condition dot.
+        if (isContainer && hasContents) {
+            var ck = containerKey(it), isOpen = !!expanded[ck];
+            kids.push(el("button", {
+                type: "button", class: "row-caret", "data-expand": ck,
+                "aria-expanded": isOpen ? "true" : "false",
+                "aria-label": (isOpen ? "Collapse contents of " : "Expand contents of ") + stripColor(it.name || "container"),
+                text: isOpen ? "▾" : "▸"
+            }));
+        } else if (!isContainer) {
+            var dot = conditionDot(it.condition);
+            if (dot) kids.push(dot);
+        }
         kids.push(el("span", { class: "row-name", text: stripColor(it.name) }));
         if (it.count && it.count > 1) kids.push(el("span", { class: "tag", text: "×" + it.count }));
-        if (kind === "equip") { var cn = conditionNode(it.condition); if (cn) kids.push(cn); }
-        if (it.type === "container") kids.push(el("span", { class: "dim", "aria-hidden": "true", text: it.closed ? " 🔒" : " 📦" }));
+        // A closed/locked (or empty) container can't be searched inline — mark
+        // its state with a glyph instead of a caret.
+        if (isContainer && (it.closed || !hasContents)) {
+            kids.push(el("span", {
+                class: "row-glyph", "aria-hidden": "true",
+                title: it.locked ? "Locked" : it.closed ? "Closed" : "Container",
+                text: it.closed || it.locked ? "🔒" : "📦"
+            }));
+        }
         kids.push(el("button", { type: "button", class: "row-more", "aria-label": "Actions", text: "⋯" }));
-        ds.class = "row" + (kind === "content" ? " sub" : "");
+        ds.class = "item-row" + (kind === "content" ? " sub" : "");
         return el("li", assign(ds, {}), kids);
     }
     function assign(a, b) { Object.keys(b).forEach(function (k) { a[k] = b[k]; }); return a; }
 
-    // A row list where any container row is followed by a sub-list of its (open)
-    // contents. Shared by the inventory and equipment panels so a WORN container
-    // (a backpack on the back) is inspectable exactly like a carried one — the
-    // game already emits worn-container contents in Char.Equipment (#1590); the
-    // equipment panel just wasn't rendering them (issue #1801).
+    // A row list where an open, expanded container row is followed by a
+    // sub-list of its contents. Shared by the inventory and equipment panels
+    // so a WORN container (a backpack on the back) is inspectable exactly like
+    // a carried one — the game already emits worn-container contents in
+    // Char.Equipment (#1590); the equipment panel just wasn't rendering them
+    // (issue #1801). Contents render only when the container is expanded
+    // (packs start collapsed); stackable rows are folded to a ×count.
     function itemListWithContents(items, kind) {
         var list = el("ul", { class: "row-list" });
-        (items || []).forEach(function (it) {
+        // Worn gear occupies distinct slots (Head, Left/Right finger, …) so it
+        // is never stacked; carried piles are.
+        var top = kind === "equip" ? (items || []) : groupStackables(items);
+        top.forEach(function (it) {
             list.appendChild(itemRow(it, kind));
-            if (it.contents && it.contents.length) {
+            if (it.type === "container" && it.contents && it.contents.length && expanded[containerKey(it)]) {
                 var sub = el("ul", { class: "row-list sub" });
                 var ct = targetOf(it.keywords || it.name);
-                it.contents.forEach(function (c) { sub.appendChild(itemRow(c, "content", ct)); });
+                groupStackables(it.contents).forEach(function (c) { sub.appendChild(itemRow(c, "content", ct)); });
                 list.appendChild(sub);
             }
         });
@@ -809,7 +872,7 @@
                     // Real keyword: a tap withdraws from the pouch directly (the
                     // requested behaviour); ⋯ opens deposit/examine.
                     var tgt = targetOf(c.keywords);
-                    li = el("li", { class: "row comp", "data-cmd": "get " + tgt + " pouch", title: "Withdraw from pouch — ⋯ for more" }, [
+                    li = el("li", { class: "item-row comp", "data-cmd": "get " + tgt + " pouch", title: "Withdraw from pouch — ⋯ for more" }, [
                         el("span", { class: "row-name", text: name }),
                         c.count > 1 ? el("span", { class: "tag", text: "×" + c.count }) : null,
                         el("button", { type: "button", class: "row-more", "data-menu": "component", "data-target": tgt, "data-name": name, "aria-label": "Actions", text: "⋯" })
@@ -817,7 +880,7 @@
                 } else {
                     // No keywords (pre-deploy of the game field): a name-derived
                     // withdraw wouldn't resolve, so offer examine only.
-                    li = el("li", { class: "row comp", "data-cmd": "examine " + targetOf(c.name), title: "Examine" }, [
+                    li = el("li", { class: "item-row comp", "data-cmd": "examine " + targetOf(c.name), title: "Examine" }, [
                         el("span", { class: "row-name", text: name }),
                         c.count > 1 ? el("span", { class: "tag", text: "×" + c.count }) : null
                     ]);
@@ -1533,6 +1596,19 @@
             e.preventDefault();
             return;
         }
+        // 1b) Container expand carets — checked before the row's own action
+        // menu so a tap on the caret only toggles its contents.
+        var exp = e.target.closest("[data-expand]");
+        if (exp && dom.app.contains(exp)) {
+            var ekey = exp.getAttribute("data-expand");
+            if (expanded[ekey]) delete expanded[ekey]; else expanded[ekey] = true;
+            saveSet("ishar.itemsExpanded", expanded);
+            renderEquipment();
+            renderInventory();
+            api.onLayoutChange();
+            e.preventDefault();
+            return;
+        }
         // 2) Ability chip filters + star.
         var chip = e.target.closest("[data-abtype],[data-abusable]");
         if (chip && dom.app.contains(chip)) {
@@ -1894,13 +1970,19 @@
                 { name: "a talon-barbed whip", keywords: "whip talon", type: "weapon", vnum: 3, location: "Wielding", condition: 35 },
                 { name: "a sturdy traveling pack", keywords: "pack traveling", type: "container", vnum: 4, location: "Back", closeable: true, closed: false, contents: [
                     { name: "a flask of lamp oil", keywords: "flask oil", count: 2 },
-                    { name: "a coil of silk rope", keywords: "rope silk coil", count: 1 }
+                    { name: "a coil of silk rope", keywords: "rope silk coil", count: 1 },
+                    // Duplicate rows (no count) — the game emits these; the HUD
+                    // folds them to "a glyph of teleportation ×2".
+                    { name: "a glyph of teleportation", keywords: "glyph teleportation" },
+                    { name: "a glyph of teleportation", keywords: "glyph teleportation" }
                 ] },
                 { name: "a rune-locked coffer", keywords: "coffer runelocked", type: "container", vnum: 5, location: "Held", closeable: true, closed: true, locked: true }
             ] },
             "Char.Inventory": { items: [
                 { name: "a glowing potion", keywords: "potion glowing", type: "potion", vnum: 10, count: 3 },
+                // Two separate rows for the same scroll — fold to ×2.
                 { name: "a scroll of recall", keywords: "scroll recall", type: "scroll", vnum: 12, count: 1 },
+                { name: "a scroll of recall", keywords: "scroll recall", type: "scroll", vnum: 12 },
                 { name: "a leather sack", keywords: "sack leather", type: "container", vnum: 11, count: 1, closeable: true, closed: false, contents: [{ name: "a brass key", keywords: "key brass", count: 1 }] }
             ], coins: [{ name: "gold", vnum: 0, count: 18230 }, { name: "silver", vnum: 0, count: 340 }, { name: "obsidian", vnum: 0, count: 12 }], components: [
                 { name: "a pinch of sulfur", keywords: "sulfur pinch", count: 7 },

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -382,10 +382,21 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
 - **`.hud-btn`(`--icon`)** — the topbar button, aligned with `.ac-btn`.
 - **`#hud-dock button`** — icon-over-label phone tabs; `.unread` renders an
   amber dot (used by Chat).
-- **`.exit` compass, `.row` lists, `.kv`, `.aff`, `.skill` hotbar** — the
+- **`.exit` compass, `.item-row` lists, `.kv`, `.aff`, `.skill` hotbar** — the
   in-panel widgets; all have coarse-pointer bumps and `:focus-visible` rings.
   Hotbar buttons always contain both `.skill-cd` and `.skill-pct`; the
   `.cooling` class (flipped by JS each tick) picks which one shows.
+- **`.item-row`** — the equipment/inventory row (NB: **not** `.row` — that's
+  Bootstrap's grid class, loaded globally; see decisions.md). One nowrap flex
+  line: an optional lead cell (a `.row-caret` on an expandable container, else
+  a `.cond-dot`), `.row-name` (ellipsized), a `.tag` ×count, an optional
+  `.row-glyph` (🔒/📦) for a closed container, and the trailing `.row-more` ⋯.
+  Item condition is a **colour-coded `.cond-dot`** (● ok/mid/low, exact % in
+  the `title`), never a word on its own line. Worn containers expand inline
+  to a `.row-list.sub`; **packs start collapsed** and toggle via the caret
+  (`data-expand`, persisted in `ishar.itemsExpanded`). Identical stackable
+  rows are folded to one `×N` (the game emits duplicate rows; the HUD
+  defaults to stacking).
 - **`#history-pop` / `.hist-item`** — the touch command-history popover,
   anchored above the input inside `#command-form` (works with the HUD off;
   rows are `textContent`-built, 44px on coarse pointers). Revealed via

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -803,3 +803,47 @@ pressure is a number, not a count-the-red-tags exercise. Feed-side renames
 ride along: the group feed's opponent field is `fighting_name` (display
 name, redacted to "someone" when the recipient couldn't see them) — distinct
 on purpose from the occupants feed's `fighting` handle.
+
+---
+
+## 2026-07-16 — HUD equipment/inventory rows: one line, dot condition, collapsed packs, auto-stack
+
+**Decision.** The equipment and inventory rows are rebuilt around a single
+class, **`.item-row`** (renamed from `.row`), and four rules:
+
+- **One nowrap line per item.** The row is `display:flex; flex-wrap:nowrap`;
+  `.row-name` carries `min-width:0` so it ellipsizes instead of forcing wraps.
+- **Condition is a colour dot, not a word.** `conditionNode` → `conditionDot`:
+  a single `.cond-dot` (● ok/mid/low, same breakpoints as the group hp tint),
+  with the exact "N% — pristine/worn/…" in the `title`. It no longer consumes
+  a whole line.
+- **The ⋯ actions button and container glyph stay inline** (they were only ever
+  wrapping because of the bug below), and a closed/locked container shows a
+  `.row-glyph` (🔒/📦) instead of an expand affordance.
+- **Worn/carried containers start collapsed.** An open container gets a
+  `.row-caret` (`data-expand`, keyed by vnum, persisted in
+  `ishar.itemsExpanded`); its contents (`.row-list.sub`) render only when
+  expanded. Opening your bag no longer dumps its whole contents into the view.
+- **Identical stackables auto-fold to `×N`.** The game emits duplicate rows
+  rather than a count (two "a glyph of teleportation"); `groupStackables`
+  merges same name+type+condition into one row with a summed count. Worn gear
+  is never stacked (slots are distinct); containers are never merged.
+
+**Why.** The visible symptom — every cell (slot, name, condition, ⋯, glyph)
+stacked onto its own line, packs force-expanded — was a **class-name
+collision**: the HUD's `.row` is also **Bootstrap's grid `.row`**, loaded
+globally on every page, whose `.row > * { width:100%; flex-shrink:0 }` and
+`flex-wrap:wrap` forced each child to a full-width line. Renaming to
+`.item-row` escapes the grid entirely (the correct green-field fix, not a
+`!important` patch). The remaining three changes are the density win the
+collision was hiding: a 30-year item list on a phone wants a colour tick, an
+inline menu handle, and bags you open on purpose — not a three-line block per
+item.
+
+**Notes.** Discipline unchanged: `el()`/textContent only, tokens for every
+colour (`--ac-ok`/`--hud-edge`/`--ac-danger` for the dot), ≥44px touch targets
+(the caret gets a full-row-height tap zone without widening the lead column).
+Condition detail now lives in the `title`/Examine rather than on-screen text —
+an accepted trade for the tiny known audience, consistent with the game's own
+condition-colour language. Verify with `/connect?demo=1` (the demo feed now
+carries duplicate rows and a multi-item pack to exercise stacking + expand).


### PR DESCRIPTION
## Summary

Rebuilds the equipment and inventory row layout to fix a Bootstrap grid collision that was stacking every cell (slot, name, condition, actions) onto separate lines. Renames `.row` → `.item-row` to escape Bootstrap's global `.row` class, then applies four density improvements: condition as a colour-coded dot (not a word), containers start collapsed (not force-expanded), identical stackables auto-fold to ×N, and all content stays on a single nowrap flex line.

## Changes

- **Class rename & flex fix:** `.row` → `.item-row` with `flex-wrap: nowrap` to keep rows as single lines. Bootstrap's `.row > * { width: 100% }` was forcing wraps; the rename escapes that collision entirely.

- **Condition display:** `conditionNode()` → `conditionDot()` — a single colour-coded bullet (● ok/mid/low, same breakpoints as group HP tint) with the exact "N% — pristine/worn/…" in the `title` attribute. Frees up a full line per item.

- **Container expand/collapse:** New `expanded` state (persisted in `ishar.itemsExpanded`, keyed by vnum or keyword). Containers start collapsed; an open container shows a `.row-caret` (▸/▾) that toggles its `.row-list.sub` contents. Closed/locked/empty containers show a `.row-glyph` (🔒/📦) instead.

- **Auto-stacking:** New `groupStackables()` function merges identical items (same name + type + condition) into one row with a summed count. The game emits duplicate rows instead of counts; the HUD now defaults to folding them. Worn gear is never stacked (slots are distinct); containers are never merged.

- **Lead cell alignment:** Condition dots and expand carets share a fixed-width lead column (`.cond-dot`, `.row-caret` both `width: .9rem`), keeping item names aligned down the list.

- **Touch targets:** On coarse pointers, `.row-caret` expands to `width: 1.6rem; min-height: 40px` for a full-row-height tap zone without widening the lead column.

- **Demo data:** Updated `Char.Equipment` and `Char.Inventory` fixtures to include duplicate rows and a multi-item pack, exercising stacking and expand behavior.

## Implementation Notes

- Discipline unchanged: `el()`/textContent only, tokens for every colour (`--ac-ok`, `--hud-edge`, `--ac-danger`), ≥44px touch targets.
- Condition detail now lives in the `title`/Examine rather than on-screen text — an accepted trade for the tiny known audience, consistent with the game's own condition-colour language.
- The visible symptom (every cell on its own line, packs force-expanded) was entirely a CSS collision; the remaining three changes are the density win that collision was hiding.
- Verify with `/connect?demo=1` (demo feed now carries duplicate rows and a multi-item pack).

See `docs/design/decisions.md` for the full rationale and design notes.

https://claude.ai/code/session_01Qt6Un6Wj3XKFL9aXr5zC2J