### PR TITLE
Recipe browser: categories, search, filters, batch-craft queue

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -513,23 +513,26 @@ body.connect-page #content { padding: .5rem !important; }
 /* ----- Abilities browser (bounded, searchable) ----- */
 #panel-abilities { padding: 6px; }
 .ab-controls { flex: none; margin-bottom: 5px; }
-.ab-search {
+/* Search box + filter chips — shared by the abilities overlay and the
+   professions recipe browser so the two filter surfaces read identically. */
+.ab-search, .recipe-search {
     width: 100%; font-size: 16px; padding: 5px 8px;
     background: var(--ac-bg); color: var(--ac-text);
     border: 1px solid var(--ac-border); border-radius: var(--ac-radius-sm);
 }
-.ab-search:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: -1px; }
-.ab-chips { flex: none; display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
-.ab-chip {
+.ab-search:focus-visible, .recipe-search:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: -1px; }
+.ab-chips, .recipe-chips { flex: none; display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.ab-chip, .recipe-chip {
     font-size: .66rem; font-weight: 700; padding: 3px 9px; cursor: pointer;
     background: var(--ac-panel); color: var(--ac-dim);
     border: 1px solid var(--ac-border); border-radius: 999px;
 }
-.ab-chip:hover { border-color: var(--ac-accent); color: var(--ac-accent); }
-.ab-chip.on { color: var(--ac-accent); border-color: var(--ac-accent); background: var(--ac-wash); }
+.ab-chip:hover, .recipe-chip:hover { border-color: var(--ac-accent); color: var(--ac-accent); }
+.ab-chip.on, .recipe-chip.on { color: var(--ac-accent); border-color: var(--ac-accent); background: var(--ac-wash); }
 .ab-chip.ab-fav { color: var(--hud-gold); }
 .ab-chip.ab-fav.on { color: var(--hud-gold); border-color: var(--hud-gold); background: var(--hud-gold-wash); }
-.ab-chip.ab-usable.on { color: var(--ac-ok); border-color: rgba(76, 187, 23, .5); background: var(--ac-ok-wash); }
+.ab-chip.ab-usable.on,
+.recipe-chip.avail.on { color: var(--ac-ok); border-color: rgba(76, 187, 23, .5); background: var(--ac-ok-wash); }
 .ab-scroll { flex: 1; min-height: 0; overflow-y: auto; }
 .ab-list { list-style: none; margin: 0; padding: 0; }
 .ab-row {
@@ -820,26 +823,73 @@ body.connect-page #content { padding: .5rem !important; }
 .prof-hint { border-top: 1px solid var(--ac-border); margin-top: 8px; font-family: monospace; }
 
 /* Recipe browser (Char.Recipes) inside a profession row. */
-.recipe-list { margin-top: 4px; padding-left: 14px; }
+.recipe-controls { margin: 4px 0 6px; padding-left: 14px; }
+.recipe-list { margin-top: 2px; padding-left: 14px; }
+
+/* Category = a collapsible section header (a thematic break, not a lost
+   all-caps line): a full-width disclosure with a caret, name, and a count. */
 .recipe-cat {
-    font-size: .68rem; font-weight: 700; text-transform: uppercase;
-    letter-spacing: .06em; color: var(--ac-dim); padding: 6px 0 2px;
+    display: flex; align-items: center; gap: 6px; width: 100%;
+    margin: 8px 0 2px; padding: 4px 2px 5px; cursor: pointer; text-align: left;
+    background: none; border: 0; border-bottom: 1px solid var(--ac-border);
+    color: var(--ac-text);
 }
+.recipe-cat-caret { flex: none; width: .9rem; color: var(--ac-dim); font-size: .72rem; }
+.recipe-cat-name {
+    flex: 1; min-width: 0; font-size: .68rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .07em; color: var(--ac-accent-2);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.recipe-cat-count {
+    flex: none; font-size: .62rem; font-weight: 700; color: var(--ac-dim);
+    background: var(--ac-bg); border-radius: 999px; padding: 0 6px;
+    font-variant-numeric: tabular-nums;
+}
+.recipe-cat:hover .recipe-cat-name { color: var(--ac-accent); }
+.recipe-cat.collapsed { border-bottom-color: transparent; }
+
 .recipe-row { display: flex; align-items: center; gap: 6px; padding: 3px 0; }
-/* The name is the component-details disclosure — the TOUCH path to "what am
-   I missing?" (the hover title is desktop convenience only). */
+/* The name is the component / batch-craft disclosure — the TOUCH path to
+   "what am I missing?" and the queue (the hover title is desktop convenience). */
 .recipe-toggle {
     flex: 1; min-width: 0; display: block; text-align: left;
     background: none; border: 0; padding: 0; cursor: pointer;
 }
 .recipe-name { font-size: .82rem; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Rank: a bare tier-colored number (no "r" prefix). */
 .recipe-rank { flex: none; font-variant-numeric: tabular-nums; }
-.recipe-ok { flex: none; color: var(--ac-ok); }
+/* Craftable count: visually distinct from the rank — a washed pill, green
+   when ready (×N / ✓), red "Missing" when short. */
+.recipe-avail { flex: none; font-weight: 700; font-variant-numeric: tabular-nums; }
+.recipe-avail.ok { color: var(--ac-ok); background: var(--ac-ok-wash); }
+.recipe-avail.missing { color: var(--ac-danger); background: var(--ac-danger-wash); }
+
 .recipe-comps { padding: 2px 0 6px 10px; border-left: 2px solid var(--ac-border); margin-left: 2px; }
 .recipe-comp { font-size: .74rem; padding: 1px 0; font-variant-numeric: tabular-nums; }
 .recipe-comp.ok { color: var(--ac-ok); }
 .recipe-comp.missing { color: var(--ac-danger); }
 .recipe-comp.loc { color: var(--ac-dim); }
+
+/* Batch-craft queue (targetless recipes): stepper + editable count + Max +
+   Craft ×N. Mirrors the game's `<verb> <recipe> <count>` chain (cap 99). */
+.recipe-queue {
+    display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
+    margin: 2px 0 6px 10px; padding: 6px 8px;
+    background: var(--ac-elev); border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius-sm);
+}
+.recipe-queue-label { font-size: .72rem; color: var(--ac-dim); }
+.recipe-qty-btn { min-width: 26px; text-align: center; font-weight: 700; padding: 3px 6px; }
+.recipe-qty-num {
+    width: 3ch; text-align: center; font-size: 16px; padding: 3px 4px;
+    font-variant-numeric: tabular-nums;
+    background: var(--ac-bg); color: var(--ac-text);
+    border: 1px solid var(--ac-border); border-radius: var(--ac-radius-sm);
+}
+.recipe-qty-num:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: -1px; }
+.recipe-queue-craft { margin-left: auto; font-weight: 700; color: var(--ac-accent); border-color: var(--ac-border-2); }
+.recipe-queue-craft.off { opacity: .45; }
+
 .prof-btn.off { opacity: .45; }
 
 /* Profession difficulty buckets (docs/gmcp_feeds.md) — the same palette the
@@ -854,6 +904,9 @@ body.connect-page #content { padding: .5rem !important; }
 /* Tablets show the micro-menu with a coarse pointer — bump its launchers too. */
 @media (pointer: coarse) {
     .prof-btn { min-height: 40px; padding: 6px 12px; }
+    .recipe-chip { min-height: 34px; }
+    .recipe-cat { min-height: 42px; }
+    .recipe-qty-btn { min-width: 40px; }
     .micro-btn { width: 42px; height: 42px; }
 }
 
@@ -1046,7 +1099,8 @@ body.connect-page #content { padding: .5rem !important; }
 .panel-h-toggle:focus-visible, .row-more:focus-visible, .menu-item:focus-visible,
 .ab-chip:focus-visible, .ab-star:focus-visible, .panel-h-btn:focus-visible,
 .aff-release:focus-visible, .occ-row:focus-visible, .sub-h.collapse:focus-visible,
-.micro-btn:focus-visible, .prof-btn:focus-visible {
+.micro-btn:focus-visible, .prof-btn:focus-visible, .prof-head:focus-visible,
+.recipe-toggle:focus-visible, .recipe-cat:focus-visible, .recipe-chip:focus-visible {
     outline: 2px solid var(--ac-accent); outline-offset: 2px;
 }
 

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -2244,21 +2244,32 @@
         add(S.equipment);
         return counts;
     }
-    // Mirror of the game's `available` filter: item + treasure components
-    // must be covered; location components are display-only (the in-game
-    // filter skips them too — "what could I craft if I traveled there").
-    function recipeCraftable(r, counts, treasure) {
+    // How many of a recipe the carried components allow, mirroring the game's
+    // recipe_available_count: min over item + treasure components of
+    // floor(have / need). Location components are display-only (the in-game
+    // `available` filter skips them too — "what could I craft if I traveled
+    // there"). Returns Infinity when nothing material bounds it (craftable,
+    // but not limited by mats — e.g. a location-only or component-free recipe).
+    function recipeCraftCount(r, counts, treasure) {
         var comps = (r && r.components) || [];
+        var min = Infinity;
         for (var i = 0; i < comps.length; i++) {
             var comp = comps[i];
             if (!comp) continue;
             if (comp.kind === "item") {
-                if ((counts[comp.vnum] || 0) < (Number(comp.count) || 1)) return false;
+                var need = Number(comp.count) || 1;
+                if (need > 0) min = Math.min(min, Math.floor((counts[comp.vnum] || 0) / need));
             } else if (comp.kind === "treasure") {
-                if (treasure < (Number(comp.amount) || 0)) return false;
+                var amt = Number(comp.amount) || 0;
+                if (amt > 0) min = Math.min(min, Math.floor(treasure / amt));
             }
         }
-        return true;
+        return min;
+    }
+    // Craftable-now: the same portable-components join as the game's `available`
+    // filter (≥ 1 of everything material; location requirements ignored).
+    function recipeCraftable(r, counts, treasure) {
+        return recipeCraftCount(r, counts, treasure) >= 1;
     }
     // One-line component summary for a recipe row's native tooltip.
     function recipeComponentsText(r) {
@@ -2289,10 +2300,48 @@
     function profBtn(label, fn, cls) {
         return el("button", { type: "button", class: "prof-btn" + (cls ? " " + cls : ""), text: label, onclick: fn });
     }
-    // Which professions' recipe lists / recipes' component details are
-    // unfolded (session-local UI state).
-    var profOpen = {};
-    var recipeOpen = {};
+    // Session-local recipe-browser UI state.
+    var profOpen = {};       // profession id → recipe list unfolded
+    var recipeOpen = {};     // recipe id → component/queue detail unfolded
+    var catCollapsed = {};   // "pid:category" → section folded
+    var recipeQty = {};      // recipe id → chosen craft quantity (queue stepper)
+    var profSearch = {};     // profession id → recipe search string
+    var profCat = {};        // profession id → selected category ("" = all)
+    var profAvailOnly = false;   // global "craftable now" filter (persisted)
+    try { profAvailOnly = localStorage.getItem("ishar.profAvailOnly") === "1"; } catch (e) {}
+    function persistProfAvail() {
+        try { localStorage.setItem("ishar.profAvailOnly", profAvailOnly ? "1" : "0"); } catch (e) {}
+    }
+
+    // Category display order. The game lists categories alphabetically; the web
+    // browser reads them anatomically instead — worn slots head → feet, then
+    // held items, then any unknown category (alpha), with transmutation /
+    // general pushed to the bottom. Keeps Enchanting's gear-slot categories in
+    // paperdoll order rather than Body → Feet → Head → Shield → …
+    var CATEGORY_ORDER = [
+        "head", "face", "eyes", "ears", "neck", "throat", "about",
+        "shoulders", "back", "body", "torso", "chest",
+        "arms", "wrist", "wrists", "hands", "gloves",
+        "finger", "ring", "waist", "belt", "legs", "feet",
+        "weapon", "shield"
+    ];
+    var CATEGORY_BOTTOM = { transmutation: 1, general: 2, miscellaneous: 3, misc: 3, other: 4 };
+    function categoryRank(name) {
+        var key = String(name || "").trim().toLowerCase();
+        if (CATEGORY_BOTTOM[key]) return 900 + CATEGORY_BOTTOM[key];
+        var i = CATEGORY_ORDER.indexOf(key);
+        if (i >= 0) return 100 + i;
+        return 500;   // unknown category — ordered alphabetically within its band
+    }
+    function sortRecipes(list) {
+        return list.slice().sort(function (a, b) {
+            var ra = categoryRank(a.category), rb = categoryRank(b.category);
+            if (ra !== rb) return ra - rb;
+            var ca = String(a.category || "").toLowerCase(), cb = String(b.category || "").toLowerCase();
+            if (ca !== cb) return ca < cb ? -1 : 1;   // separate same-band categories alpha
+            return (Number(a.min_rank) || 0) - (Number(b.min_rank) || 0);
+        });
+    }
 
     // The tappable component breakdown under a recipe row — the touch path
     // to "what am I missing?" (the hover title is desktop convenience only).
@@ -2325,16 +2374,69 @@
         return block;
     }
 
+    // The batch-craft station for a targetless recipe (the game chains crafts
+    // with `<verb> <recipe> <count>`, capped at 99). A keyboard-free stepper
+    // plus an editable count and a Max shortcut = the components on hand. The
+    // −/+/Max buttons and the field update in place (no re-render) so typing
+    // stays smooth and focus never drops.
+    function recipeQueue(p, r, count) {
+        var craftable = count >= 1;
+        var maxMake = (count === Infinity) ? 99 : Math.max(1, Math.min(99, count));
+        var q = Math.max(1, Math.min(99, Math.floor(Number(recipeQty[r.id]) || 1)));
+        recipeQty[r.id] = q;
+        var num = el("input", {
+            type: "text", inputmode: "numeric", class: "recipe-qty-num",
+            value: String(q), "aria-label": "Quantity to craft"
+        });
+        var craftBtn = profBtn(q > 1 ? "Craft ×" + q : "Craft", function () {
+            var n = Math.max(1, Math.min(99, Math.floor(Number(recipeQty[r.id]) || 1)));
+            sendCmd(profCmd(p, nameOf(r.name) + (n > 1 ? " " + n : "")));
+            dismissProfessionsWindow();
+        }, "recipe-queue-craft" + (craftable ? "" : " off"));
+        function setQ(v, writeField) {
+            v = Math.max(1, Math.min(99, Math.floor(Number(v) || 1)));
+            recipeQty[r.id] = v;
+            if (writeField) num.value = String(v);
+            craftBtn.textContent = v > 1 ? "Craft ×" + v : "Craft";
+        }
+        num.addEventListener("input", function () { setQ(num.value, false); });
+        num.addEventListener("change", function () { num.value = String(recipeQty[r.id]); });
+        num.addEventListener("blur", function () { num.value = String(recipeQty[r.id]); });
+        return el("div", { class: "recipe-queue" }, [
+            el("span", { class: "recipe-queue-label", text: "Make" }),
+            profBtn("−", function () { setQ(recipeQty[r.id] - 1, true); }, "recipe-qty-btn"),
+            num,
+            profBtn("+", function () { setQ(recipeQty[r.id] + 1, true); }, "recipe-qty-btn"),
+            profBtn("Max", function () { setQ(maxMake, true); }, "recipe-qty-max"),
+            craftBtn
+        ]);
+    }
+
     function recipeRow(p, r, counts, treasure) {
         var rank = Number(p.rank) || 0;
         var tier = profTier((Number(r.min_rank) || 1) - rank);
-        var craftable = recipeCraftable(r, counts, treasure);
+        var count = recipeCraftCount(r, counts, treasure);
+        var craftable = count >= 1;
         var targeted = r.target_gear_type != null;
         var isOpen = !!recipeOpen[r.id];
-        var actBtn;
+        // Craftable-count badge (#8) — distinct from the rank: a green ×N (how
+        // many the components allow) or ✓ (ready, mats-unbounded / targeted),
+        // or a red "Missing". Replaces the old bare ✓.
+        var availBadge;
+        if (!craftable) {
+            availBadge = el("span", { class: "tag recipe-avail missing", title: "Missing components", text: "Missing" });
+        } else if (targeted || count === Infinity) {
+            availBadge = el("span", { class: "tag recipe-avail ok", title: "Components ready", text: "✓" });
+        } else {
+            availBadge = el("span", { class: "tag recipe-avail ok", title: "You can make " + count + " with your components", text: "×" + count });
+        }
+        // Inline action. Enchants keep their item picker (single target, no
+        // chaining). Targetless crafts get a quick Craft-one here; the batch
+        // queue lives in the disclosed detail, so hide this button when open.
+        var actions = [];
         if (targeted) {
             var targets = enchantTargets(r);
-            actBtn = profBtn("Enchant…", function (e) {
+            actions.push(profBtn("Enchant…", function (e) {
                 var opener = e && e.target && e.target.closest(".prof-btn");
                 // Second tap on the opener toggles the picker closed.
                 if (menuOpen && menuAnchorEl === opener) { closeMenu(); return; }
@@ -2350,12 +2452,12 @@
                 });
                 if (!acts.length) acts = [{ label: "No matching item carried", fn: function () {}, keep: true }];
                 openMenu("Enchant · " + stripColor(r.name || ""), acts, opener);
-            }, "menu-opener" + (targets.length ? "" : " off"));   // .menu-opener: exempt from outside-click dismissal
-        } else {
-            actBtn = profBtn("Craft", function () {
+            }, "menu-opener" + (targets.length ? "" : " off")));   // .menu-opener: exempt from outside-click dismissal
+        } else if (!isOpen) {
+            actions.push(profBtn("Craft", function () {
                 sendCmd(profCmd(p, nameOf(r.name)));
                 dismissProfessionsWindow();
-            }, craftable ? "" : "off");
+            }, craftable ? "" : "off"));
         }
         var row = el("div", { class: "recipe-row", title: recipeComponentsText(r) || null }, [
             el("button", {
@@ -2365,25 +2467,47 @@
             }, [
                 el("span", { class: "recipe-name tier-" + tier, text: stripColor(r.name || "?") })
             ]),
-            el("span", { class: "tag recipe-rank tier-" + tier, text: "r" + (r.min_rank != null ? r.min_rank : "?") }),
-            craftable ? el("span", { class: "tag recipe-ok", title: "You have the components", text: "✓" }) : null,
-            el("span", { class: "prof-actions" }, [actBtn])
+            el("span", { class: "tag recipe-rank tier-" + tier, title: "Minimum rank " + (r.min_rank != null ? r.min_rank : "?"), text: (r.min_rank != null ? String(r.min_rank) : "?") }),
+            availBadge,
+            el("span", { class: "prof-actions" }, actions)
         ]);
         var wrap = el("div", { class: "recipe-item" }, [row]);
-        if (isOpen) wrap.appendChild(recipeCompsBlock(r, counts, treasure));
+        if (isOpen) {
+            wrap.appendChild(recipeCompsBlock(r, counts, treasure));
+            if (!targeted) wrap.appendChild(recipeQueue(p, r, count));
+        }
         return wrap;
+    }
+
+    // The overlay/sheet body that scrolls the panel — saved/restored across
+    // rebuilds so a filter/collapse/keystroke doesn't snap a long list to top.
+    function profScrollParent() {
+        var n = dom.professions && dom.professions.parentElement;
+        while (n) {
+            var oy = "";
+            try { oy = getComputedStyle(n).overflowY; } catch (e) {}
+            if ((oy === "auto" || oy === "scroll") && n.scrollHeight > n.clientHeight + 1) return n;
+            n = n.parentElement;
+        }
+        return null;
     }
 
     function renderProfessions() {
         if (!dom.professions) return;
-        // Wholesale rebuilds run on every inventory delta while the overlay
-        // is open — carry keyboard focus across (a11y: don't dump a keyboard/
-        // switch user to <body> mid-session).
-        var focusKey = null;
-        if (document.activeElement && dom.professions.contains(document.activeElement) &&
-            document.activeElement.getAttribute) {
-            focusKey = document.activeElement.getAttribute("data-focus");
+        // Wholesale rebuilds run on every inventory delta while the overlay is
+        // open (and on every search keystroke) — carry keyboard focus + caret
+        // across (a11y: don't dump a keyboard/switch user to <body>), and hold
+        // the scroll position.
+        var focusKey = null, caretPos = null;
+        var ae = document.activeElement;
+        if (ae && dom.professions.contains(ae) && ae.getAttribute) {
+            focusKey = ae.getAttribute("data-focus");
+            if (ae.tagName === "INPUT" && ae.selectionStart != null) {
+                try { caretPos = ae.selectionStart; } catch (e) {}
+            }
         }
+        var sc = profScrollParent();
+        var savedTop = sc ? sc.scrollTop : 0;
         var kids = [];
         var c = S.craft;
         if (c) {
@@ -2414,11 +2538,6 @@
             var pct = maxRank > 0 ? Math.max(0, Math.min(100, (rank / maxRank) * 100)) : 100;
             var isOpen = !!profOpen[p.id];
             var recipes = (S.recipes || []).filter(function (r) { return r && r.profession_id === p.id; });
-            recipes.sort(function (a, b) {
-                var ca = String(a.category || ""), cb = String(b.category || "");
-                if (ca !== cb) return ca < cb ? -1 : 1;
-                return (Number(a.min_rank) || 0) - (Number(b.min_rank) || 0);
-            });
             var row = el("div", { class: "prof-row" }, [
                 el("button", {
                     type: "button", class: "prof-head", "data-focus": "p" + p.id,
@@ -2438,18 +2557,82 @@
                 ])
             ]);
             if (isOpen) {
-                var listEl = el("div", { class: "recipe-list" });
-                var lastCat = null;
-                recipes.forEach(function (r) {
+                var pid = p.id;
+                var sorted = sortRecipes(recipes);
+                // The full ordered category set — the chip list, independent of
+                // what the active search/filter currently shows.
+                var catList = [];
+                sorted.forEach(function (r) {
                     var cat = String(r.category || "General");
-                    if (cat !== lastCat) {
-                        listEl.appendChild(el("div", { class: "recipe-cat", text: cat }));
-                        lastCat = cat;
-                    }
-                    listEl.appendChild(recipeRow(p, r, counts, treasure));
+                    if (catList.indexOf(cat) === -1) catList.push(cat);
                 });
+                var searchVal = profSearch[pid] || "";
+                var q = searchVal.trim().toLowerCase();
+                var selCat = profCat[pid] || "";
+                if (selCat && catList.indexOf(selCat) === -1) selCat = profCat[pid] = "";   // recipe forgotten → stale category
+
+                // Controls: search + Available toggle + category chips. Only when
+                // there's something to browse (a 0-recipe profession skips them).
+                if (recipes.length) {
+                    var searchInput = el("input", {
+                        type: "text", class: "recipe-search", "data-focus": "search-" + pid,
+                        placeholder: "Search recipes…", autocomplete: "off", spellcheck: "false",
+                        value: searchVal, "aria-label": "Search recipes"
+                    });
+                    searchInput.addEventListener("input", function () { profSearch[pid] = searchInput.value; renderProfessions(); });
+                    var chips = el("div", { class: "recipe-chips" });
+                    chips.appendChild(el("button", {
+                        type: "button", class: "recipe-chip avail" + (profAvailOnly ? " on" : ""),
+                        "data-focus": "avail-" + pid,
+                        onclick: function () { profAvailOnly = !profAvailOnly; persistProfAvail(); renderProfessions(); },
+                        text: "✓ Available"
+                    }));
+                    var catChip = function (label, val) {
+                        return el("button", {
+                            type: "button", class: "recipe-chip" + (selCat === val ? " on" : ""),
+                            onclick: function () { profCat[pid] = (selCat === val ? "" : val); renderProfessions(); },
+                            text: label
+                        });
+                    };
+                    chips.appendChild(catChip("All", ""));
+                    catList.forEach(function (cat) { chips.appendChild(catChip(cat, cat)); });
+                    row.appendChild(el("div", { class: "recipe-controls" }, [searchInput, chips]));
+                }
+
+                var shown = sorted.filter(function (r) {
+                    if (q && stripColor(r.name || "").toLowerCase().indexOf(q) === -1) return false;
+                    if (selCat && String(r.category || "General") !== selCat) return false;
+                    if (profAvailOnly && !recipeCraftable(r, counts, treasure)) return false;
+                    return true;
+                });
+
+                var listEl = el("div", { class: "recipe-list" });
                 if (!recipes.length) {
                     listEl.appendChild(el("div", { class: "prof-empty", text: "No recipes known yet — trainers and discovery await." }));
+                } else if (!shown.length) {
+                    listEl.appendChild(el("div", { class: "prof-empty", text: "No recipes match." }));
+                } else {
+                    var byCat = {}, order = [];
+                    shown.forEach(function (r) {
+                        var cat = String(r.category || "General");
+                        if (!byCat[cat]) { byCat[cat] = []; order.push(cat); }
+                        byCat[cat].push(r);
+                    });
+                    order.forEach(function (cat) {
+                        var key = pid + ":" + cat;
+                        var collapsed = !!catCollapsed[key];
+                        listEl.appendChild(el("button", {
+                            type: "button", class: "recipe-cat" + (collapsed ? " collapsed" : ""),
+                            "data-focus": "cat-" + pid + "-" + cat.replace(/[^a-z0-9]+/gi, "_"),
+                            "aria-expanded": collapsed ? "false" : "true",
+                            onclick: (function (k, was) { return function () { closeMenu(); catCollapsed[k] = !was; renderProfessions(); }; })(key, collapsed)
+                        }, [
+                            el("span", { class: "recipe-cat-caret", "aria-hidden": "true", text: collapsed ? "▸" : "▾" }),
+                            el("span", { class: "recipe-cat-name", text: cat }),
+                            el("span", { class: "recipe-cat-count", text: String(byCat[cat].length) })
+                        ]));
+                        if (!collapsed) byCat[cat].forEach(function (r) { listEl.appendChild(recipeRow(p, r, counts, treasure)); });
+                    });
                 }
                 row.appendChild(listEl);
             }
@@ -2457,9 +2640,15 @@
         });
         kids.push(el("div", { class: "prof-hint", text: "profession — overview & trainers · harvest <node> — gather" }));
         fill(dom.professions, kids);
+        if (sc) sc.scrollTop = savedTop;
         if (focusKey && /^[a-z0-9_-]+$/i.test(focusKey)) {
             var refocus = dom.professions.querySelector('[data-focus="' + focusKey + '"]');
-            if (refocus) refocus.focus();
+            if (refocus) {
+                refocus.focus();
+                if (caretPos != null && refocus.setSelectionRange) {
+                    try { refocus.setSelectionRange(caretPos, caretPos); } catch (e) {}
+                }
+            }
         }
         tickCraft();
     }
@@ -3231,12 +3420,24 @@
                   components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 2 }, { kind: "item", vnum: 9003, name: "a sprig of nightshade", count: 1 }] },
                 { id: 102, profession_id: 1, name: "tincture of stone", category: "Draughts", min_rank: 39, duration: 30,
                   components: [{ kind: "item", vnum: 9099, name: "a lump of granite dust", count: 1 }, { kind: "treasure", amount: 500 }] },
+                { id: 106, profession_id: 1, name: "weak salve", category: "Draughts", min_rank: 10, duration: 15,
+                  components: [{ kind: "item", vnum: 9003, name: "a sprig of nightshade", count: 1 }] },
                 { id: 103, profession_id: 1, name: "alchemist's fire", category: "Reagents", min_rank: 22, duration: 25,
                   components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 4 }, { kind: "location", label: "a forge" }] },
