### PR TITLE
Add hunger/thirst indicators to HP and MV bars

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -203,6 +203,20 @@ body.connect-page #content { padding: .5rem !important; }
     .vbar-track { height: 14px; }
 }
 
+/* Hunger / thirst reserve icon riding the end of the HP (food) and MV (water)
+   bars. Quiet and dim when the reserve is healthy; it warms to amber as it
+   runs low and reddens when the game would warn you're "very hungry/thirsty",
+   so it only pulls the eye when there's something to act on. */
+.vbar-reserve { flex: 0 0 auto; display: inline-flex; align-items: center; line-height: 0; }
+.vbar-reserve-icon { width: .82rem; height: .82rem; }
+.vbar-reserve[data-state="ok"]   { color: var(--ac-dim); opacity: .65; }
+.vbar-reserve[data-state="low"]  { color: var(--hud-edge); opacity: 1; }
+.vbar-reserve[data-state="crit"] { color: var(--ac-danger); opacity: 1; }
+@media (prefers-reduced-motion: no-preference) {
+    .vbar-reserve[data-state="crit"] { animation: reserve-pulse 1.5s ease-in-out infinite; }
+    @keyframes reserve-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .4; } }
+}
+
 /* ----- Left column: scrolling stack + pinned compass rose ----- */
 #hud-left {
     display: flex; flex-direction: column; gap: 6px;

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -62,6 +62,7 @@
     var barLocked = localStorage.getItem("ishar.barUnlocked") !== "1";
     var pickedSlot = null;                     // tap-to-swap source (edit mode)
     var spriteUrl = "";                        // game-icons sprite URL (set in init)
+    var biUrl = "";                            // Bootstrap Icons sprite URL (set in init)
     var collapsed = loadSet("ishar.collapsed");
     // Which containers the player has expanded to view. Packs start COLLAPSED
     // (default absent = closed): a carried bag shouldn't spill its whole
@@ -375,6 +376,24 @@
         return svg;
     }
 
