### PR TITLE
Add professions overlay app: the HUD extension model

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -812,9 +812,20 @@ body.connect-page #content { padding: .5rem !important; }
     letter-spacing: .06em; color: var(--ac-dim); padding: 6px 0 2px;
 }
 .recipe-row { display: flex; align-items: center; gap: 6px; padding: 3px 0; }
-.recipe-name { font-size: .82rem; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The name is the component-details disclosure — the TOUCH path to "what am
+   I missing?" (the hover title is desktop convenience only). */
+.recipe-toggle {
+    flex: 1; min-width: 0; display: block; text-align: left;
+    background: none; border: 0; padding: 0; cursor: pointer;
+}
+.recipe-name { font-size: .82rem; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .recipe-rank { flex: none; font-variant-numeric: tabular-nums; }
 .recipe-ok { flex: none; color: var(--ac-ok); }
+.recipe-comps { padding: 2px 0 6px 10px; border-left: 2px solid var(--ac-border); margin-left: 2px; }
+.recipe-comp { font-size: .74rem; padding: 1px 0; font-variant-numeric: tabular-nums; }
+.recipe-comp.ok { color: var(--ac-ok); }
+.recipe-comp.missing { color: var(--ac-danger); }
+.recipe-comp.loc { color: var(--ac-dim); }
 .prof-btn.off { opacity: .45; }
 
 /* Profession difficulty buckets (docs/gmcp_feeds.md) — the same palette the

--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -68,9 +68,10 @@ body.connect-page #content { padding: .5rem !important; }
 
 .hud-off #hud-left,
 .hud-off #hud-right,
-.hud-off #hud-hotbar,
+.hud-off #hud-actionrow,
 .hud-off #hud-dock,
 .hud-off #hud-sheet,
+.hud-off #hud-overlay,
 .hud-off #hud-menu,
 .hud-off #rose-overlay,
 .hud-off #rose-toggle,
@@ -797,7 +798,11 @@ body.connect-page #content { padding: .5rem !important; }
 .prof-btn:hover { border-color: var(--ac-accent); }
 .prof-empty, .prof-hint { font-size: .76rem; color: var(--ac-dim); padding: 6px 2px; }
 .prof-hint { border-top: 1px solid var(--ac-border); margin-top: 8px; font-family: monospace; }
-@media (pointer: coarse) { .prof-btn { min-height: 40px; padding: 6px 12px; } }
+/* Tablets show the micro-menu with a coarse pointer — bump its launchers too. */
+@media (pointer: coarse) {
+    .prof-btn { min-height: 40px; padding: 6px 12px; }
+    .micro-btn { width: 42px; height: 42px; }
+}
 
 /* ----- Context / action menu ----- */
 #hud-menu {

--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -777,7 +777,13 @@ body.connect-page #content { padding: .5rem !important; }
 }
 .prof-row { padding: 8px 2px; border-bottom: 1px solid var(--ac-border); }
 .prof-row:last-of-type { border-bottom: 0; }
-.prof-head { display: flex; align-items: baseline; gap: 8px; }
+/* The header is the recipe-list disclosure — a full-width unstyled button. */
+.prof-head {
+    display: flex; align-items: baseline; gap: 8px; width: 100%;
+    background: none; border: 0; padding: 0; cursor: pointer; text-align: left;
+    color: var(--ac-text);
+}
+.prof-caret { color: var(--ac-dim); font-size: .8rem; }
 .prof-name { font-weight: 700; font-size: .9rem; color: var(--ac-text); }
 .prof-tier { flex: none; }
 .prof-rank { margin-left: auto; font-size: .74rem; color: var(--ac-dim); font-variant-numeric: tabular-nums; }
@@ -798,6 +804,28 @@ body.connect-page #content { padding: .5rem !important; }
 .prof-btn:hover { border-color: var(--ac-accent); }
 .prof-empty, .prof-hint { font-size: .76rem; color: var(--ac-dim); padding: 6px 2px; }
 .prof-hint { border-top: 1px solid var(--ac-border); margin-top: 8px; font-family: monospace; }
+
+/* Recipe browser (Char.Recipes) inside a profession row. */
+.recipe-list { margin-top: 4px; padding-left: 14px; }
+.recipe-cat {
+    font-size: .68rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .06em; color: var(--ac-dim); padding: 6px 0 2px;
+}
+.recipe-row { display: flex; align-items: center; gap: 6px; padding: 3px 0; }
+.recipe-name { font-size: .82rem; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.recipe-rank { flex: none; font-variant-numeric: tabular-nums; }
+.recipe-ok { flex: none; color: var(--ac-ok); }
+.prof-btn.off { opacity: .45; }
+
+/* Profession difficulty buckets (docs/gmcp_feeds.md) — the same palette the
+   game's recipe/harvest lists color by. The .menu-item compounds outrank the
+   menu's own color rule (defined later) for the disenchant entry. */
+.tier-trivial, .menu-item.tier-trivial { color: var(--ac-dim); }
+.tier-easy,    .menu-item.tier-easy    { color: var(--ac-ok); }
+.tier-medium,  .menu-item.tier-medium  { color: var(--hud-gold); }
+.tier-hard,    .menu-item.tier-hard    { color: var(--hud-edge); }
+.tier-blocked, .menu-item.tier-blocked { color: var(--ac-danger); }
+
 /* Tablets show the micro-menu with a coarse pointer — bump its launchers too. */
 @media (pointer: coarse) {
     .prof-btn { min-height: 40px; padding: 6px 12px; }

--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -698,6 +698,107 @@ body.connect-page #content { padding: .5rem !important; }
     .skill-sweep { transition: --sweep 1s linear; }
 }
 
+/* ----- Action row: skill bar + micro-menu (overlay app launchers) ----- */
+/* The micro-menu is the WoW-style cluster of small icon buttons at the right
+   end of the action-bar row; each opens a transient overlay app (see
+   docs/design/decisions.md "The HUD extension model"). On phones it is
+   hidden — the dock is the phone's micro-menu. */
+#hud-actionrow { display: flex; gap: 8px; align-items: center; flex: none; min-width: 0; }
+#hud-actionrow #hud-hotbar { flex: 1 1 auto; min-width: 0; }
+#hud-micro { display: flex; gap: 4px; flex: none; margin-left: auto; }
+.micro-btn {
+    position: relative; width: 32px; height: 32px; padding: 0; cursor: pointer; overflow: hidden;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--ac-elev); color: var(--ac-dim);
+    border: 1px solid var(--ac-border); border-radius: var(--ac-radius-sm);
+}
+.micro-btn[hidden] { display: none; }
+.micro-btn:hover { border-color: var(--ac-accent); color: var(--ac-text); }
+.micro-btn[aria-pressed="true"] { color: var(--ac-accent); border-color: var(--ac-accent); }
+.micro-btn .bi { width: 1rem; height: 1rem; }
+/* Dot badge: the app's feed changed while its window was closed. */
+.micro-btn.unread::after {
+    content: ""; position: absolute; top: 3px; right: 3px;
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--ac-accent); box-shadow: 0 0 0 2px var(--ac-elev);
+}
+/* Progress strip: a long-running activity (active craft/harvest) filling up. */
+.micro-strip {
+    position: absolute; left: 0; bottom: 0; height: 3px; width: 0;
+    background: var(--hud-event); pointer-events: none;
+}
+.micro-strip[hidden] { display: none; }
+@media (max-width: 767.98px) { #hud-micro { display: none; } }
+
+/* ----- Overlay window (micro-menu apps, desktop) ----- */
+#hud-overlay {
+    position: fixed; z-index: 1038;   /* above the sheet/popovers, below #hud-menu */
+    left: 50%; top: 50%; transform: translate(-50%, -50%);
+    width: min(520px, calc(100vw - 32px));
+    max-height: min(72vh, 620px);
+    display: flex; flex-direction: column;
+    background: var(--ac-panel); border: 1px solid var(--ac-border-2);
+    border-radius: var(--ac-radius); box-shadow: 0 16px 44px rgba(0, 0, 0, .6);
+}
+#hud-overlay[hidden] { display: none; }
+.overlay-head {
+    flex: none; display: flex; align-items: center; gap: 8px;
+    padding: 8px 10px 6px; border-bottom: 1px solid var(--ac-border);
+}
+.overlay-title {
+    font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .09em; color: var(--ac-dim);
+}
+#hud-overlay-body { overflow-y: auto; min-height: 0; padding: 6px 10px 10px; }
+#hud-overlay-body .panel { display: none; background: transparent; border: 0; }
+#hud-overlay-body .panel.overlay-active { display: block; }
+
+/* ----- Professions overlay app ----- */
+.craft-activity {
+    margin: 6px 0 10px; padding: 8px;
+    background: var(--ac-elev); border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius-sm);
+}
+.craft-label { font-size: .78rem; color: var(--ac-text); margin-bottom: 6px; }
+.craft-track {
+    position: relative; height: 16px;
+    background: var(--ac-bg); border: 1px solid var(--ac-border);
+    border-radius: 3px; overflow: hidden;
+}
+.craft-fill { position: absolute; inset: 0 auto 0 0; height: 100%; background: var(--hud-event); opacity: .85; }
+.craft-time {
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    font-size: .68rem; font-weight: 700; text-shadow: 0 0 2px #000, 0 0 2px #000;
+    font-variant-numeric: tabular-nums;
+}
+@media (prefers-reduced-motion: no-preference) {
+    .micro-strip, .craft-fill { transition: width 1s linear; }
+}
+.prof-row { padding: 8px 2px; border-bottom: 1px solid var(--ac-border); }
+.prof-row:last-of-type { border-bottom: 0; }
+.prof-head { display: flex; align-items: baseline; gap: 8px; }
+.prof-name { font-weight: 700; font-size: .9rem; color: var(--ac-text); }
+.prof-tier { flex: none; }
+.prof-rank { margin-left: auto; font-size: .74rem; color: var(--ac-dim); font-variant-numeric: tabular-nums; }
+.prof-track {
+    position: relative; height: 8px; margin: 6px 0;
+    background: var(--ac-bg); border: 1px solid var(--ac-border);
+    border-radius: 3px; overflow: hidden;
+}
+.prof-fill { position: absolute; inset: 0 auto 0 0; height: 100%; background: var(--ac-accent); opacity: .7; }
+.prof-foot { display: flex; align-items: center; gap: 8px; }
+.prof-recipes { font-size: .74rem; color: var(--ac-dim); font-variant-numeric: tabular-nums; }
+.prof-actions { margin-left: auto; display: flex; gap: 6px; }
+.prof-btn {
+    font-size: .72rem; padding: 3px 8px; cursor: pointer;
+    background: var(--ac-elev); color: var(--ac-text);
+    border: 1px solid var(--ac-border); border-radius: var(--ac-radius-sm);
+}
+.prof-btn:hover { border-color: var(--ac-accent); }
+.prof-empty, .prof-hint { font-size: .76rem; color: var(--ac-dim); padding: 6px 2px; }
+.prof-hint { border-top: 1px solid var(--ac-border); margin-top: 8px; font-family: monospace; }
+@media (pointer: coarse) { .prof-btn { min-height: 40px; padding: 6px 12px; } }
+
 /* ----- Context / action menu ----- */
 #hud-menu {
     position: fixed; z-index: 1040; min-width: 172px; max-width: min(80vw, 260px);