+                { id: 104, profession_id: 1, name: "spark reagent", category: "Reagents", min_rank: 30, duration: 18,
+                  components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 2 }] },
+                { id: 105, profession_id: 1, name: "elixir of vigor", category: "Elixirs", min_rank: 45, duration: 40,
+                  components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 3 }, { kind: "treasure", amount: 300 }] },
                 { id: 201, profession_id: 2, name: "minor soothing", category: "Head", min_rank: 8, duration: 20, target_gear_type: 6,
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 1 }] },
+                { id: 204, profession_id: 2, name: "warding sigil", category: "Body", min_rank: 10, duration: 22, target_gear_type: 2,
+                  components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 1 }] },
+                { id: 205, profession_id: 2, name: "fleetfoot glyph", category: "Feet", min_rank: 14, duration: 22, target_gear_type: 5,
+                  components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 1 }] },
                 { id: 202, profession_id: 2, name: "keened edge", category: "Weapon", min_rank: 16, duration: 30, target_gear_type: 0,
                   components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 2 }, { kind: "treasure", amount: 800 }] },
+                { id: 206, profession_id: 2, name: "aegis boon", category: "Shield", min_rank: 22, duration: 28, target_gear_type: 1,
+                  components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 1 }] },
                 { id: 203, profession_id: 2, name: "greater arcane dust", category: "Transmutation", min_rank: 20, duration: 10,
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 2 }] }
             ] },

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -2314,16 +2314,18 @@
     }
 
     // Category display order. The game lists categories alphabetically; the web