+    // Build an <svg><use> referencing the self-hosted Bootstrap Icons sprite
+    // (the same sprite the page chrome uses via {% bi %}). `name` is a fixed
+    // vocabulary from this file, but sanitize anyway so a stray value can't
+    // smuggle markup into the href. The symbol carries its own 0 0 16 16
+    // viewBox, so — like {% bi %} — the wrapper sets none.
+    function biSvg(name, cls) {
+        name = String(name || "").replace(/[^a-z0-9-]/g, "");
+        var svg = document.createElementNS(SVGNS, "svg");
+        svg.setAttribute("class", cls || "bi");
+        svg.setAttribute("aria-hidden", "true");
+        var use = document.createElementNS(SVGNS, "use");
+        var href = biUrl + "#" + name;
+        use.setAttributeNS(XLINKNS, "xlink:href", href);
+        use.setAttribute("href", href);
+        svg.appendChild(use);
+        return svg;
+    }
+
     // DOM builder — the ONLY way data-derived nodes are created here. Values
     // reach the DOM as text/attributes, never parsed as markup.
     function el(tag, attrs, kids) {
@@ -586,13 +605,51 @@
     function vitalsShape(v) {
         return (v && v.opponent_hp_pct != null ? "t" : "")
             + (v && v.metamagic != null ? "m" : "")
-            + (v && v.edge != null ? "e" : "");
+            + (v && v.edge != null ? "e" : "")
+            + (v && v.food != null ? "f" : "")
+            + (v && v.water != null ? "w" : "");
     }
+
+    // Hunger / thirst reserves ride the HP and MV bars (food fuels HP regen,
+    // water fuels move regen — eating/drinking refill those pools). `food` and
+    // `water` are a 0-100 percentage of the max reserve; the game omits them
+    // when hunger/thirst doesn't apply (immortals), so the indicator is absent.
+    // The state thresholds mirror the game's `score` warnings: <= PHPT/2 of the
+    // pool (≈16%) is "very hungry/thirsty", <= PHPT (≈33%) is "getting…".
+    function reserveState(pct) {
+        if (pct == null) return "ok";
+        if (pct <= 16) return "crit";
+        if (pct <= 33) return "low";
+        return "ok";
+    }
+    function reserveTitle(kind, pct) {
+        var food = kind === "food";
+        var word = pct == null ? "" : (pct <= 16 ? (food ? "very hungry" : "very thirsty")
+            : pct <= 33 ? (food ? "getting hungry" : "getting thirsty")
+            : (food ? "well fed" : "hydrated"));
+        return (food ? "Food" : "Water") + " reserve: " + (pct == null ? "—" : pct + "%")
+            + (word ? " — " + word : "");
+    }
+    // A small state-tinted icon appended to the HP (food) / MV (water) bar.
+    function reserveEl(kind, pct) {
+        return el("span", {
+            class: "vbar-reserve " + kind,
+            "data-state": reserveState(pct),
+            title: reserveTitle(kind, pct),
+            "aria-label": reserveTitle(kind, pct),
+            role: "img"
+        }, [biSvg(kind === "food" ? "apple" : "droplet-fill", "bi vbar-reserve-icon")]);
+    }
+
     function cacheVitalsRefs() {
-        vitalsCache = { shape: vitalsShape(S.vitals), bars: {} };
+        vitalsCache = { shape: vitalsShape(S.vitals), bars: {}, reserves: {} };
         ["hp", "mp", "mv", "tgt", "mm", "edge"].forEach(function (cls) {
             var e = dom.vitals.querySelector(".vbar." + cls);
             if (e) vitalsCache.bars[cls] = { fill: e.querySelector(".vbar-fill"), text: e.querySelector(".vbar-text") };
+        });
+        ["food", "water"].forEach(function (k) {
+            var e = dom.vitals.querySelector(".vbar-reserve." + k);
+            if (e) vitalsCache.reserves[k] = e;
         });
     }
     function updateVitals() {
@@ -615,6 +672,16 @@
         }
         upd("mm", v && v.metamagic != null ? v.metamagic : null, v ? v.metamagic_max : 0);
         upd("edge", v && v.edge != null ? v.edge : null, v ? v.edge_max : 0);
+        updReserve("food", v && v.food != null ? v.food : null);
+        updReserve("water", v && v.water != null ? v.water : null);
+    }
+    function updReserve(kind, pct) {
+        var n = vitalsCache.reserves[kind];
+        if (!n || pct == null) return;
+        n.setAttribute("data-state", reserveState(pct));
+        var t = reserveTitle(kind, pct);
+        n.setAttribute("title", t);
+        n.setAttribute("aria-label", t);
     }
     function vbar(label, cur, max, cls) {
         var has = cur !== null && cur !== undefined;
@@ -632,9 +699,15 @@
         var sub = st ? ("L" + st.level + " " + st.race + " " + st["class"])
                      : (S.connected ? "awaiting character data" : "not connected");
 
-        var barKids = [vbar("HP", v ? v.hp : null, v ? v.maxhp : 0, "hp"),
+        var hpBar = vbar("HP", v ? v.hp : null, v ? v.maxhp : 0, "hp");
+        var mvBar = vbar("MV", v ? v.move : null, v ? v.maxmove : 0, "mv");
+        // Food rides the HP bar, water the MV bar — that's the pool each one
+        // refills. Present only when the game sends them (mortals with hunger).
+        if (v && v.food != null) hpBar.appendChild(reserveEl("food", v.food));
+        if (v && v.water != null) mvBar.appendChild(reserveEl("water", v.water));
+        var barKids = [hpBar,
                        vbar("MP", v ? v.mp : null, v ? v.maxmp : 0, "mp"),
-                       vbar("MV", v ? v.move : null, v ? v.maxmove : 0, "mv")];
+                       mvBar];
         if (v && v.opponent_hp_pct != null) {
             barKids.push(el("div", { class: "vbar tgt" }, [
                 el("span", { class: "vbar-label", text: "Foe" }),
@@ -2460,6 +2533,7 @@
         if (opts.onComm) api.onComm = opts.onComm;
         if (opts.onVitals) api.onVitals = opts.onVitals;
         if (opts.spriteUrl) spriteUrl = String(opts.spriteUrl);
+        if (opts.biUrl) biUrl = String(opts.biUrl);
         if (opts.skillIcons && typeof opts.skillIcons === "object") curatedIcons = opts.skillIcons;
 
         dom.app = document.getElementById("connect-app");
@@ -2584,7 +2658,7 @@
 
         var feeds = {
             "Char.Status": { name: "Aelwyn", "class": "Magician", race: "Elf", position: "Standing", level: 45, align: 350, xp: 1250000, tnl: 48000, gold: 18230, bank: 500000, remort: 3 },
-            "Char.Vitals": { hp: 412, maxhp: 480, mp: 130, maxmp: 300, move: 198, maxmove: 240, position: "Standing", opponent_hp_pct: 35, metamagic: 60, metamagic_max: 100, metamagic_regen: 5 },
+            "Char.Vitals": { hp: 412, maxhp: 480, mp: 130, maxmp: 300, move: 198, maxmove: 240, position: "Standing", opponent_hp_pct: 35, metamagic: 60, metamagic_max: 100, metamagic_regen: 5, food: 27, water: 9 },
             "Game.Time": { hour: 21, hour12: 9, ampm: "pm", day: 14, day_name: "Sunday", month: 6, month_name: "the Long Shadows", year: 1247, night: true, season_id: 15, season_end: 0, events: [{ name: "Double Essence", seconds: 5400 }, { name: "Festival of Flames" }], moons: [{ name: "Shavar", phase: 4, phase_name: "full", up: true }, { name: "Chenchir", phase: 6, phase_name: "last quarter", up: true }] },
             "Room.Info": { num: 3001, name: "The Grand Concourse", area: "Ishar Nexus", environment: "City", exits: { n: 3002, e: 3005, s: 3008, w: 3010, u: 3100, d: 3200, into: 3500 } },
             "Room.Occupants": { occupants: [

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -933,6 +933,7 @@
             onComm: onComm,
             onVitals: onVitals,
             spriteUrl: "{% static 'img/game-icons.svg' %}",
+            biUrl: "{% static 'bootstrap-icons/bootstrap-icons.svg' %}",
             skillIcons: (function() {
                 try {
                     var e = document.getElementById("ishar-skill-icons");

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -379,6 +379,10 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   (denser cousins of `.ac-panel` / `.ac-panel__h`).
 - **`.vbar` / `.mini`** — labeled vitals bars (HP/MP/MV/Foe/XP/MM/Edge) and
   the tiny group-member triple.
+- **`.vbar-reserve`** — the hunger (`.food`, apple) / thirst (`.water`, droplet)
+  icon riding the end of the HP and MV bars; `data-state` `ok`/`low`/`crit`
+  tints it dim → `--hud-edge` → `--ac-danger`. Built client-side via `biSvg()`
+  from `Char.Vitals.food`/`water` (see decisions.md 2026-07-17).
 - **`.hud-btn`(`--icon`)** — the topbar button, aligned with `.ac-btn`.
 - **`#hud-dock button`** — icon-over-label phone tabs; `.unread` renders an
   amber dot (used by Chat).

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -979,3 +979,47 @@ Condition detail now lives in the `title`/Examine rather than on-screen text —
 an accepted trade for the tiny known audience, consistent with the game's own
 condition-colour language. Verify with `/connect?demo=1` (the demo feed now
 carries duplicate rows and a multi-item pack to exercise stacking + expand).
+
+---
+
+## 2026-07-17 — HUD hunger/thirst indicators ride the HP and MV bars
+
+**Decision.** Hunger and thirst surface as a **small state-tinted icon at the
+end of the HP bar (food, Bootstrap Icons `apple`) and the MV bar (thirst,
+`droplet-fill`)** — not a new stacked row, not a word. The tint is the only
+signal that changes: **dim/muted** while the reserve is healthy, **amber**
+(`--hud-edge`) once it runs low, **red** (`--ac-danger`, with a
+reduced-motion-gated pulse) when the game would warn you're "very
+hungry/thirsty". The exact percentage + word live in the `title`/`aria-label`.
+
+**Why the HP and MV bars specifically.** In the game hunger/thirst is
+**pool-based, not a DikuMUD 0–24 counter**: eating refills the **HP-regen
+pool**, drinking the **move-regen pool**, and `score`'s hunger/thirst warnings
+read exactly those two pools (`get_pool(pc,HITP)` vs `PHPT`,
+`get_pool(pc,MOVP)` vs `PMPT`; `MAX_POOL = PERM_PTS*3`). So food *is* the HP
+bar's reserve and water *is* the MV bar's — pinning the icon to that bar is
+mechanically true, not decorative. The state thresholds mirror `score`: `≤16%`
+of the pool (game's `<PHPT/2`) is crit, `≤33%` (`<=PHPT`) is low.
+
+**Data.** Two new optional `Char.Vitals` fields, `food` and `water`
+(0–100 percent of the max reserve), added game-side (ishar-mud#1824). The game
+**omits them when hunger/thirst doesn't apply** (immortals / any "unlimited"
+reserve), so the indicator is simply absent rather than pinned full. They ride
+the per-prompt vitals because the reserves drain continuously as you regen; the
+client folds them into the existing `updateVitals` hot path (in-place
+`data-state`/`title` swaps, no extra re-render) with presence tracked in
+`vitalsShape`.
+
+**Convention set: client-side Bootstrap Icons via `biSvg()`.** The HUD chrome
+already uses Bootstrap Icons through `{% bi %}` server-side; the vitals are
+client-rendered, so a small `biSvg(name, cls)` helper (mirroring the
+game-icons `iconSvg()`) now builds `<use>` refs into the self-hosted
+`bootstrap-icons.svg` sprite, fed a `biUrl` init option. Game-icons stays the
+language for skills/abilities; Bootstrap Icons for HUD status chrome — no new
+dependency, no sprite surgery. Reach for `biSvg()` for future HUD status glyphs
+rather than adding one-off symbols to the game-icons subset.
+
+**Notes.** Discipline unchanged: `el()`/`textContent` only, every colour from a
+token, motion gated behind `prefers-reduced-motion`, and the icon sits inside
+the existing bar's row (no new tap target). Verify with `/connect?demo=1`
+(the demo feed now carries `food`/`water` so both a low and a crit state show).


### PR DESCRIPTION
## Summary

Surface hunger and thirst as small state-tinted icons riding the HP bar (food, apple) and MV bar (water, droplet) respectively. The icon tint signals reserve health: dim when healthy, amber when low, red when critical (with a reduced-motion-gated pulse). Exact percentage and descriptive text live in the `title`/`aria-label`.

## Changes

- **New `biSvg()` helper** — mirrors the existing `iconSvg()` pattern to build `<use>` refs into the self-hosted Bootstrap Icons sprite. Establishes a convention for client-side Bootstrap Icons (HUD status chrome) vs. game-icons (skills/abilities).

- **Two new optional `Char.Vitals` fields** — `food` and `water` (0–100 percent of max reserve). The game omits them when hunger/thirst doesn't apply (immortals), so the indicator is simply absent rather than pinned full.

- **Reserve state tracking** — `reserveState()` maps percentage to `ok`/`low`/`crit` thresholds (≤16% = crit, ≤33% = low), mirroring the game's `score` warnings. `reserveTitle()` builds the descriptive text.

- **Reserve element builder** — `reserveEl()` creates the icon span with `data-state` attribute, `title`, and `aria-label`. Appended to the HP bar (food) and MV bar (water) during vitals render.

- **Vitals cache extension** — `vitalsCache.reserves` tracks the reserve elements for in-place updates. `updReserve()` swaps `data-state`/`title`/`aria-label` on each prompt without re-rendering.

- **CSS for reserve icons** — `.vbar-reserve` and `.vbar-reserve-icon` with state-based color tokens (`--ac-dim` → `--hud-edge` → `--ac-danger`) and a reduced-motion-gated pulse animation for crit state.

- **Init option** — `biUrl` passed to `hud.init()` to set the Bootstrap Icons sprite URL (fed from `connect.html` template).

- **Demo feed update** — `Char.Vitals` now includes `food: 27, water: 9` to exercise both low and crit states.

## Implementation Notes

- Discipline unchanged: `el()`/`textContent` only, every colour from a token, motion gated behind `prefers-reduced-motion`, and the icon sits inside the existing bar's row (no new tap target).
- The reserves drain continuously as you regen, so they ride the per-prompt vitals hot path (in-place swaps, no extra re-render) with presence tracked in `vitalsShape`.
- Mechanically true: food refills the HP-regen pool, water the move-regen pool — pinning the icon to that bar is not decorative.
- See `docs/design/decisions.md` 2026-07-17 for full rationale and game-side context (ishar-mud#1824).

https://claude.ai/code/session_01L6oKDUkCzycXX6PQEYXn7B