@@ -818,6 +919,9 @@ body.connect-page #content { padding: .5rem !important; }
    scroll edge; labels ellipsize rather than overflow. */
 #hud-dock button span { max-width: 100%; overflow: hidden; text-overflow: ellipsis; }
 #hud-dock button .bi { width: 1.1rem; height: 1.1rem; }
+/* Overlay-app tabs are availability-gated by hud.js (no professions → no tab);
+   display:flex above would otherwise defeat the hidden attribute. */
+#hud-dock button[hidden] { display: none; }
 #hud-dock button[aria-pressed="true"] { color: var(--ac-accent); background: var(--ac-elev); }
 
 #hud-dock button.unread::after,
@@ -883,7 +987,8 @@ body.connect-page #content { padding: .5rem !important; }
 .who-act button:focus-visible, .action-btn:focus-visible, .sheet-close:focus-visible,
 .panel-h-toggle:focus-visible, .row-more:focus-visible, .menu-item:focus-visible,
 .ab-chip:focus-visible, .ab-star:focus-visible, .panel-h-btn:focus-visible,
-.aff-release:focus-visible, .occ-row:focus-visible, .sub-h.collapse:focus-visible {
+.aff-release:focus-visible, .occ-row:focus-visible, .sub-h.collapse:focus-visible,
+.micro-btn:focus-visible, .prof-btn:focus-visible {
     outline: 2px solid var(--ac-accent); outline-offset: 2px;
 }
 

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -2216,18 +2216,55 @@
     function profBtn(label, fn, cls) {
         return el("button", { type: "button", class: "prof-btn" + (cls ? " " + cls : ""), text: label, onclick: fn });
     }
-    // Which professions' recipe lists are unfolded (session-local UI state).
+    // Which professions' recipe lists / recipes' component details are
+    // unfolded (session-local UI state).
     var profOpen = {};
+    var recipeOpen = {};
+
+    // The tappable component breakdown under a recipe row — the touch path
+    // to "what am I missing?" (the hover title is desktop convenience only).
+    function recipeCompsBlock(r, counts, treasure) {
+        var block = el("div", { class: "recipe-comps" });
+        ((r && r.components) || []).forEach(function (comp) {
+            if (!comp) return;
+            var ok, text;
+            if (comp.kind === "item") {
+                var need = Number(comp.count) || 1;
+                var have = counts[comp.vnum] || 0;
+                ok = have >= need;
+                text = need + "× " + stripColor(comp.name || "component") + " (have " + have + ")";
+            } else if (comp.kind === "treasure") {
+                var amt = Number(comp.amount) || 0;
+                ok = treasure >= amt;
+                text = amt + " gold of treasure (have " + treasure + ")";
+            } else if (comp.kind === "location") {
+                ok = null;   // display-only; never blocks craftable
+                text = "requires " + (comp.label || "a location");
+            } else {
+                return;
+            }
+            block.appendChild(el("div", {
+                class: "recipe-comp" + (ok === true ? " ok" : ok === false ? " missing" : " loc"),
+                text: text
+            }));
+        });
+        if (!block.firstChild) block.appendChild(el("div", { class: "recipe-comp loc", text: "No components required." }));
+        return block;
+    }
 
     function recipeRow(p, r, counts, treasure) {
         var rank = Number(p.rank) || 0;
         var tier = profTier((Number(r.min_rank) || 1) - rank);
         var craftable = recipeCraftable(r, counts, treasure);
         var targeted = r.target_gear_type != null;
+        var isOpen = !!recipeOpen[r.id];
         var actBtn;
         if (targeted) {
+            var targets = enchantTargets(r);
             actBtn = profBtn("Enchant…", function (e) {
-                var targets = enchantTargets(r);
+                var opener = e && e.target && e.target.closest(".prof-btn");
+                // Second tap on the opener toggles the picker closed.
+                if (menuOpen && menuAnchorEl === opener) { closeMenu(); return; }
                 var acts = targets.map(function (it) {
                     return {
                         label: stripColor(it.name || "item"),
@@ -2238,25 +2275,42 @@
                         }
                     };
                 });
-                if (!acts.length) acts = [{ label: "No matching item carried", fn: function () {} }];
-                openMenu("Enchant · " + stripColor(r.name || ""), acts, e && e.target);
-            }, "menu-opener");   // exempt from the outside-click menu dismissal
+                if (!acts.length) acts = [{ label: "No matching item carried", fn: function () {}, keep: true }];
+                openMenu("Enchant · " + stripColor(r.name || ""), acts, opener);
+            }, "menu-opener" + (targets.length ? "" : " off"));   // .menu-opener: exempt from outside-click dismissal
         } else {
             actBtn = profBtn("Craft", function () {
                 sendCmd(profCmd(p, nameOf(r.name)));
                 dismissProfessionsWindow();
             }, craftable ? "" : "off");
         }
-        return el("div", { class: "recipe-row", title: recipeComponentsText(r) || null }, [
-            el("span", { class: "recipe-name tier-" + tier, text: stripColor(r.name || "?") }),
+        var row = el("div", { class: "recipe-row", title: recipeComponentsText(r) || null }, [
+            el("button", {
+                type: "button", class: "recipe-toggle", "data-focus": "r" + r.id,
+                "aria-expanded": isOpen ? "true" : "false",
+                onclick: function () { closeMenu(); recipeOpen[r.id] = !recipeOpen[r.id]; renderProfessions(); }
+            }, [
+                el("span", { class: "recipe-name tier-" + tier, text: stripColor(r.name || "?") })
+            ]),
             el("span", { class: "tag recipe-rank tier-" + tier, text: "r" + (r.min_rank != null ? r.min_rank : "?") }),
             craftable ? el("span", { class: "tag recipe-ok", title: "You have the components", text: "✓" }) : null,
             el("span", { class: "prof-actions" }, [actBtn])
         ]);
+        var wrap = el("div", { class: "recipe-item" }, [row]);
+        if (isOpen) wrap.appendChild(recipeCompsBlock(r, counts, treasure));
+        return wrap;
     }
 
     function renderProfessions() {
         if (!dom.professions) return;
+        // Wholesale rebuilds run on every inventory delta while the overlay
+        // is open — carry keyboard focus across (a11y: don't dump a keyboard/
+        // switch user to <body> mid-session).
+        var focusKey = null;
+        if (document.activeElement && dom.professions.contains(document.activeElement) &&
+            document.activeElement.getAttribute) {
+            focusKey = document.activeElement.getAttribute("data-focus");
+        }
         var kids = [];
         var c = S.craft;
         if (c) {
@@ -2294,8 +2348,9 @@
             });
             var row = el("div", { class: "prof-row" }, [
                 el("button", {
-                    type: "button", class: "prof-head", "aria-expanded": isOpen ? "true" : "false",
-                    onclick: function () { profOpen[p.id] = !profOpen[p.id]; renderProfessions(); }
+                    type: "button", class: "prof-head", "data-focus": "p" + p.id,
+                    "aria-expanded": isOpen ? "true" : "false",
+                    onclick: function () { closeMenu(); profOpen[p.id] = !profOpen[p.id]; renderProfessions(); }
                 }, [
                     el("span", { class: "prof-caret", "aria-hidden": "true", text: isOpen ? "▾" : "▸" }),
                     el("span", { class: "prof-name", text: p.name || "?" }),
@@ -2329,6 +2384,10 @@
         });
         kids.push(el("div", { class: "prof-hint", text: "profession — overview & trainers · harvest <node> — gather" }));
         fill(dom.professions, kids);
+        if (focusKey && /^[a-z0-9_-]+$/i.test(focusKey)) {
+            var refocus = dom.professions.querySelector('[data-focus="' + focusKey + '"]');
+            if (refocus) refocus.focus();
+        }
         tickCraft();
     }
 
@@ -2341,9 +2400,11 @@
     function sendCmd(c) { c = safeCmd(c); if (c) api.send(c); }
 
     var menuOpen = false;
+    var menuAnchorEl = null;   // the element the open menu was anchored to
     function closeMenu() {
         if (!menuOpen) return;
         menuOpen = false;
+        menuAnchorEl = null;
         dom.menu.hidden = true;
         dom.menu.classList.remove("menu-picker");
         while (dom.menu.firstChild) dom.menu.removeChild(dom.menu.firstChild);
@@ -2398,13 +2459,16 @@
                     else if (a.prefill != null) api.prefill(a.prefill);
                     else if (a.cmd) sendCmd(a.cmd);
                     closeMenu();
-                    if (sheetName && mqMobile.matches) setSheet(null);
+                    // `keep`: informational rows shouldn't throw away the
+                    // phone sheet the menu was opened from.
+                    if (!a.keep && sheetName && mqMobile.matches) setSheet(null);
                 }
             }));
         });
         fill(dom.menu, kids);
         dom.menu.hidden = false;
         menuOpen = true;