-    // browser reads them anatomically instead — worn slots head → feet, then
-    // held items, then any unknown category (alpha), with transmutation /
-    // general pushed to the bottom. Keeps Enchanting's gear-slot categories in
-    // paperdoll order rather than Body → Feet → Head → Shield → …
+    // browser reads them by paperdoll slot instead — head → feet, with the
+    // held items (weapon, shield) in their worn position (below hands/gloves,
+    // above the waist) rather than dangling at the end. Any unknown category
+    // falls to a middle band (alpha); transmutation / general sink to the
+    // bottom. Keeps Enchanting's gear-slot categories in paperdoll order
+    // rather than the alphabetical Body → Feet → Head → Shield → …
     var CATEGORY_ORDER = [
         "head", "face", "eyes", "ears", "neck", "throat", "about",
         "shoulders", "back", "body", "torso", "chest",
-        "arms", "wrist", "wrists", "hands", "gloves",
-        "finger", "ring", "waist", "belt", "legs", "feet",
-        "weapon", "shield"
+        "arms", "wrist", "wrists", "hands", "gloves", "finger", "ring",
+        "weapon", "shield",
+        "waist", "belt", "legs", "feet"
     ];
     var CATEGORY_BOTTOM = { transmutation: 1, general: 2, miscellaneous: 3, misc: 3, other: 4 };
     function categoryRank(name) {

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -471,23 +471,41 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   `Rank n/max` + rank meter + recipe counts) fed by `Char.Professions`,
   topped by the live craft/harvest cast bar fed by `Char.Craft` (ticked
   locally each second; the micro button mirrors it as `.micro-strip`).