+        menuAnchorEl = anchor || null;
         positionMenu(anchor);
     }
     function positionMenu(anchor) {

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -45,6 +45,7 @@
         equipment: [], inventory: null, train: null,
         affects: null, group: null, who: null, occupants: [],
         skills: [], cooldownExpiry: {}, cooldownTotal: {}, usable: {},
+        professions: [], craft: null,
         chat: [], connected: false,
         // Default targets (from Room.Occupants) that make the hotbar
         // target-aware: offensive spells → hostile, defensive → beneficial.
@@ -96,14 +97,31 @@
     // the movement (rose) and interaction (occupants) surfaces are together at
     // the bottom, nearest the input.
     var PANELS = ["equipment", "inventory", "train", "group", "occupants", "room",
-                  "status", "abilities", "chat", "who"];
+                  "status", "abilities", "chat", "who", "professions"];
     var PANEL_HOME = {
         occupants: "hud-left-scroll", equipment: "hud-left-scroll",
         inventory: "hud-left-scroll", train: "hud-left-scroll",
         group: "hud-left-scroll",
         room: "hud-left",
-        status: "hud-right", abilities: "hud-right", chat: "hud-right", who: "hud-right"
+        status: "hud-right", abilities: "hud-right", chat: "hud-right", who: "hud-right",
+        professions: "hud-overlay-body"
     };
+
+    // ------------------------------------------------------------------
+    // Overlay apps — the micro-menu registry, THE single point of extension
+    // for transient HUD surfaces (docs/design/decisions.md 2026-07-17: the
+    // HUD extension model). Each entry needs: a [data-overlay=key] button in
+    // #hud-micro, a [data-panel=key] dock button, a #panel-<key> node inside
+    // #hud-overlay-body, and PANELS/PANEL_HOME entries. Desktop opens the
+    // #hud-overlay window; phones open the same panel in the bottom sheet.
+    // Hotkeys are Ctrl+<letter>, strict single-modifier.
+    // ------------------------------------------------------------------
+    var OVERLAYS = [
+        { key: "professions", title: "Professions", hotkey: "p",
+          render: function () { renderProfessions(); },
+          available: function () { return (S.professions || []).length > 0; } }
+    ];
+    var overlayName = null;   // open overlay app key (desktop), or null
 
     // Position capability ranking (index = capability), from the game's
     // posn_names[] (constants.c). Higher rank = more capable; a skill whose
@@ -522,6 +540,8 @@
             case "Group.Update": S.group = data; renderGroup(); break;
             case "Char.Who": S.who = data; renderWho(); break;
             case "Char.Skills": S.skills = (data && data.skills) || []; renderHotbar(); renderAbilities(); break;
+            case "Char.Professions": applyProfessions(data); break;
+            case "Char.Craft": applyCraft(data); break;
             case "Char.Cooldowns":
                 applyCooldowns(data); tickHotbar();
                 // The Abilities browser can be ~400 rows; only rebuild it for a