-  Expanding a row opens the **recipe browser** fed by `Char.Recipes`:
-  rows grouped by category, name colored by the **`.tier-*` difficulty
-  classes** (trivial/easy/medium/hard/blocked — the contract's shared
-  buckets, computed client-side from `min_rank` − rank), a `✓` when the
-  component join against `Char.Inventory` (vnums + the `treasure` total)
-  says it's craftable, and an action per row: **Craft** (targetless) or
-  **Enchant…** (targeted — an item picker over carried items whose
-  `gear_type` matches the recipe's `target_gear_type`, sending
-  `enchant <item> <recipe>`). Native `title` holds the component summary.
-  The same `.tier-*` classes color the enchanter's **`Disenchant (rN)`**
+  Expanding a row opens the **recipe browser** fed by `Char.Recipes`
+  (`.recipe-controls/.recipe-search/.recipe-chips/.recipe-chip`,
+  `.recipe-cat/.recipe-cat-caret/.recipe-cat-name/.recipe-cat-count`,
+  `.recipe-row/.recipe-toggle/.recipe-name/.recipe-rank/.recipe-avail`,
+  `.recipe-comps`, `.recipe-queue/.recipe-qty-btn/.recipe-qty-num`):
+  - **Controls.** A per-profession **search** box plus filter chips — an
+    **Available** toggle (craftable-now only, persisted) and one chip per
+    **category** — share the abilities overlay's `.ab-search`/`.ab-chip`
+    styling (one CSS rule serves both).
+  - **Categories** are collapsible **section headers** (a thematic-break
+    rule, caret, name, count), ordered **anatomically head → feet, then
+    held items (weapon/shield), then unknown categories alpha, with
+    transmutation / general last** — *not* the game's alphabetical order
+    (a deliberate web presentation choice; see the ADR).
+  - **Rows.** Name colored by the **`.tier-*` difficulty classes**
+    (trivial/easy/medium/hard/blocked — computed client-side from
+    `min_rank` − rank), a **bare rank number** (`.recipe-rank`, no `r`
+    prefix), and a **craftable-count badge** (`.recipe-avail`): green
+    `×N` (how many the carried components allow — mirrors the game's
+    `recipe_available_count`), `✓` (ready / targeted), or red `Missing`.
+    Action per row: **Craft** (targetless; hidden while the row's detail
+    is open) or **Enchant…** (targeted — an item picker over carried
+    items whose `gear_type` matches `target_gear_type`, sending
+    `enchant <item> <recipe>`).
+  - **Detail** (tap the name) discloses `.recipe-comps` — the per-component
+    have/need breakdown (the touch path to "what am I missing?") — and, for
+    targetless recipes, the **batch-craft queue** (`.recipe-queue`): a
+    keyboard-free `−`/`+` stepper + editable count + **Max** (= components
+    on hand) + **Craft ×N**, sending `<verb> <recipe> <count>` (the game's
+    craft chain, capped at 99).
+  The `.tier-*` classes also color the enchanter's **`Disenchant (rN)`**
   entry in inventory item context menus (from the item's
-  `disenchant_rank`). Tapping a recipe's name discloses `.recipe-comps` —
-  the per-component have/need breakdown (the touch path to "what am I
-  missing?"; the hover `title` is desktop convenience only). Note one
-  deliberate palette divergence: the trivial tier renders `--ac-dim`
-  (de-emphasis) where the game shows white — worthless-for-skillup recipes
-  should recede, not match body text.
+  `disenchant_rank`). Note one deliberate palette divergence: the trivial
+  tier renders `--ac-dim` (de-emphasis) where the game shows white —
+  worthless-for-skillup recipes should recede, not match body text.
 
 Verify with `/connect?demo=1` (sample GMCP feeds, no server needed).
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -481,8 +481,9 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
     **category** — share the abilities overlay's `.ab-search`/`.ab-chip`
     styling (one CSS rule serves both).
   - **Categories** are collapsible **section headers** (a thematic-break
-    rule, caret, name, count), ordered **anatomically head → feet, then
-    held items (weapon/shield), then unknown categories alpha, with
+    rule, caret, name, count), ordered **by paperdoll slot — head → feet,
+    with the held items (weapon/shield) in their worn position (below
+    hands, above the waist) — then unknown categories alpha, with
     transmutation / general last** — *not* the game's alphabetical order
     (a deliberate web presentation choice; see the ADR).
   - **Rows.** Name colored by the **`.tier-*` difficulty classes**

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -17,12 +17,17 @@ supports everything consumed here.
 
 - **Category order is a web concern.** The game lists recipe categories
   alphabetically (`compare_category_summary`, `strcasecmp`). The browser
-  instead orders them **anatomically — head → feet worn slots, then held
-  items (weapon, shield), then any unknown category alpha, with
-  `transmutation` / `general` / `misc` pushed to the bottom** (`categoryRank`
-  in `hud.js`). Enchanting's gear-slot categories then read like a paperdoll
-  (Head, Body, Feet, Weapon, Shield, Transmutation) rather than the
-  alphabetical Body → Feet → Head → Shield → Transmutation → Weapon.
+  instead orders them **by paperdoll slot — head → feet, with the held items
+  (weapon, shield) in their worn position (below hands/gloves, above the
+  waist) rather than dangling at the end; any unknown category falls to a
+  middle band (alpha); `transmutation` / `general` / `misc` sink to the
+  bottom** (`categoryRank` in `hud.js`). Enchanting's gear-slot categories
+  then read like a paperdoll (Head, Body, Weapon, Shield, Feet,
+  Transmutation) rather than the alphabetical Body → Feet → Head → Shield →
+  Transmutation → Weapon. The slot list is anchored on the game's full
+  `gear_names` set, so every gear-slot category is covered now and forward;
+  free-form theme categories (Draughts, Reagents, Smelting, …) hit the alpha
+  band — exactly the game's own order, so no regression.
 - **Rank loses its `r` prefix** — a bare tier-colored number
   (`.recipe-rank`). The old `✓` craftable mark is replaced by a
   **craftable-count badge** (`.recipe-avail`): green `×N` computed the same

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,49 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-17 — Recipe browser fast-follow: anatomical category order, filters/search/collapse, batch-craft queue, craftable-count badge
+
+**Decision.** The Professions recipe browser (shipped the same day) gets a
+usability pass, all client-side (`hud.js` + `hud.css`); the game already
+supports everything consumed here.
+
+- **Category order is a web concern.** The game lists recipe categories
+  alphabetically (`compare_category_summary`, `strcasecmp`). The browser
+  instead orders them **anatomically — head → feet worn slots, then held
+  items (weapon, shield), then any unknown category alpha, with
+  `transmutation` / `general` / `misc` pushed to the bottom** (`categoryRank`
+  in `hud.js`). Enchanting's gear-slot categories then read like a paperdoll
+  (Head, Body, Feet, Weapon, Shield, Transmutation) rather than the
+  alphabetical Body → Feet → Head → Shield → Transmutation → Weapon.
+- **Rank loses its `r` prefix** — a bare tier-colored number
+  (`.recipe-rank`). The old `✓` craftable mark is replaced by a
+  **craftable-count badge** (`.recipe-avail`): green `×N` computed the same
+  way the game's `recipe_available_count` does (`min` over item+treasure
+  components of `floor(have/need)`; location comps ignored), `✓` when ready
+  but unbounded/targeted, red `Missing` otherwise. Count and rank are
+  deliberately distinct pills so they can't be misread for each other.
+- **Filter + search + collapse.** A per-profession search box and filter
+  chips (an **Available** toggle — persisted — plus one chip per category)
+  reuse the abilities overlay's `.ab-search`/`.ab-chip` styling via shared
+  CSS selectors (one rule, two surfaces — the reduce-entropy move rather than
+  a forked look). Category headers double as **collapse** disclosures.
+- **Batch-craft queue.** Targetless recipes disclose a `−`/`+`/editable/**Max**
+  stepper + **Craft ×N** that sends `<verb> <recipe> <count>` — the game's
+  existing craft chain (cap 99). The quick inline **Craft** (=1) is hidden
+  while the detail is open so there's exactly one craft action per state.
+
+**Why.** The browser launched alphabetical, all-caps-header, single-craft, and
+count-less; the phone-first playerbase asked for order that matches how they
+think about gear, a way to find one recipe in a long list, and the batch craft
+they already have in-game (`fabricate steel ingot 3`). Mirroring the game's
+`available` math keeps the ×N honest.
+
+**Notes.** Verified against the real render code via `?demo=1`-style feeds in a
+headless-Chromium harness (desktop overlay + phone sheet; `scrollWidth ==
+innerWidth` at the narrow viewport — no horizontal overflow; the queue row
+`flex-wrap`s before it can). Not exercised against a live GMCP session — the
+owner's on-prod check. Relates to ishar-web#124, PR #123.
+
 ## 2026-07-17 — The HUD extension model: three surface tiers, and the micro-menu + overlay convention
 
 **Decision.** The HUD now has a **definitive placement rule** for every new


### PR DESCRIPTION
A usability pass on the Professions recipe browser (shipped same-day), all client-side. The game already supports everything consumed here.

## Summary

The recipe browser gains **category-aware ordering** (paperdoll slot order, not alphabetical), **per-profession search + filter chips** (Available toggle, category chips), **collapsible category sections**, and a **batch-craft queue** for targetless recipes. The craftable-count badge replaces the bare `✓` with a green `×N` (how many the components allow), `✓` (ready/targeted), or red `Missing`.

## Key Changes

- **`recipeCraftCount(r, counts, treasure)`** — new function mirroring the game's `recipe_available_count`: returns `min` over item+treasure components of `floor(have/need)`, or `Infinity` when unbounded (location-only or component-free recipes). `recipeCraftable()` now wraps it (`>= 1`).

- **Category ordering** — `categoryRank()` and `sortRecipes()` order by paperdoll slot (head → feet, weapon/shield in worn position, not alphabetical), unknown categories alpha, transmutation/general/misc last. Enchanting's gear-slot categories now read like a paperdoll instead of alphabetically.

- **Session-local UI state** — new state objects: `catCollapsed` (section fold), `recipeQty` (craft quantity), `profSearch` (search string), `profCat` (selected category), `profAvailOnly` (global filter, persisted to localStorage).

- **Search + filter controls** — per-profession search box (`.recipe-search`) and filter chips (`.recipe-chip`): an **Available** toggle (persisted) and one chip per category. Reuses `.ab-search`/`.ab-chip` styling from the abilities overlay (one CSS rule, two surfaces).

- **Collapsible categories** — category headers (`.recipe-cat`) are now full-width disclosure buttons with a caret, name, and count. Fold state persists in `catCollapsed`.

- **Batch-craft queue** — targetless recipes disclose a `−`/`+`/editable/**Max** stepper + **Craft ×N** (`.recipe-queue`). Sends `<verb> <recipe> <count>` (the game's existing craft chain, capped at 99). The quick inline **Craft** button is hidden while detail is open.

- **Craftable-count badge** — replaces the bare `✓` with `.recipe-avail`: green `×N` (computed like the game's `recipe_available_count`), `✓` (ready/targeted), or red `Missing`. Rank loses its `r` prefix (bare tier-colored number).

- **Scroll + focus preservation** — `renderProfessions()` now saves/restores scroll position and keyboard focus + caret across rebuilds (search keystroke, filter toggle, collapse).

- **Test data** — added sample recipes (weak salve, spark reagent, elixir of vigor, warding sigil, fleetfoot glyph, aegis boon) to exercise the new features.

## Implementation Notes

- `profScrollParent()` finds the scrollable ancestor (overlay or sheet body) to preserve scroll position across re-renders.
- Search is case-insensitive, matches recipe names, and filters in real-time.
- The **Max** button in the queue computes `maxMake` from `recipeCraftCount()` (capped at 99).
- Category collapse state is keyed `"pid:category"` to isolate per-profession.
- The **Available** toggle is persisted to `localStorage.ishar.profAvailOnly` (try/catch for privacy mode).
- CSS reuses `.ab-search`/`.ab-chip` selectors for the recipe browser (reduce entropy).
- Coarse-pointer media query bumps touch targets (chips, category headers, stepper buttons).

https://claude.ai/code/session_01XMSgR6YUdwUhgvXjAKjAe3