@@ -1796,6 +1816,27 @@
     function wireHotkeys() {
         document.addEventListener("keydown", function (e) {
             if (!hudOn || !S.connected) return;
+            // Esc closes the open overlay window before anything else claims it.
+            if (e.key === "Escape" && overlayName && !mqMobile.matches) {
+                setOverlay(null);
+                return;
+            }
+            // Overlay hotkeys: Ctrl+<letter> toggles a micro-menu app (e.g.
+            // Ctrl+P → Professions). Strict single-modifier, and swallowed
+            // only when the app is actually available, so browser defaults
+            // survive everywhere else.
+            var ctrlOnly = e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey;
+            if (ctrlOnly && /^[a-z]$/.test(String(e.key || "").toLowerCase())) {
+                var letter = String(e.key).toLowerCase();
+                for (var oi = 0; oi < OVERLAYS.length; oi++) {
+                    var ov = OVERLAYS[oi];
+                    if (ov.hotkey === letter && (!ov.available || ov.available())) {
+                        e.preventDefault();
+                        toggleOverlay(ov.key);
+                        return;
+                    }
+                }
+            }
             if (e.key === "`" && e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
                 if (usedPages() > 1) { e.preventDefault(); flipHotbarPage(); }
                 return;
@@ -1928,6 +1969,190 @@
         if (iconOrNull) iconOverrides[k] = iconOrNull; else delete iconOverrides[k];
         saveMap("ishar.icons", iconOverrides);
         renderHotbar(); renderAbilities();
+    }
+
+    // ------------------------------------------------------------------
+    // Overlay apps: micro-menu buttons → #hud-overlay window (desktop) or
+    // the bottom sheet (phones). One overlay at a time; Esc, outside-click,
+    // the ✕, the hotkey, or the button all dismiss. Registry: OVERLAYS.
+    // ------------------------------------------------------------------
+    function overlayByKey(key) {
+        for (var i = 0; i < OVERLAYS.length; i++) {
+            if (OVERLAYS[i].key === key) return OVERLAYS[i];
+        }
+        return null;
+    }
+    function setOverlay(name) {
+        var ov = name ? overlayByKey(name) : null;
+        overlayName = ov ? ov.key : null;
+        OVERLAYS.forEach(function (o) {
+            var p = document.getElementById("panel-" + o.key);
+            if (p) p.classList.toggle("overlay-active", o.key === overlayName);
+            var b = dom.micro && dom.micro.querySelector('button[data-overlay="' + o.key + '"]');
+            if (b) b.setAttribute("aria-pressed", o.key === overlayName ? "true" : "false");
+        });
+        if (dom.overlay) dom.overlay.hidden = !ov;
+        if (dom.overlayTitle) dom.overlayTitle.textContent = ov ? ov.title : "";
+        if (ov) { ov.render(); markOverlayUnread(ov.key, false); }
+    }
+    function toggleOverlay(key) {
+        if (mqMobile.matches) { setSheet(sheetName === key ? null : key); return; }
+        setOverlay(overlayName === key ? null : key);
+    }
+    function overlayVisible(key) {
+        if (!hudOn) return false;
+        return mqMobile.matches ? sheetName === key : overlayName === key;
+    }
+    // Dot badge on the app's launchers (micro button + dock button): the feed
+    // changed while its window was closed. Same idiom as the chat unread dot.
+    function markOverlayUnread(key, on) {
+        ['#hud-micro button[data-overlay="' + key + '"]',
+         '#hud-dock button[data-panel="' + key + '"]'].forEach(function (sel) {
+            var b = document.querySelector(sel);
+            if (b) b.classList.toggle("unread", !!on);
+        });
+    }
+    // Availability gate: an app with nothing to show hides its launchers
+    // entirely (a character with no professions never sees the button).
+    function updateMicro() {
+        OVERLAYS.forEach(function (o) {
+            var avail = !o.available || o.available();
+            var b = dom.micro && dom.micro.querySelector('button[data-overlay="' + o.key + '"]');
+            if (b) b.hidden = !avail;
+            var d = dom.dock && dom.dock.querySelector('button[data-panel="' + o.key + '"]');
+            if (d) d.hidden = !avail;
+            if (!avail) {
+                if (overlayName === o.key) setOverlay(null);
+                if (sheetName === o.key) setSheet(null);
+                markOverlayUnread(o.key, false);
+            }
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // Professions (Char.Professions + Char.Craft) — the first overlay app.
+    // Standing rows (rank/tier/recipes) plus a live craft/harvest cast bar.
+    // ------------------------------------------------------------------
+    var lastProfessionsBody = null;
+    function applyProfessions(data) {
+        var list = (data && data.professions) || [];
+        var body = "";
+        try { body = JSON.stringify(list); } catch (e) {}
+        // Badge only on a *change* after the first snapshot — the login burst
+        // shouldn't light the dot.
+        var changed = lastProfessionsBody !== null && body !== lastProfessionsBody;
+        lastProfessionsBody = body;
+        S.professions = list;
+        updateMicro();
+        renderProfessions();
+        if (changed && !overlayVisible("professions")) markOverlayUnread("professions", true);
+    }
+    function applyCraft(data) {
+        if (data && data.active) {
+            S.craft = {
+                kind: data.kind === "harvest" ? "harvest" : "craft",
+                name: String(data.name || ""),
+                quantity: Number(data.quantity) || 1,
+                chain: Number(data.chain_remaining) || 0,
+                // Like cooldowns: store the expiry and tick locally between feeds.
+                expiry: now() + (Number(data.remaining) || 0),
+                total: Math.max(1, Number(data.duration) || Number(data.remaining) || 1)
+            };
+        } else {
+            S.craft = null;
+        }
+        renderProfessions();
+        tickCraft();
+    }
+    // Per-second updates that must not rebuild the panel: the micro button's
+    // progress strip and the open panel's cast-bar numbers.
+    function tickCraft() {
+        var c = S.craft;
+        var rem = c ? Math.max(0, c.expiry - now()) : 0;
+        var pctW = c ? Math.max(0, Math.min(100, (1 - rem / c.total) * 100)) + "%" : "0%";
+        var b = dom.micro && dom.micro.querySelector('button[data-overlay="professions"]');
+        if (b) {
+            b.classList.toggle("busy", !!c);
+            var strip = b.querySelector(".micro-strip");
+            if (strip) { strip.hidden = !c; if (c) strip.style.width = pctW; }
+        }
+        if (c && dom.professions) {
+            var fillBar = dom.professions.querySelector(".craft-fill");
+            if (fillBar) fillBar.style.width = pctW;
+            var t = dom.professions.querySelector(".craft-time");
+            if (t) t.textContent = fmtDur(rem);
+        }
+    }
+    // Command builder: alchemy (and any future non-shortcut profession) routes
+    // through `craft <profession> …`; enchanting/artificing have their own
+    // verbs. `verb` and `name` come from the feed; sendCmd sanitizes.
+    function profCmd(p, sub) {
+        var base = (p.verb && p.verb !== "craft")
+            ? p.verb
+            : "craft " + String(p.name || "").toLowerCase();
+        return sub ? base + " " + sub : base;
+    }
+    function profBtn(label, cmd) {
+        return el("button", {
+            type: "button", class: "prof-btn", text: label,
+            onclick: function () {
+                sendCmd(cmd);
+                // The output lands in the terminal — get the window out of
+                // the way on every form factor.
+                if (mqMobile.matches) { if (sheetName) setSheet(null); }
+                else if (overlayName) setOverlay(null);
+            }
+        });
+    }
+    function renderProfessions() {
+        if (!dom.professions) return;
+        var kids = [];
+        var c = S.craft;
+        if (c) {
+            var rem = Math.max(0, c.expiry - now());
+            var pct = Math.max(0, Math.min(100, (1 - rem / c.total) * 100));
+            var label = (c.kind === "harvest" ? "Harvesting" : "Crafting") + " — " + c.name
+                + (c.quantity > 1 ? " ×" + c.quantity : "")
+                + (c.chain > 0 ? " (+" + c.chain + " queued)" : "");
+            kids.push(el("div", { class: "craft-activity" }, [
+                el("div", { class: "craft-label", text: label }),
+                el("div", { class: "craft-track" }, [
+                    el("div", { class: "craft-fill", style: "width:" + pct + "%" }),
+                    el("span", { class: "craft-time", text: fmtDur(rem) })
+                ])
+            ]));
+        }
+        var profs = S.professions || [];
+        if (!profs.length && !c) {
+            kids.push(el("div", { class: "prof-empty", text: "No professions yet. Seek out a profession master to learn one." }));
+            fill(dom.professions, kids);
+            return;
+        }
+        profs.forEach(function (p) {
+            var rank = Number(p.rank) || 0;
+            var maxRank = Number(p.max_rank) || 0;
+            var pct = maxRank > 0 ? Math.max(0, Math.min(100, (rank / maxRank) * 100)) : 100;
+            kids.push(el("div", { class: "prof-row" }, [
+                el("div", { class: "prof-head" }, [
+                    el("span", { class: "prof-name", text: p.name || "?" }),
+                    p.tier ? el("span", { class: "tag prof-tier", text: p.tier }) : null,
+                    el("span", { class: "prof-rank", text: "Rank " + rank + (maxRank ? "/" + maxRank : "") })
+                ]),
+                el("div", { class: "prof-track", title: maxRank ? rank + " of " + maxRank + " ranks" : "Rank " + rank }, [
+                    el("div", { class: "prof-fill", style: "width:" + pct + "%" })
+                ]),
+                el("div", { class: "prof-foot" }, [
+                    el("span", { class: "prof-recipes", text: "Recipes " + (p.recipes_known != null ? p.recipes_known : "–") + "/" + (p.recipes_total != null ? p.recipes_total : "–") }),
+                    el("span", { class: "prof-actions" }, [
+                        profBtn("Recipes", profCmd(p, "")),
+                        profBtn("Craftable", profCmd(p, "available"))
+                    ])
+                ])
+            ]));
+        });
+        kids.push(el("div", { class: "prof-hint", text: "profession — overview & trainers · harvest <node> — gather" }));
+        fill(dom.professions, kids);
+        tickCraft();
     }
 
     // ------------------------------------------------------------------
@@ -2346,6 +2571,7 @@
             if (home && p.parentNode !== home) home.appendChild(p);
         });
         if (!mobile && sheetName) setSheet(null);
+        if (mobile && overlayName) setOverlay(null);
         updateRoseOverlay();
     }
 
@@ -2366,6 +2592,7 @@
         dom.app.classList.toggle("sheet-open", !!name);
         if (name === "chat") { markChatUnread(false); dom.chat.scrollTop = dom.chat.scrollHeight; }
         if (name === "abilities") renderAbilities();   // refresh cooldown/mana greying on open
+        if (overlayByKey(name)) { overlayByKey(name).render(); markOverlayUnread(name, false); }
     }
     function chatVisible() {
         if (!hudOn) return false;
@@ -2441,14 +2668,17 @@
     function renderAll() {
         renderVitals(); renderRoom(); renderOccupants(); renderGroup(); renderEquipment(); renderInventory();
         renderTrain(); renderStatus(); renderWho(); renderChat(); renderHotbar(); renderAbilities();
+        renderProfessions(); updateMicro();
     }
     function reset() {
         S.vitals = null; S.status = null; S.time = null; S.room = null;
         S.equipment = []; S.inventory = null; S.train = null;
         S.affects = null; S.group = null; S.who = null; S.occupants = [];
         S.skills = []; S.cooldownExpiry = {}; S.cooldownTotal = {}; S.usable = {};
+        S.professions = []; S.craft = null;
         S.tgtHostile = null; S.tgtFriendly = null;
         lastVitalsBody = null;
+        lastProfessionsBody = null;
         renderAll();
     }
 
@@ -2475,6 +2705,10 @@
         dom.chat = document.getElementById("panel-chat");
         dom.who = document.getElementById("panel-who");
         dom.hotbar = document.getElementById("hud-hotbar");
+        dom.micro = document.getElementById("hud-micro");
+        dom.professions = document.getElementById("panel-professions");
+        dom.overlay = document.getElementById("hud-overlay");
+        dom.overlayTitle = document.getElementById("hud-overlay-title");
         dom.dock = document.getElementById("hud-dock");
         dom.sheet = document.getElementById("hud-sheet");
         dom.sheetBody = document.getElementById("hud-sheet-body");
@@ -2514,6 +2748,14 @@
         var sheetClose = document.getElementById("hud-sheet-close");
         if (sheetClose) sheetClose.addEventListener("click", function () { setSheet(null); });
 
+        // Micro-menu: each button toggles its overlay app (sheet on phones).
+        if (dom.micro) dom.micro.addEventListener("click", function (e) {
+            var b = e.target.closest("button[data-overlay]");
+            if (b) toggleOverlay(b.getAttribute("data-overlay"));
+        });
+        var overlayClose = document.getElementById("hud-overlay-close");
+        if (overlayClose) overlayClose.addEventListener("click", function () { setOverlay(null); });
+
         // Mobile rose overlay toggle button.
         var roseBtn = document.getElementById("rose-toggle");
         if (roseBtn) roseBtn.addEventListener("click", function () {
@@ -2523,9 +2765,14 @@
             updateRoseOverlay();
         });
 
-        // Outside tap dismisses the sheet and any open menu.
+        // Outside tap dismisses the sheet, the overlay window and any open menu.
         document.addEventListener("click", function (e) {
             if (menuOpen && !dom.menu.contains(e.target) && !e.target.closest("[data-menu],.row-more")) closeMenu();
+            if (overlayName && !mqMobile.matches && dom.overlay &&
+                !dom.overlay.contains(e.target) && !e.target.closest("#hud-micro") &&
+                !dom.menu.contains(e.target)) {
+                setOverlay(null);
+            }
             if (!sheetName || !mqMobile.matches) return;
             if (dom.sheet.contains(e.target) || dom.dock.contains(e.target)) return;
             if (dom.menu.contains(e.target)) return;
@@ -2554,6 +2801,7 @@
                 e.textContent = fmtDur(parseFloat(e.getAttribute("data-expiry")) - t);
             });
             if (S.skills.length) tickHotbar();
+            if (S.craft) tickCraft();
         }, 1000);
     }
 
@@ -2634,7 +2882,12 @@
             ] },
             "Char.Skills": { skills: bigSkills },
             "Char.Cooldowns": { cooldowns: [{ id: 3, remaining: 8 }], usable: { "3": false } },
-            "Char.Train": { stats: [{ name: "Str", value: 18, add: 2 }, { name: "Int", value: 25 }, { name: "Wis", value: 20 }], xp: 1250000, xp_pct: 62, can_advance: true, aux: [{ name: "Crit", value: "12.5% (+2%)" }], resources: [{ name: "Practices", value: 5, max: 10 }, { name: "Trains", value: 2, max: 2 }] }
+            "Char.Train": { stats: [{ name: "Str", value: 18, add: 2 }, { name: "Int", value: 25 }, { name: "Wis", value: 20 }], xp: 1250000, xp_pct: 62, can_advance: true, aux: [{ name: "Crit", value: "12.5% (+2%)" }], resources: [{ name: "Practices", value: 5, max: 10 }, { name: "Trains", value: 2, max: 2 }] },
+            "Char.Professions": { professions: [
+                { id: 1, name: "Alchemy", verb: "craft", rank: 34, max_rank: 99, tier: "Journeyman", recipes_known: 21, recipes_total: 58 },
+                { id: 2, name: "Enchanting", verb: "enchant", rank: 12, max_rank: 99, tier: "Novice", recipes_known: 6, recipes_total: 44 }
+            ] },
+            "Char.Craft": { active: true, kind: "craft", name: "minor healing draught", profession_id: 1, remaining: 14, duration: 20, quantity: 2, chain_remaining: 3 }
         };
         Object.keys(feeds).forEach(function (k) { onGmcp(k, JSON.stringify(feeds[k])); });
         [

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -45,7 +45,7 @@
         equipment: [], inventory: null, train: null,
         affects: null, group: null, who: null, occupants: [],
         skills: [], cooldownExpiry: {}, cooldownTotal: {}, usable: {},
-        professions: [], craft: null,
+        professions: [], recipes: [], craft: null,
         chat: [], connected: false,
         // Default targets (from Room.Occupants) that make the hotbar
         // target-aware: offensive spells → hostile, defensive → beneficial.
@@ -539,14 +539,22 @@
             case "Game.Time": S.time = data; renderVitals(); break;
             case "Room.Info": S.room = data; renderRoom(); break;
             case "Room.Occupants": applyOccupants(data); break;
-            case "Char.Equipment": S.equipment = (data && data.items) || []; renderEquipment(); renderInventory(); break;
-            case "Char.Inventory": S.inventory = data; renderInventory(); renderEquipment(); break;
+            case "Char.Equipment":
+                S.equipment = (data && data.items) || []; renderEquipment(); renderInventory();
+                // Craftable-now marks join against carried items.
+                if (overlayVisible("professions")) renderProfessions();
+                break;
+            case "Char.Inventory":
+                S.inventory = data; renderInventory(); renderEquipment();
+                if (overlayVisible("professions")) renderProfessions();
+                break;
             case "Char.Train": S.train = data; renderTrain(); break;
             case "Char.Affects": S.affects = data; stampAffectExpiry(data); renderStatus(); break;
             case "Group.Update": S.group = data; renderGroup(); break;
             case "Char.Who": S.who = data; renderWho(); break;
             case "Char.Skills": S.skills = (data && data.skills) || []; renderHotbar(); renderAbilities(); break;
             case "Char.Professions": applyProfessions(data); break;
+            case "Char.Recipes": S.recipes = (data && data.recipes) || []; renderProfessions(); break;
             case "Char.Craft": applyCraft(data); break;
             case "Char.Cooldowns":
                 applyCooldowns(data); tickHotbar();
@@ -1015,7 +1023,8 @@
             "data-name": stripColor(it.name || ""),
             "data-container": container || "",
             "data-closeable": it.closeable ? "1" : "",
-            "data-closed": it.closed ? "1" : ""
+            "data-closed": it.closed ? "1" : "",
+            "data-disen": (Number(it.disenchant_rank) > 0) ? String(it.disenchant_rank) : ""
         };
     }
     // One inventory/equipment row. Everything stays on a single line: an
@@ -2119,18 +2128,133 @@
         var base = (p.verb && p.verb !== "craft") ? p.verb : "craft " + word;
         return sub ? base + " " + sub : base;
     }
-    function profBtn(label, cmd) {
-        return el("button", {
-            type: "button", class: "prof-btn", text: label,
-            onclick: function () {
-                sendCmd(cmd);
-                // The output lands in the terminal — get the window out of
-                // the way on every form factor.
-                if (mqMobile.matches) { if (sheetName) setSheet(null); }
-                else if (overlayName) setOverlay(null);
-            }
-        });
+    // Shared profession difficulty buckets (docs/gmcp_feeds.md — part of the
+    // GMCP contract; mirrors the game's recipe_skillup_tiers / harvest tiers).
+    // delta = required_rank − your rank.
+    function profTier(delta) {
+        if (delta <= -4) return "trivial";
+        if (delta <= -1) return "easy";
+        if (delta <= 3) return "medium";
+        if (delta <= 5) return "hard";
+        return "blocked";
     }
+    function professionById(id) {
+        var list = S.professions || [];
+        for (var i = 0; i < list.length; i++) {
+            if (list[i] && list[i].id === id) return list[i];
+        }
+        return null;
+    }
+    // The player's Enchanting standing (identified by its command verb), or
+    // null — gates the disenchant context-menu entry.
+    function enchanterStanding() {
+        var list = S.professions || [];
+        for (var i = 0; i < list.length; i++) {
+            if (list[i] && list[i].verb === "enchant") return list[i];
+        }
+        return null;
+    }
+    // Carried vnum→count map for the craftable-now join: inventory items,
+    // pouch components, open container contents, and worn gear — the same
+    // scope as the game's portable-component check. Entries without a vnum
+    // simply don't count (the game re-validates anyway).
+    function inventoryVnumCounts() {
+        var counts = {};
+        function add(list) {
+            (list || []).forEach(function (it) {
+                if (!it) return;
+                if (it.vnum != null) counts[it.vnum] = (counts[it.vnum] || 0) + (Number(it.count) || 1);
+                if (it.contents && !it.closed) add(it.contents);
+            });
+        }
+        if (S.inventory) { add(S.inventory.items); add(S.inventory.components); }
+        add(S.equipment);
+        return counts;
+    }
+    // Mirror of the game's `available` filter: item + treasure components
+    // must be covered; location components are display-only (the in-game
+    // filter skips them too — "what could I craft if I traveled there").
+    function recipeCraftable(r, counts, treasure) {
+        var comps = (r && r.components) || [];
+        for (var i = 0; i < comps.length; i++) {
+            var comp = comps[i];
+            if (!comp) continue;
+            if (comp.kind === "item") {
+                if ((counts[comp.vnum] || 0) < (Number(comp.count) || 1)) return false;
+            } else if (comp.kind === "treasure") {
+                if (treasure < (Number(comp.amount) || 0)) return false;
+            }
+        }
+        return true;
+    }
+    // One-line component summary for a recipe row's native tooltip.
+    function recipeComponentsText(r) {
+        return ((r && r.components) || []).map(function (comp) {
+            if (!comp) return "";
+            if (comp.kind === "item") return (Number(comp.count) || 1) + "× " + stripColor(comp.name || "component");
+            if (comp.kind === "treasure") return comp.amount + " gold of treasure";
+            if (comp.kind === "location") return "requires " + (comp.label || "a location");
+            return "";
+        }).filter(Boolean).join(" · ");
+    }
+    // Inventory items matching an enchant recipe's gear slot — the same join
+    // the game performs (get_gear_type(item) == recipe->target_gear_type).
+    // Enchant targets resolve from carried items only (the command is FINV).
+    function enchantTargets(r) {
+        var out = [];
+        ((S.inventory && S.inventory.items) || []).forEach(function (it) {
+            if (it && it.gear_type != null && it.gear_type === r.target_gear_type) out.push(it);
+        });
+        return out;
+    }
+    function dismissProfessionsWindow() {
+        // Command output lands in the terminal — get the window out of the
+        // way on every form factor.
+        if (mqMobile.matches) { if (sheetName) setSheet(null); }
+        else if (overlayName) setOverlay(null);
+    }
+    function profBtn(label, fn, cls) {
+        return el("button", { type: "button", class: "prof-btn" + (cls ? " " + cls : ""), text: label, onclick: fn });
+    }
+    // Which professions' recipe lists are unfolded (session-local UI state).
+    var profOpen = {};
+
+    function recipeRow(p, r, counts, treasure) {
+        var rank = Number(p.rank) || 0;
+        var tier = profTier((Number(r.min_rank) || 1) - rank);
+        var craftable = recipeCraftable(r, counts, treasure);
+        var targeted = r.target_gear_type != null;
+        var actBtn;
+        if (targeted) {
+            actBtn = profBtn("Enchant…", function (e) {
+                var targets = enchantTargets(r);
+                var acts = targets.map(function (it) {
+                    return {
+                        label: stripColor(it.name || "item"),
+                        fn: function () {
+                            // `enchant <item> <recipe>` (fabricate likewise).
+                            sendCmd(profCmd(p, targetOf(it.keywords || it.name) + " " + nameOf(r.name)));
+                            dismissProfessionsWindow();
+                        }
+                    };
+                });
+                if (!acts.length) acts = [{ label: "No matching item carried", fn: function () {} }];
+                openMenu("Enchant · " + stripColor(r.name || ""), acts, e && e.target);
+            }, "menu-opener");   // exempt from the outside-click menu dismissal
+        } else {
+            actBtn = profBtn("Craft", function () {
+                sendCmd(profCmd(p, nameOf(r.name)));
+                dismissProfessionsWindow();
+            }, craftable ? "" : "off");
+        }
+        return el("div", { class: "recipe-row", title: recipeComponentsText(r) || null }, [
+            el("span", { class: "recipe-name tier-" + tier, text: stripColor(r.name || "?") }),
+            el("span", { class: "tag recipe-rank tier-" + tier, text: "r" + (r.min_rank != null ? r.min_rank : "?") }),
+            craftable ? el("span", { class: "tag recipe-ok", title: "You have the components", text: "✓" }) : null,
+            el("span", { class: "prof-actions" }, [actBtn])
+        ]);
+    }
+
     function renderProfessions() {
         if (!dom.professions) return;
         var kids = [];
@@ -2155,12 +2279,25 @@
             fill(dom.professions, kids);
             return;
         }
+        var counts = inventoryVnumCounts();
+        var treasure = (S.inventory && Number(S.inventory.treasure)) || 0;
         profs.forEach(function (p) {
             var rank = Number(p.rank) || 0;
             var maxRank = Number(p.max_rank) || 0;
             var pct = maxRank > 0 ? Math.max(0, Math.min(100, (rank / maxRank) * 100)) : 100;
-            kids.push(el("div", { class: "prof-row" }, [
-                el("div", { class: "prof-head" }, [
+            var isOpen = !!profOpen[p.id];
+            var recipes = (S.recipes || []).filter(function (r) { return r && r.profession_id === p.id; });
+            recipes.sort(function (a, b) {
+                var ca = String(a.category || ""), cb = String(b.category || "");
+                if (ca !== cb) return ca < cb ? -1 : 1;
+                return (Number(a.min_rank) || 0) - (Number(b.min_rank) || 0);
+            });
+            var row = el("div", { class: "prof-row" }, [
+                el("button", {
+                    type: "button", class: "prof-head", "aria-expanded": isOpen ? "true" : "false",
+                    onclick: function () { profOpen[p.id] = !profOpen[p.id]; renderProfessions(); }
+                }, [
+                    el("span", { class: "prof-caret", "aria-hidden": "true", text: isOpen ? "▾" : "▸" }),
                     el("span", { class: "prof-name", text: p.name || "?" }),
                     p.tier ? el("span", { class: "tag prof-tier", text: p.tier }) : null,
                     el("span", { class: "prof-rank", text: "Rank " + rank + (maxRank ? "/" + maxRank : "") })
@@ -2169,13 +2306,26 @@
                     el("div", { class: "prof-fill", style: "width:" + pct + "%" })
                 ]),
                 el("div", { class: "prof-foot" }, [
-                    el("span", { class: "prof-recipes", text: "Recipes " + (p.recipes_known != null ? p.recipes_known : "–") + "/" + (p.recipes_total != null ? p.recipes_total : "–") }),
-                    el("span", { class: "prof-actions" }, [
-                        profBtn("Recipes", profCmd(p, "")),
-                        profBtn("Craftable", profCmd(p, "available"))
-                    ])
+                    el("span", { class: "prof-recipes", text: "Recipes " + (p.recipes_known != null ? p.recipes_known : "–") + "/" + (p.recipes_total != null ? p.recipes_total : "–") })
                 ])
-            ]));
+            ]);
+            if (isOpen) {
+                var listEl = el("div", { class: "recipe-list" });
+                var lastCat = null;
+                recipes.forEach(function (r) {
+                    var cat = String(r.category || "General");
+                    if (cat !== lastCat) {
+                        listEl.appendChild(el("div", { class: "recipe-cat", text: cat }));
+                        lastCat = cat;
+                    }
+                    listEl.appendChild(recipeRow(p, r, counts, treasure));
+                });
+                if (!recipes.length) {
+                    listEl.appendChild(el("div", { class: "prof-empty", text: "No recipes known yet — trainers and discovery await." }));
+                }
+                row.appendChild(listEl);
+            }
+            kids.push(row);
         });
         kids.push(el("div", { class: "prof-hint", text: "profession — overview & trainers · harvest <node> — gather" }));
         fill(dom.professions, kids);
@@ -2240,7 +2390,8 @@
             // handler would fire the command a *second* time. The onclick owns
             // the action outright.
             kids.push(el("button", {
-                type: "button", class: "menu-item" + (a.danger ? " danger" : ""),
+                type: "button",
+                class: "menu-item" + (a.danger ? " danger" : "") + (a.tier ? " tier-" + a.tier : ""),
                 text: a.label,
                 onclick: function () {
                     if (a.fn) a.fn();
@@ -2378,6 +2529,17 @@
             openContainers().forEach(function (c) {
                 if (c.target !== t) acts.push({ label: "Put in " + c.shortName, cmd: "put " + t + " into " + c.target });
             });
+            // Profession context: enchanters see the disenchant path with the
+            // item's rank requirement, colored by the standard difficulty
+            // buckets (docs/gmcp_feeds.md). The game re-validates the rank.
+            var ench = enchanterStanding();
+            if (ench && ds.disen > 0 && kind !== "content") {
+                acts.push({
+                    label: "Disenchant (r" + ds.disen + ")",
+                    cmd: "disenchant " + t,
+                    tier: profTier(ds.disen - (Number(ench.rank) || 0))
+                });
+            }
             acts.push({ label: "Drop", cmd: "drop " + t });
             acts.push({ label: "Sacrifice", cmd: "sacrifice " + t, danger: true });
         }
@@ -2562,7 +2724,8 @@
             kind: host.getAttribute("data-kind") || "item",
             container: host.getAttribute("data-container") || "",
             closeable: host.getAttribute("data-closeable") === "1",
-            closed: host.getAttribute("data-closed") === "1"
+            closed: host.getAttribute("data-closed") === "1",
+            disen: Number(host.getAttribute("data-disen")) || 0
         };
     }
     // Right-click opens the same menu on desktop.
@@ -2703,7 +2866,7 @@
         S.equipment = []; S.inventory = null; S.train = null;
         S.affects = null; S.group = null; S.who = null; S.occupants = [];
         S.skills = []; S.cooldownExpiry = {}; S.cooldownTotal = {}; S.usable = {};
-        S.professions = []; S.craft = null;
+        S.professions = []; S.recipes = []; S.craft = null;
         S.tgtHostile = null; S.tgtFriendly = null;
         lastVitalsBody = null;
         lastProfessionsBody = null;
@@ -2795,7 +2958,13 @@
 
         // Outside tap dismisses the sheet, the overlay window and any open menu.
         document.addEventListener("click", function (e) {
-            if (menuOpen && !dom.menu.contains(e.target) && !e.target.closest("[data-menu],.row-more")) closeMenu();
+            // A click that re-renders its own panel (e.g. a recipe-list
+            // disclosure) detaches the target before this listener runs —
+            // contains() would then read "outside" and close the surface the
+            // click was inside. A disconnected target was always handled by
+            // its own onclick; never treat it as an outside click.
+            if (e.target && e.target.isConnected === false) return;
+            if (menuOpen && !dom.menu.contains(e.target) && !e.target.closest("[data-menu],.row-more,.menu-opener")) closeMenu();
             if (overlayName && !mqMobile.matches && dom.overlay &&
                 !dom.overlay.contains(e.target) && !e.target.closest("#hud-micro") &&
                 !dom.menu.contains(e.target)) {
@@ -2893,13 +3062,17 @@
                 // Two separate rows for the same scroll — fold to ×2.
                 { name: "a scroll of recall", keywords: "scroll recall", type: "scroll", vnum: 12, count: 1 },
                 { name: "a scroll of recall", keywords: "scroll recall", type: "scroll", vnum: 12 },
+                // Profession context: gear_type joins enchant targeting;
+                // disenchant_rank feeds the enchanter's context-menu entry.
+                { name: "a quilted woolen hood", keywords: "hood woolen quilted", type: "armor", vnum: 20, count: 1, gear_type: 6, disenchant_rank: 9 },
+                { name: "a tarnished silver band", keywords: "band silver tarnished", type: "armor", vnum: 21, count: 1, gear_type: 4, disenchant_rank: 45 },
                 { name: "a leather sack", keywords: "sack leather", type: "container", vnum: 11, count: 1, closeable: true, closed: false, contents: [{ name: "a brass key", keywords: "key brass", count: 1 }] }
             ], coins: [{ name: "gold", vnum: 0, count: 18230 }, { name: "silver", vnum: 0, count: 340 }, { name: "obsidian", vnum: 0, count: 12 }], components: [
-                { name: "a pinch of sulfur", keywords: "sulfur pinch", count: 7 },
-                { name: "a vial of powdered silver", keywords: "silver vial powdered", count: 3 },
-                { name: "a sprig of nightshade", keywords: "nightshade sprig", count: 12 },
-                { name: "a shard of frost quartz", keywords: "quartz frost shard", count: 5 }
-            ] },
+                { name: "a pinch of sulfur", keywords: "sulfur pinch", vnum: 9001, count: 7 },
+                { name: "a vial of powdered silver", keywords: "silver vial powdered", vnum: 9002, count: 3 },
+                { name: "a sprig of nightshade", keywords: "nightshade sprig", vnum: 9003, count: 12 },
+                { name: "a shard of frost quartz", keywords: "quartz frost shard", vnum: 9004, count: 5 }
+            ], treasure: 620 },
             "Char.Affects": { buffs: [{ name: "Stoneskin", id: 101, duration: 1800 }, { name: "Haste", id: 102, duration: 240 }], debuffs: [{ name: "Poison", id: 201, duration: 45 }], maintained: [{ name: "Detect Invisibility", id: 301, duration: 600, target: "self" }, { name: "Shroud", id: 302, duration: 900, target: "Boric", skill: "shroud", handle: "1.boric", releasable: true }] },
             "Group.Update": { leader: "Aelwyn", size: 3, members: [
                 { name: "Aelwyn", level: 45, hp_pct: 86, mp_pct: 85, mv_pct: 82, position: "Standing", race: "Elf", "class": "Magician", leader: true, in_room: true, is_tank: false, fighting_name: "a scarred alley thug", threat: 40, tank_threat: 120, threat_level: "low" },
@@ -2914,6 +3087,20 @@
             "Char.Professions": { professions: [
                 { id: 1, name: "Alchemy", verb: "craft", rank: 34, max_rank: 99, tier: "Journeyman", recipes_known: 21, recipes_total: 58 },
                 { id: 2, name: "Enchanting", verb: "enchant", rank: 12, max_rank: 99, tier: "Novice", recipes_known: 6, recipes_total: 44 }
+            ] },
+            "Char.Recipes": { recipes: [
+                { id: 101, profession_id: 1, name: "minor healing draught", category: "Draughts", min_rank: 30, duration: 20,
+                  components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 2 }, { kind: "item", vnum: 9003, name: "a sprig of nightshade", count: 1 }] },
+                { id: 102, profession_id: 1, name: "tincture of stone", category: "Draughts", min_rank: 39, duration: 30,
+                  components: [{ kind: "item", vnum: 9099, name: "a lump of granite dust", count: 1 }, { kind: "treasure", amount: 500 }] },
+                { id: 103, profession_id: 1, name: "alchemist's fire", category: "Reagents", min_rank: 22, duration: 25,
+                  components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 4 }, { kind: "location", label: "a forge" }] },
+                { id: 201, profession_id: 2, name: "minor soothing", category: "Head", min_rank: 8, duration: 20, target_gear_type: 6,
+                  components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 1 }] },
+                { id: 202, profession_id: 2, name: "keened edge", category: "Weapon", min_rank: 16, duration: 30, target_gear_type: 0,
+                  components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 2 }, { kind: "treasure", amount: 800 }] },
+                { id: 203, profession_id: 2, name: "greater arcane dust", category: "Transmutation", min_rank: 20, duration: 10,
+                  components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 2 }] }
             ] },
             "Char.Craft": { active: true, kind: "craft", name: "minor healing draught", profession_id: 1, remaining: 14, duration: 20, quantity: 2, chain_remaining: 3 }
         };

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -116,10 +116,16 @@
     // #hud-overlay window; phones open the same panel in the bottom sheet.
     // Hotkeys are Ctrl+<letter>, strict single-modifier.
     // ------------------------------------------------------------------
+    // Reserved hotkey letters (never register these): "l" (Ctrl+L clears the
+    // terminal — bound in connect.html and would be silently shadowed since
+    // this handler runs first). Ctrl+<letter> may shadow a browser default
+    // (Ctrl+P = print) — deliberate, and only while the app is available.
     var OVERLAYS = [
         { key: "professions", title: "Professions", hotkey: "p",
           render: function () { renderProfessions(); },
-          available: function () { return (S.professions || []).length > 0; } }
+          // The activity bar must stay reachable even in the (theoretical)
+          // no-professions-but-harvesting state.
+          available: function () { return (S.professions || []).length > 0 || !!S.craft; } }
     ];
     var overlayName = null;   // open overlay app key (desktop), or null
 
@@ -1815,9 +1821,16 @@
     // comes fully alive when the HUD runs installed/fullscreen (no tab strip).
     function wireHotkeys() {
         document.addEventListener("keydown", function (e) {
-            if (!hudOn || !S.connected) return;
-            // Esc closes the open overlay window before anything else claims it.
+            // Overlay keys are gated on the HUD only, not the connection —
+            // browsing a reference window while the link is down is fine.
+            if (!hudOn) return;
+            // Esc closes the open overlay window before anything else claims
+            // it. This listener registers before the page's Esc handler
+            // (IsharHUD.init runs first in connect.html), so stop the event
+            // here or the same press would also close the page's search /
+            // settings / history popovers behind the overlay.
             if (e.key === "Escape" && overlayName && !mqMobile.matches) {
+                e.stopImmediatePropagation();
                 setOverlay(null);
                 return;
             }
@@ -1837,6 +1850,7 @@
                     }
                 }
             }
+            if (!S.connected) return;
             if (e.key === "`" && e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
                 if (usedPages() > 1) { e.preventDefault(); flipHotbarPage(); }
                 return;
@@ -1983,6 +1997,8 @@
         return null;
     }
     function setOverlay(name) {
+        var prev = overlayName;
+        var hadFocus = dom.overlay && dom.overlay.contains(document.activeElement);
         var ov = name ? overlayByKey(name) : null;
         overlayName = ov ? ov.key : null;
         OVERLAYS.forEach(function (o) {
@@ -1993,7 +2009,17 @@
         });
         if (dom.overlay) dom.overlay.hidden = !ov;
         if (dom.overlayTitle) dom.overlayTitle.textContent = ov ? ov.title : "";
-        if (ov) { ov.render(); markOverlayUnread(ov.key, false); }
+        if (ov) {
+            ov.render();
+            markOverlayUnread(ov.key, false);
+            // Dialog semantics: move focus into the window (tabindex="-1") so
+            // keyboard/SR users land where the content is, not behind it.
+            if (dom.overlay && dom.overlay.focus) dom.overlay.focus();
+        } else if (prev && hadFocus) {
+            // Closing with focus inside: hand it back to the launcher.
+            var lb = dom.micro && dom.micro.querySelector('button[data-overlay="' + prev + '"]');
+            if (lb && !lb.hidden) lb.focus();
+        }
     }
     function toggleOverlay(key) {
         if (mqMobile.matches) { setSheet(sheetName === key ? null : key); return; }
@@ -2061,6 +2087,7 @@
         } else {
             S.craft = null;
         }
+        updateMicro();   // craft state feeds the availability gate too
         renderProfessions();
         tickCraft();
     }
@@ -2072,7 +2099,6 @@
         var pctW = c ? Math.max(0, Math.min(100, (1 - rem / c.total) * 100)) + "%" : "0%";
         var b = dom.micro && dom.micro.querySelector('button[data-overlay="professions"]');
         if (b) {
-            b.classList.toggle("busy", !!c);
             var strip = b.querySelector(".micro-strip");
             if (strip) { strip.hidden = !c; if (c) strip.style.width = pctW; }
         }
@@ -2087,9 +2113,10 @@
     // through `craft <profession> …`; enchanting/artificing have their own
     // verbs. `verb` and `name` come from the feed; sendCmd sanitizes.
     function profCmd(p, sub) {
-        var base = (p.verb && p.verb !== "craft")
-            ? p.verb
-            : "craft " + String(p.name || "").toLowerCase();
+        // First word only: the parser prefix-matches profession names, and a
+        // multi-word name would spill its tail into the argument slot.
+        var word = String(p.name || "").toLowerCase().split(/\s+/)[0];
+        var base = (p.verb && p.verb !== "craft") ? p.verb : "craft " + word;
         return sub ? base + " " + sub : base;
     }
     function profBtn(label, cmd) {
@@ -2631,6 +2658,7 @@
     }
     function setHud(on, persist) {
         hudOn = on;
+        if (!on && overlayName) setOverlay(null);   // no orphaned overlay behind a hidden HUD
         dom.app.classList.toggle("hud-on", on);
         dom.app.classList.toggle("hud-off", !on);
         var btn = document.getElementById("ui-toggle");

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -177,8 +177,8 @@
             <div id="hud-hotbar" class="empty"></div>
             <nav id="hud-micro" aria-label="Overlay windows">
                 <button type="button" class="micro-btn" data-overlay="professions" hidden
-                        aria-pressed="false" title="Professions (Ctrl+P)"
-                        aria-label="Professions (Ctrl+P)">
+                        aria-pressed="false" aria-haspopup="dialog" aria-controls="hud-overlay"
+                        title="Professions (Ctrl+P)" aria-label="Professions (Ctrl+P)">
                     {% bi "tools" %}
                     <span class="micro-strip" hidden></span>
                 </button>
@@ -287,7 +287,7 @@
     <!-- Desktop overlay window: the transient surface behind the micro-menu
        (one overlay app at a time; Esc / outside-click / ✕ dismiss). On phones
        the same panel nodes open in the bottom sheet instead. -->
-    <div id="hud-overlay" hidden>
+    <div id="hud-overlay" role="dialog" aria-labelledby="hud-overlay-title" tabindex="-1" hidden>
         <div class="overlay-head">
             <span id="hud-overlay-title" class="overlay-title"></span>
             <button type="button" class="sheet-close" id="hud-overlay-close" aria-label="Close window">

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -169,7 +169,21 @@
                 &#x25BC; Latest
             </button>
         </div>
-        <div id="hud-hotbar" class="empty"></div>
+        <!-- Action row: the skill bar plus the micro-menu — small icon buttons
+           that open transient overlay apps (Ctrl+letter hotkeys). See
+           docs/design/decisions.md "The HUD extension model". Buttons are
+           revealed by hud.js when the matching feed has data. -->
+        <div id="hud-actionrow">
+            <div id="hud-hotbar" class="empty"></div>
+            <nav id="hud-micro" aria-label="Overlay windows">
+                <button type="button" class="micro-btn" data-overlay="professions" hidden
+                        aria-pressed="false" title="Professions (Ctrl+P)"
+                        aria-label="Professions (Ctrl+P)">
+                    {% bi "tools" %}
+                    <span class="micro-strip" hidden></span>
+                </button>
+            </nav>
+        </div>
         <form id="command-form" autocomplete="off">
             <!-- Recent-commands popover for touch screens (Arrow keys have no
                thumb equivalent). The button is revealed by JS on coarse
@@ -237,6 +251,10 @@
             {% bi "stars" %}
             <span>Skills</span>
         </button>
+        <button type="button" data-panel="professions" aria-pressed="false" hidden>
+            {% bi "tools" %}
+            <span>Craft</span>
+        </button>
         <button type="button" data-panel="train" aria-pressed="false">
             {% bi "person-up" %}
             <span>Char</span>
@@ -264,6 +282,21 @@
             </button>
         </div>
         <div id="hud-sheet-body"></div>
+    </div>
+
+    <!-- Desktop overlay window: the transient surface behind the micro-menu
+       (one overlay app at a time; Esc / outside-click / ✕ dismiss). On phones
+       the same panel nodes open in the bottom sheet instead. -->
+    <div id="hud-overlay" hidden>
+        <div class="overlay-head">
+            <span id="hud-overlay-title" class="overlay-title"></span>
+            <button type="button" class="sheet-close" id="hud-overlay-close" aria-label="Close window">
+                {% bi "x-lg" %}
+            </button>
+        </div>
+        <div id="hud-overlay-body">
+            <section id="panel-professions" class="panel"></section>
+        </div>
     </div>
 
     <!-- Context/action menu (inventory, equipment, occupants). Built on demand

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -460,12 +460,25 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   launcher. On phones the same panel node opens in `#hud-sheet` via a dock
   button (`placePanels()` re-homes it). Register apps in the `OVERLAYS`
   table in `hud.js`.
-- **Professions app** (`.prof-row/.prof-track/.prof-btn`,
+- **Professions app** (`.prof-row/.prof-head/.prof-track/.prof-btn`,
+  `.recipe-list/.recipe-cat/.recipe-row`,
   `.craft-activity/.craft-track/.craft-fill/.craft-time`) — the reference
-  overlay app: profession standing rows (name + tier `.tag` + `Rank n/max` +
-  rank meter + recipe counts + command buttons) fed by `Char.Professions`,
+  overlay app: profession standing rows (disclosure header + tier `.tag` +
+  `Rank n/max` + rank meter + recipe counts) fed by `Char.Professions`,
   topped by the live craft/harvest cast bar fed by `Char.Craft` (ticked
   locally each second; the micro button mirrors it as `.micro-strip`).
+  Expanding a row opens the **recipe browser** fed by `Char.Recipes`:
+  rows grouped by category, name colored by the **`.tier-*` difficulty
+  classes** (trivial/easy/medium/hard/blocked — the contract's shared
+  buckets, computed client-side from `min_rank` − rank), a `✓` when the
+  component join against `Char.Inventory` (vnums + the `treasure` total)
+  says it's craftable, and an action per row: **Craft** (targetless) or
+  **Enchant…** (targeted — an item picker over carried items whose
+  `gear_type` matches the recipe's `target_gear_type`, sending
+  `enchant <item> <recipe>`). Native `title` holds the component summary.
+  The same `.tier-*` classes color the enchanter's **`Disenchant (rN)`**
+  entry in inventory item context menus (from the item's
+  `disenchant_rank`).
 
 Verify with `/connect?demo=1` (sample GMCP feeds, no server needed).
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -478,7 +478,12 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   `enchant <item> <recipe>`). Native `title` holds the component summary.
   The same `.tier-*` classes color the enchanter's **`Disenchant (rN)`**
   entry in inventory item context menus (from the item's
-  `disenchant_rank`).
+  `disenchant_rank`). Tapping a recipe's name discloses `.recipe-comps` —
+  the per-component have/need breakdown (the touch path to "what am I
+  missing?"; the hover `title` is desktop convenience only). Note one
+  deliberate palette divergence: the trivial tier renders `--ac-dim`
+  (de-emphasis) where the game shows white — worthless-for-skillup recipes
+  should recede, not match body text.
 
 Verify with `/connect?demo=1` (sample GMCP feeds, no server needed).
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -445,6 +445,27 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   Ctrl+Shift+F, closed by Esc. Match decorations use the amber accent.
 - Note `.hud-btn[hidden] { display: none; }` — the button's explicit
   `display` would otherwise defeat the `hidden` attribute.
+- **`#hud-actionrow` / `#hud-micro` / `.micro-btn`** — the action row wraps
+  the skill bar plus the **micro-menu**: small icon buttons (32px, `{% bi %}`
+  glyphs) that toggle transient **overlay apps** (`Ctrl`+letter hotkeys; see
+  decisions.md "The HUD extension model", 2026-07-17). Launchers are
+  availability-gated by their feed (`hidden` when there's nothing to show) and
+  may carry a `.unread` dot (feed changed while closed) and a `.micro-strip`
+  progress bar (long-running activity). Hidden on phones — the dock is the
+  phone's micro-menu.
+- **`#hud-overlay` / `.overlay-head` / `.overlay-title`** — the desktop
+  overlay window (fixed, centered, `z-index` 1038 — above sheet/popovers,
+  below `#hud-menu`): one `.panel.overlay-active` at a time from
+  `#hud-overlay-body`; dismissed by Esc, outside-click, ✕, the hotkey or the
+  launcher. On phones the same panel node opens in `#hud-sheet` via a dock
+  button (`placePanels()` re-homes it). Register apps in the `OVERLAYS`
+  table in `hud.js`.
+- **Professions app** (`.prof-row/.prof-track/.prof-btn`,
+  `.craft-activity/.craft-track/.craft-fill/.craft-time`) — the reference
+  overlay app: profession standing rows (name + tier `.tag` + `Rank n/max` +
+  rank meter + recipe counts + command buttons) fed by `Char.Professions`,
+  topped by the live craft/harvest cast bar fed by `Char.Craft` (ticked
+  locally each second; the micro button mirrors it as `.micro-strip`).
 
 Verify with `/connect?demo=1` (sample GMCP feeds, no server needed).
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -49,7 +49,11 @@ guards, same discipline as the action bar's `Alt/Ctrl+digit`), chosen
 mnemonically: `Ctrl+P` = Professions. The keydown handler swallows the event
 only when the HUD is on and the overlay actually toggled, so terminal/browser
 behavior survives everywhere else. `Esc` closes the open overlay before
-anything else claims it.
+anything else claims it (the HUD's listener registers first and stops the
+event, by design). **Reserved letters:** `l` (`Ctrl+L` clears the terminal —
+a page binding the overlay handler would silently shadow). Shadowing a
+browser default (`Ctrl+P` = print) is a deliberate trade, taken only while
+the app has something to show.
 
 **Why.** The tabs/collapsible-panel pattern was quietly becoming the answer to
 every new feature, and it doesn't scale: each addition taxes the side columns

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,64 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-17 — The HUD extension model: three surface tiers, and the micro-menu + overlay convention
+
+**Decision.** The HUD now has a **definitive placement rule** for every new
+feature. Three tiers, by how the player consumes the information:
+
+1. **Ambient** — glanced at every second: the vitals topbar, the action bar,
+   the compass rose. This set is **closed**; adding to it means arguing (in a
+   new ADR) that something else leaves. Screen real estate here is the
+   scarcest resource the client has.
+2. **Persistent panels** — *monitored* across a session: group, occupants,
+   gear, bag, chat — the desktop side columns and the phone dock/sheet. This
+   set is now **closed by default**: a new feature does not get a column
+   panel just by existing.
+3. **Overlay apps** — *consulted on demand*: professions, and any future
+   quest log / recipe browser / achievements / reference view. An overlay is
+   a transient, dismissible surface — opened from the **micro-menu**, closed
+   by `Esc`, outside-click, its ✕, or its own toggle. **One overlay at a
+   time.** Nothing inside an overlay may be required mid-combat; if a
+   feature needs a per-second glance it belongs (by exception) in tier 1/2.
+
+**The micro-menu.** A row of small icon buttons docked at the **right end of
+the action-bar row** (`#hud-actionrow` = `#hud-hotbar` + `#hud-micro`) — the
+WoW micro-menu, deliberately: players already have a mental slot for "little
+buttons next to the skill bar that open windows". Each overlay app registers
+one button, one hotkey, and one renderer in the `OVERLAYS` table in `hud.js` —
+the registry is the single point of extension. Buttons may carry at most a
+**dot badge** (something changed while closed) and a **thin progress strip**
+(a long-running activity, e.g. an active craft): ambient-lite signals, no
+text, no counts.
+
+**On phones there is no separate micro-menu** — the dock *is* the phone's
+micro-menu. An overlay app adds a dock button like any panel and opens in the
+bottom sheet; `placePanels()` re-homes the same panel node between the
+desktop overlay container and the sheet. One renderer, two presentations.
+
+**Hotkeys.** Overlay hotkeys are **`Ctrl`+letter** (strict single-modifier
+guards, same discipline as the action bar's `Alt/Ctrl+digit`), chosen
+mnemonically: `Ctrl+P` = Professions. The keydown handler swallows the event
+only when the HUD is on and the overlay actually toggled, so terminal/browser
+behavior survives everywhere else. `Esc` closes the open overlay before
+anything else claims it.
+
+**Why.** The tabs/collapsible-panel pattern was quietly becoming the answer to
+every new feature, and it doesn't scale: each addition taxes the side columns
+(desktop) or lengthens the dock crawl (phone), and most new data — professions
+included — is reference material, not monitoring. Naming the three tiers turns
+"where does this go?" from a per-feature debate into a lookup. The micro-menu
+buys unbounded extension for ~30px of an already-existing row.
+
+**Migration notes.** Existing tier-2/tab residents that are really reference
+views — the **Abilities browser** and **Who** are the clear candidates, and the
+gear/history popovers should eventually converge on the same overlay
+primitive — migrate opportunistically, each as its own change. The
+Professions overlay is the reference implementation of the whole convention
+(`#hud-overlay`, `.micro-btn`, `OVERLAYS`, `Ctrl+P`).
+
+---
+
 ## 2026-07-16 — HUD icons: a standardized map everyone inherits, and the `.hud-tip` tooltip convention
 
 **Decision (icon resolution).** Skill icons are a **standardized set every player


### PR DESCRIPTION
Implements the first overlay app (professions) and establishes the HUD extension convention for all future transient surfaces.

## Summary

This change introduces a new **overlay app system** for the HUD — a scalable pattern for reference/on-demand features that don't belong in the persistent side columns. The professions overlay is the reference implementation, demonstrating the full convention: micro-menu launchers, hotkey bindings, availability gating, and a shared renderer that works on both desktop (fixed window) and phones (bottom sheet).

## Key Changes

**Overlay infrastructure** (`hud.js`):
- Added `OVERLAYS` registry — the single point of extension for new overlay apps. Each entry specifies a key, title, hotkey, render function, and availability gate.
- New `setOverlay()` / `toggleOverlay()` / `overlayVisible()` functions manage overlay state and focus semantics (dialog-like behavior: Esc closes, focus moves into the window).
- Hotkey handler for `Ctrl`+letter (strict single-modifier) to toggle overlays; `Esc` closes the open overlay before other handlers claim it.
- Availability gating: overlay launchers hide entirely when their feed has no data (e.g., a character with no professions never sees the button).
- Unread dot badges on launchers when a feed changes while the overlay is closed.

**Professions overlay app** (`hud.js` + `hud.css`):
- Three new GMCP feeds: `Char.Professions` (standing rows), `Char.Recipes` (recipe list), `Char.Craft` (active craft/harvest cast bar).
- Profession rows show rank/tier/recipe counts with a disclosure header to expand the recipe browser.
- Recipe browser groups recipes by category, colors by difficulty tier (trivial/easy/medium/hard/blocked), and shows a `✓` when components are in inventory.
- Live craft/harvest cast bar with per-second tick updates; the micro button mirrors progress as a thin `.micro-strip`.
- Enchanting context: disenchant menu entry on gear items, colored by difficulty tier relative to the player's enchanting rank.

**UI updates**:
- Micro-menu: small icon buttons (32px) at the right end of the action row (`#hud-actionrow` = `#hud-hotbar` + `#hud-micro`). Hidden on phones — the dock is the phone's micro-menu.
- Desktop overlay window (`#hud-overlay`): centered, fixed, one app at a time; dismissed by Esc, outside-click, ✕, hotkey, or launcher.
- Dock button for professions (phones open the same panel in the bottom sheet).
- Inventory items now carry a `data-disen` attribute (disenchant rank) for the context menu.

**Design documentation** (`docs/design/decisions.md`):
- New ADR (2026-07-17) formalizing the three-tier HUD model: ambient (vitals/action bar), persistent panels (columns/dock), and overlay apps (on-demand reference). Establishes the micro-menu convention, hotkey discipline, and extension pattern.

## Implementation Details

- **Availability gating:** The professions button hides unless the character has professions or an active craft. This prevents UI clutter for characters without the feature.
- **Inventory join:** Recipe craftability is computed client-side by joining against `Char.Inventory` (vnums + treasure), matching the game's portable-component scope.
- **Difficulty tiers:** Shared buckets (trivial/easy/medium/hard/blocked) computed from `min_rank − player_rank`, used consistently in recipe rows, menu entries, and the disenchant context action.
- **Craft ticking:** Like cooldowns, craft expiry is stored and ticked locally each second; the micro button's progress strip and the cast bar update without rebuilding the panel.
- **Phone behavior:** On mobile, overlay apps open in the bottom sheet (same panel node, re-homed by `placePanels()`); the dock is the launcher. Desktop uses the fixed overlay window.
- **Focus management:** Opening an overlay moves focus into the window (dialog semantics); closing with focus inside hands it back to the

https://claude.ai/code/session_01K3vhEd1adVPLTTmuzuVBuX