### PR TITLE
Room panel: ground items, corpses, and harvest nodes

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -612,6 +612,16 @@ body.connect-page #content { padding: .5rem !important; }
 .row-caret:hover { color: var(--ac-accent); }
 /* Container state glyph (🔒 / 📦) for a closed or empty container. */
 .row-glyph { flex: none; color: var(--ac-dim); font-size: .82em; }
+
+/* Ground items + harvest nodes (Room.Contents) in the Room panel. The lead
+   icon shares the caret/dot column width so names align; the harvest chip
+   ("⛏ rN") takes the standard tier-* text colors. */
+.gnd-icon { flex: none; width: .9rem; text-align: center; font-size: .72rem; line-height: 1; color: var(--ac-dim); }
+.gnd-icon.corpse { color: var(--ac-danger); }
+.gnd-icon.node { color: var(--ac-accent); }
+.tag.harvest { background: var(--ac-bg); }
+.tag.harvest.tier-open { color: var(--ac-ok); }
+.tag.dim { color: var(--ac-dim); }
 .coins { margin: 5px 8px; font-size: .78rem; color: var(--hud-gold); }
 .comp-section { margin-top: 2px; }
 
@@ -1058,6 +1068,9 @@ body.connect-page #content { padding: .5rem !important; }
 .menu-item:hover { background: var(--ac-elev); color: var(--ac-accent); }
 .menu-item.danger { color: var(--ac-danger); }
 .menu-item.danger:hover { background: var(--ac-danger-wash); color: var(--ac-danger); }
+/* Inert requirement rows (e.g. a harvest whose rank gate you don't meet):
+   visible so the requirement teaches, but never clickable. */
+.menu-item.disabled, .menu-item.disabled:hover { color: var(--ac-dim); background: none; cursor: default; opacity: .65; }
 @media (pointer: coarse) { .menu-item { min-height: 44px; } }
 
 /* ----- Icon picker (reuses #hud-menu with a wider grid layout) ----- */

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -3062,7 +3062,7 @@
     // Actions for a ground object (Room.Contents item). Commands target the
     // server-computed handle so duplicates ("2.corpse.rat") resolve to the
     // exact instance; the server re-validates everything.
-    function groundItemActions(it, anchor) {
+    function groundItemActions(it) {
         var h = groundTarget(it);
         var acts = [{ label: "Look", cmd: "look " + h }];
         var isContainer = it.type === "container";
@@ -3084,18 +3084,11 @@
         if (!it.no_take && !it.is_corpse) acts.push({ label: "Get", cmd: "get " + h });
         if (it.is_corpse) {
             // Sacrifice lives HERE and only here (the command takes a corpse
-            // on the ground, never a carried item) — last, danger-styled, and
-            // behind a confirm: it destroys the corpse AND any unlooted
-            // contents, and a thumb-slip on a 44px row is one tap away.
-            acts.push({
-                label: "Sacrifice…", danger: true, keep: true,
-                fn: function () {
-                    openMenu("Sacrifice " + stripColor(it.name || "corpse") + "?", [
-                        { label: "Confirm — destroys it" + (hasContents ? " and its contents" : ""), cmd: "sacrifice " + h, danger: true },
-                        { label: "Cancel", fn: function () {} }
-                    ], anchor);
-                }
-            });
+            // on the ground, never a carried item) — last and danger-styled.
+            // No confirm, matching the game: sacrificing spills any contents
+            // onto the ground and consumes only the corpse itself, so a
+            // mis-tap costs nothing but the body.
+            acts.push({ label: "Sacrifice", cmd: "sacrifice " + h, danger: true });
         }
         return acts;
     }
@@ -3316,7 +3309,7 @@
             openMenu(ds.name || ds.target, itemActions(ds), anchor);
         } else if (kind === "grounditem") {
             var gi = (S.roomItems || [])[Number(host.getAttribute("data-idx"))];
-            if (gi) openMenu(stripColor(gi.name || ""), groundItemActions(gi, anchor), anchor);
+            if (gi) openMenu(stripColor(gi.name || ""), groundItemActions(gi), anchor);
         } else if (kind === "groundcontent") {
             var gds = readDataset(host);
             openMenu(gds.name || gds.target, groundContentActions(gds), anchor);

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -44,6 +44,9 @@
         vitals: null, status: null, time: null, room: null,
         equipment: [], inventory: null, train: null,
         affects: null, group: null, who: null, occupants: [],
+        // Room.Contents — ground objects (corpses, drops, containers) and
+        // active harvest nodes; rendered under the occupants in the Room panel.
+        roomItems: [], roomNodes: [],
         skills: [], cooldownExpiry: {}, cooldownTotal: {}, usable: {},
         professions: [], recipes: [], craft: null,
         chat: [], connected: false,
@@ -157,11 +160,14 @@
     // means the type has no primary use action (only examine/drop).
     var TYPE_VERB = {
         potion: "quaff", scroll: "recite", food: "eat", drink: "drink",
-        weapon: "wield", armor: "wear", wand: "use", staff: "use", light: "hold"
+        weapon: "wield", armor: "wear", wand: "use", staff: "use", light: "hold",
+        // `use <tome>` learns the recipe/skill it holds; `draw <deck>` pulls a
+        // card from the Fateweaver's Deck. Both resolve from inventory.
+        tome: "use", deck: "draw"
     };
     var TYPE_VERB_LABEL = {
         quaff: "Quaff", recite: "Recite", eat: "Eat", drink: "Drink",
-        wield: "Wield", wear: "Wear", use: "Use", hold: "Hold"
+        wield: "Wield", wear: "Wear", use: "Use", hold: "Hold", draw: "Draw"
     };
 
     // ------------------------------------------------------------------
@@ -531,6 +537,8 @@
         (S.skills || []).forEach(function (s) { add(nameOf(s.name)); });
         if (S.who && S.who.players) S.who.players.forEach(function (p) { add(stripColor(p.name)); });
         (S.occupants || []).forEach(function (o) { add(o.keyword); });
+        (S.roomItems || []).forEach(addKeywords);
+        (S.roomNodes || []).forEach(function (n) { String(n.keywords || "").split(/\s+/).forEach(add); });
         (S.equipment || []).forEach(addKeywords);
         if (S.inventory) {
             (S.inventory.items || []).forEach(addKeywords);
@@ -573,6 +581,11 @@
                 if (mapMod) mapMod.onRoom(data);
                 break;
             case "Room.Occupants": applyOccupants(data); break;
+            case "Room.Contents":
+                S.roomItems = (data && data.items) || [];
+                S.roomNodes = (data && data.nodes) || [];
+                renderOccupants();
+                break;
             case "Char.Equipment":
                 S.equipment = (data && data.items) || []; renderEquipment(); renderInventory();
                 // Craftable-now marks join against carried items.
@@ -1052,17 +1065,19 @@
 
     function renderOccupants() {
         var occ = S.occupants || [];
+        var items = S.roomItems || [];
+        var nodes = S.roomNodes || [];
         var hasShop = occ.some(function (o) { return o.is_shopkeeper; });
         // Room-level List (every shop here) only when there's a shop to list.
         var actions = hasShop
             ? [el("button", { type: "button", class: "panel-h-btn", "data-cmd": "list", title: "List every shopkeeper's wares here", text: "List" })]
             : null;
-        var head = panelHeader("occupants", "Room (" + occ.length + ")", false, actions);
+        var head = panelHeader("occupants", "Room (" + (occ.length + items.length + nodes.length) + ")", false, actions);
         var kids = [head];
         if (!isCollapsed("occupants")) {
-            if (!occ.length) {
-                kids.push(el("div", { class: "panel-empty", text: "No one else here." }));
-            } else {
+            if (!occ.length && !items.length && !nodes.length) {
+                kids.push(el("div", { class: "panel-empty", text: "Nothing else here." }));
+            } else if (occ.length) {
                 // Target chips (current defaults) so they're visible at a glance.
                 if (S.tgtHostile || S.tgtFriendly) {
                     var chips = [];
@@ -1098,8 +1113,133 @@
                 });
                 kids.push(list);
             }
+            // Ground objects and harvest nodes (Room.Contents) share the panel:
+            // the room's whole interaction surface lives in one place.
+            if (items.length) {
+                kids.push(el("div", { class: "sub-h", text: "On the ground" }));
+                kids.push(groundList(items));
+            }
+            if (nodes.length) {
+                kids.push(el("div", { class: "sub-h", text: "Nodes" }));
+                kids.push(nodeList(nodes));
+            }
         }
         fill(dom.occupants, kids);
+    }
+
+    // ------------------------------------------------------------------
+    // Ground items + nodes (Room.Contents) — rendered inside the Room panel.
+    // ------------------------------------------------------------------
+    // Client-side eligibility join for a harvest source (a node, or a corpse's
+    // `harvest` object): mirrors the game's gate — must hold the profession,
+    // and harvest_rank_allows (rank + 5 >= required, i.e. tier != "blocked").
+    // A profession-less source is open to everyone.
+    function harvestStanding(hv) {
+        var req = Math.max(1, Number(hv.required_rank) || 1);
+        if (!hv.profession_id) return { ok: true, tier: null, req: req };
+        var prof = professionById(hv.profession_id);
+        if (!prof) return { ok: false, tier: "blocked", untrained: true, req: req };
+        var tier = profTier(req - (Number(prof.rank) || 0));
+        return { ok: tier !== "blocked", tier: tier, prof: prof, req: req };
+    }
+    function harvestChip(hv) {
+        var hs = harvestStanding(hv);
+        var title = hs.untrained ? "Harvestable — you lack the profession"
+            : hs.ok ? "Harvestable — requires rank " + hs.req + (hs.prof ? " " + hs.prof.name : "")
+            : "Harvestable — rank " + hs.req + " needed (yours: " + (hs.prof ? hs.prof.rank : 0) + ")";
+        return el("span", {
+            class: "tag harvest tier-" + (hs.tier || "open"),
+            title: title, text: "⛏ r" + hs.req
+        });
+    }
+    // Server-computed handle first (exact instance), keyword join as fallback.
+    function groundTarget(it) { return it.handle || targetOf(it.keywords || it.name); }
+    // Nodes are matched by exact keyword token (or name substring) game-side —
+    // NOT the object parser — so send one bare token, never a dotted join.
+    function nodeTarget(n) {
+        var k = firstWord(n.keywords);
+        if (k) return k;
+        var w = String(stripColor(n.name || "")).trim().split(/\s+/);
+        return (w[w.length - 1] || "").replace(/[^A-Za-z0-9]/g, "");
+    }
+
+    function groundList(items) {
+        var list = el("ul", { class: "row-list ground" });
+        items.forEach(function (it, i) {
+            var isContainer = it.type === "container";
+            var hasContents = !!(it.contents && it.contents.length);
+            var open = isContainer && !it.closed;
+            var ekey = "g" + groundTarget(it);
+            var canExpand = open && hasContents;
+            var isOpen = canExpand && !!expanded[ekey];
+            var kids = [];
+            if (canExpand) {
+                kids.push(el("button", {
+                    type: "button", class: "row-caret", "data-expand": ekey,
+                    "aria-expanded": isOpen ? "true" : "false",
+                    "aria-label": (isOpen ? "Collapse contents of " : "Expand contents of ") + stripColor(it.name || "container"),
+                    text: isOpen ? "▾" : "▸"
+                }));
+            }
+            if (it.is_corpse) kids.push(el("span", { class: "gnd-icon corpse", title: "Corpse", "aria-hidden": "true", text: "☠" }));
+            kids.push(el("span", { class: "row-name", text: stripColor(it.name) }));
+            if (it.count && it.count > 1) kids.push(el("span", { class: "tag", text: "×" + it.count }));
+            // Glanceable loot count while the contents are folded.
+            if (canExpand && !isOpen) kids.push(el("span", { class: "tag dim", text: it.contents.length + " inside" }));
+            if (it.harvest) kids.push(harvestChip(it.harvest));
+            // Closed/empty container state glyph (same language as inventory).
+            if (isContainer && !it.is_corpse && (it.closed || !hasContents)) {
+                kids.push(el("span", {
+                    class: "row-glyph", "aria-hidden": "true",
+                    title: it.locked ? "Locked" : it.closed ? "Closed — Open to see inside" : "Empty container",
+                    text: it.closed || it.locked ? "🔒" : "📦"
+                }));
+            }
+            kids.push(el("button", { type: "button", class: "row-more", "data-menu": "grounditem", "data-idx": i, "aria-label": "Actions", text: "⋯" }));
+            list.appendChild(el("li", {
+                class: "item-row ground" + (it.is_corpse ? " corpse" : ""),
+                "data-menu": "grounditem", "data-idx": i, title: "Tap for actions"
+            }, kids));
+            if (isOpen) {
+                var sub = el("ul", { class: "row-list sub" });
+                var ct = groundTarget(it);
+                groupStackables(it.contents).forEach(function (c) {
+                    var tgt = targetOf(c.keywords || c.name);
+                    // Row tap loots the item directly (the corpse-looting hot
+                    // path); ⋯ opens the menu.
+                    sub.appendChild(el("li", {
+                        class: "item-row sub", "data-cmd": "get " + tgt + " from " + ct,
+                        title: "Take from " + stripColor(it.name || "container") + " — ⋯ for more"
+                    }, [
+                        el("span", { class: "row-name", text: stripColor(c.name) }),
+                        (c.count && c.count > 1) ? el("span", { class: "tag", text: "×" + c.count }) : null,
+                        el("button", {
+                            type: "button", class: "row-more", "data-menu": "groundcontent",
+                            "data-target": tgt, "data-name": stripColor(c.name || ""), "data-container": ct,
+                            "aria-label": "Actions", text: "⋯"
+                        })
+                    ]));
+                });
+                list.appendChild(sub);
+            }
+        });
+        return list;
+    }
+
+    function nodeList(nodes) {
+        var list = el("ul", { class: "row-list ground" });
+        nodes.forEach(function (n, i) {
+            var hs = harvestStanding(n);
+            list.appendChild(el("li", {
+                class: "item-row ground node", "data-menu": "node", "data-idx": i, title: "Tap for actions"
+            }, [
+                el("span", { class: "gnd-icon node" + (hs.tier ? " tier-" + hs.tier : ""), "aria-hidden": "true", text: "✦" }),
+                el("span", { class: "row-name", text: stripColor(n.name) }),
+                harvestChip(n),
+                el("button", { type: "button", class: "row-more", "data-menu": "node", "data-idx": i, "aria-label": "Actions", text: "⋯" })
+            ]));
+        });
+        return list;
     }
 
     // ------------------------------------------------------------------
@@ -2762,7 +2902,10 @@
         menuOpen = true;
         positionMenu(anchor);
     }
-    // actions: [{label, cmd|prefill|fn, danger}]. Anchored near `anchor`.
+    // actions: [{label, cmd|prefill|fn, danger, tier, disabled}]. Anchored
+    // near `anchor`. `disabled` renders an inert greyed row — used for
+    // actions that exist but the player can't take yet (harvest rank gates),
+    // so the requirement is visible instead of the action silently missing.
     function openMenu(title, actions, anchor) {
         closeMenu();
         hideTip();
@@ -2775,9 +2918,11 @@
             // the action outright.
             kids.push(el("button", {
                 type: "button",
-                class: "menu-item" + (a.danger ? " danger" : "") + (a.tier ? " tier-" + a.tier : ""),
+                class: "menu-item" + (a.danger ? " danger" : "") + (a.tier ? " tier-" + a.tier : "") + (a.disabled ? " disabled" : ""),
+                disabled: a.disabled ? true : null,
                 text: a.label,
                 onclick: function () {
+                    if (a.disabled) return;
                     if (a.fn) a.fn();
                     else if (a.prefill != null) api.prefill(a.prefill);
                     else if (a.cmd) sendCmd(a.cmd);
@@ -2895,6 +3040,47 @@
         return acts;
     }
 
+    // Actions for a ground object (Room.Contents item). Commands target the
+    // server-computed handle so duplicates ("2.corpse.rat") resolve to the
+    // exact instance; the server re-validates everything.
+    function groundItemActions(it) {
+        var h = groundTarget(it);
+        var acts = [{ label: "Look", cmd: "look " + h }];
+        var isContainer = it.type === "container";
+        var hasContents = !!(it.contents && it.contents.length);
+        if (it.is_corpse) {
+            if (hasContents) acts.push({ label: "Loot all", cmd: "get all from " + h });
+            if (it.harvest) acts.push(harvestAction(it.harvest, h));
+        } else if (isContainer) {
+            if (it.closeable) acts.push(it.closed ? { label: "Open", cmd: "open " + h } : { label: "Close", cmd: "close " + h });
+            if (!it.closed && hasContents) acts.push({ label: "Get all from", cmd: "get all from " + h });
+        }
+        // no_take = scenery ("You can't seem to budge...") — omit dead verbs.
+        if (!it.no_take && !it.is_corpse) acts.push({ label: "Get", cmd: "get " + h });
+        // Sacrifice lives HERE and only here: the command takes a corpse in
+        // the room, never a carried item. Last and danger-styled.
+        if (it.is_corpse) acts.push({ label: "Sacrifice", cmd: "sacrifice " + h, danger: true });
+        return acts;
+    }
+    function harvestAction(hv, target) {
+        var hs = harvestStanding(hv);
+        if (hs.untrained) return { label: "Harvest — untrained", disabled: true };
+        if (!hs.ok) return { label: "Harvest (r" + hs.req + ") — rank too low", disabled: true };
+        return { label: "Harvest (r" + hs.req + ")", cmd: "harvest " + target, tier: hs.tier || undefined };
+    }
+    function groundContentActions(ds) {
+        return [
+            { label: "Get", cmd: "get " + ds.target + " from " + ds.container }
+        ];
+    }
+    function nodeActions(n) {
+        var t = nodeTarget(n);
+        return [
+            { label: "Look", cmd: "look " + t },
+            harvestAction(n, t)
+        ];
+    }
+
     function itemActions(ds) {
         var t = ds.target, name = ds.name || t, otype = ds.otype, kind = ds.kind, container = ds.container;
         var acts = [{ label: "Examine", cmd: "examine " + t }];
@@ -2927,8 +3113,9 @@
                     tier: profTier(ds.disen - (Number(ench.rank) || 0))
                 });
             }
+            // No Sacrifice here: the command only accepts a corpse on the
+            // ground, so it lives on the Room panel's corpse menu instead.
             acts.push({ label: "Drop", cmd: "drop " + t });
-            acts.push({ label: "Sacrifice", cmd: "sacrifice " + t, danger: true });
         }
         return acts;
     }
@@ -3009,6 +3196,7 @@
             saveSet("ishar.itemsExpanded", expanded);
             renderEquipment();
             renderInventory();
+            renderOccupants();   // ground containers expand in the Room panel
             api.onLayoutChange();
             e.preventDefault();
             return;
@@ -3087,6 +3275,15 @@
         } else if (kind === "item") {
             var ds = readDataset(host);
             openMenu(ds.name || ds.target, itemActions(ds), anchor);
+        } else if (kind === "grounditem") {
+            var gi = (S.roomItems || [])[Number(host.getAttribute("data-idx"))];
+            if (gi) openMenu(stripColor(gi.name || ""), groundItemActions(gi), anchor);
+        } else if (kind === "groundcontent") {
+            var gds = readDataset(host);
+            openMenu(gds.name || gds.target, groundContentActions(gds), anchor);
+        } else if (kind === "node") {
+            var nd = (S.roomNodes || [])[Number(host.getAttribute("data-idx"))];
+            if (nd) openMenu(stripColor(nd.name || ""), nodeActions(nd), anchor);
         } else if (kind === "component") {
             var cds = readDataset(host);
             openMenu(cds.name || cds.target, componentActions(cds), anchor);
@@ -3256,6 +3453,7 @@
         S.vitals = null; S.status = null; S.time = null; S.room = null;
         S.equipment = []; S.inventory = null; S.train = null;
         S.affects = null; S.group = null; S.who = null; S.occupants = [];
+        S.roomItems = []; S.roomNodes = [];
         S.skills = []; S.cooldownExpiry = {}; S.cooldownTotal = {}; S.usable = {};
         S.professions = []; S.recipes = []; S.craft = null;
         S.tgtHostile = null; S.tgtFriendly = null;
@@ -3465,6 +3663,25 @@
                 { keyword: "Selra", short_desc: "Selra the Quiet", handle: "1.Selra", is_player: true, is_dead: false, is_shopkeeper: false, hostile_hint: "friendly", position: "Sleeping", is_loyal_follower: false, is_my_follower: false, fighting_you: false, is_your_target: false },
                 { keyword: "wolf", short_desc: "a large timber wolf", handle: "1.wolf", is_player: false, is_dead: false, is_shopkeeper: false, hostile_hint: "friendly", position: "Resting", is_loyal_follower: true, is_my_follower: true, fighting_you: false, is_your_target: false },
                 { keyword: "rat", short_desc: "the corpse of a sewer rat", handle: "1.rat", is_player: false, is_dead: true, is_shopkeeper: false, hostile_hint: "neutral", position: "Dead", is_loyal_follower: false, is_my_follower: false, fighting_you: false, is_your_target: false }
+            ] },
+            "Room.Contents": { items: [
+                { name: "the corpse of a sewer rat", keywords: "corpse rat", handle: "1.corpse.rat", type: "container", vnum: -1, count: 1, is_corpse: true,
+                  harvest: { profession_id: 1, required_rank: 30 },
+                  closeable: false, closed: false, locked: false, contents: [
+                    { name: "a pitted short sword", keywords: "sword short pitted", type: "weapon", vnum: 301, count: 1 },
+                    { name: "a mangy rat pelt", keywords: "pelt rat mangy", type: "other", vnum: 302, count: 2 }
+                ] },
+                { name: "the corpse of an alley thug", keywords: "corpse thug", handle: "1.corpse.thug", type: "container", vnum: -1, count: 1, is_corpse: true,
+                  closeable: false, closed: false, locked: false, contents: [] },
+                { name: "an iron-banded chest", keywords: "chest iron", handle: "1.chest.iron", type: "container", vnum: 310, count: 1, no_take: true,
+                  closeable: true, closed: true, locked: false, contents: [] },
+                { name: "a crumpled traveling cloak", keywords: "cloak traveling crumpled", handle: "1.cloak.traveling.crumpled", type: "armor", vnum: 311, count: 1 },
+                { name: "a glowing potion", keywords: "potion glowing", handle: "1.potion.glowing", type: "potion", vnum: 10, count: 2 },
+                { name: "a marble fountain", keywords: "fountain marble", handle: "1.fountain.marble", type: "drink", vnum: 312, count: 1, no_take: true }
+            ], nodes: [
+                { name: "a vein of glittering ore", keywords: "vein ore", profession_id: 2, required_rank: 16 },
+                { name: "a tangle of silverleaf", keywords: "silverleaf tangle", profession_id: 1, required_rank: 41 },
+                { name: "a seam of rough crystal", keywords: "seam crystal", profession_id: 3, required_rank: 5 }
             ] },
             "Char.Equipment": { items: [
                 { name: "a magnificent helmet of red dragonscales", keywords: "helmet dragonscales", type: "armor", vnum: 1, location: "Head", condition: 100 },

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -1064,7 +1064,11 @@
     }
 
     function renderOccupants() {
-        var occ = S.occupants || [];
+        // Slain occupants stay in the FEED (they hold parser ordinal slots,
+        // #1679) but not in the PANEL: the corpse object in Room.Contents is
+        // the single representation of a body — two rows for one corpse was
+        // the panel's most confusing moment (post-kill).
+        var occ = (S.occupants || []).filter(function (o) { return !o.is_dead; });
         var items = S.roomItems || [];
         var nodes = S.roomNodes || [];
         var hasShop = occ.some(function (o) { return o.is_shopkeeper; });
@@ -1086,19 +1090,22 @@
                     kids.push(el("div", { class: "tgt-chips" }, chips));
                 }
                 var list = el("ul", { class: "occ-list" });
-                occ.forEach(function (o, i) {
+                // Iterate the UNFILTERED list: data-idx must index S.occupants
+                // (openHostMenu reads it back); dead entries just skip.
+                (S.occupants || []).forEach(function (o, i) {
+                    if (o.is_dead) return;
                     var marks = "";
                     if (S.tgtHostile && S.tgtHostile.handle === o.handle) marks += " ⚔";
                     if (S.tgtFriendly && S.tgtFriendly.handle === o.handle) marks += " ✚";
                     // Position tag for anyone not simply standing (the same
                     // cue the room text gives: "is sleeping here").
-                    var ptag = (!o.is_dead && o.position && posLower(o) !== "standing")
+                    var ptag = (o.position && posLower(o) !== "standing")
                         ? posLower(o) : "";
-                    var fight = o.is_dead ? "" : occFightLabel(o);
+                    var fight = occFightLabel(o);
                     var row = el("li", {
-                        class: "occ-row " + occHostileClass(o) + (o.is_dead ? " is-dead" : ""),
+                        class: "occ-row " + occHostileClass(o),
                         "data-menu": "occupant", "data-idx": i,
-                        title: o.is_dead ? "Slain — not targetable" : "Tap for actions"
+                        title: "Tap for actions"
                     }, [
                         el("span", { class: "occ-icon", "aria-hidden": "true", text: o.is_player ? "☻" : "•" }),
                         el("span", { class: "occ-name", text: stripColor(o.short_desc || o.keyword) }),
@@ -1139,14 +1146,18 @@
         if (!hv.profession_id) return { ok: true, tier: null, req: req };
         var prof = professionById(hv.profession_id);
         if (!prof) return { ok: false, tier: "blocked", untrained: true, req: req };
-        var tier = profTier(req - (Number(prof.rank) || 0));
-        return { ok: tier !== "blocked", tier: tier, prof: prof, req: req };
+        var rank = Number(prof.rank) || 0;
+        var tier = profTier(req - rank);
+        // rank 0 = held but never practiced: harvest_rank_allows hard-fails
+        // rank <= 0 server-side regardless of the delta.
+        return { ok: rank > 0 && tier !== "blocked", tier: tier, prof: prof, req: req };
     }
     function harvestChip(hv) {
         var hs = harvestStanding(hv);
-        var title = hs.untrained ? "Harvestable — you lack the profession"
-            : hs.ok ? "Harvestable — requires rank " + hs.req + (hs.prof ? " " + hs.prof.name : "")
-            : "Harvestable — rank " + hs.req + " needed (yours: " + (hs.prof ? hs.prof.rank : 0) + ")";
+        var profName = hs.prof ? hs.prof.name : (hv.profession || "");
+        var title = hs.untrained ? "Harvestable — requires " + (profName || "a profession you lack")
+            : hs.ok ? "Harvestable — requires rank " + hs.req + (profName ? " " + profName : "")
+            : "Harvestable — " + (profName ? profName + " " : "") + "rank " + hs.req + " needed (yours: " + (hs.prof ? hs.prof.rank : 0) + ")";
         return el("span", {
             class: "tag harvest tier-" + (hs.tier || "open"),
             title: title, text: "⛏ r" + hs.req
@@ -1169,7 +1180,12 @@
             var isContainer = it.type === "container";
             var hasContents = !!(it.contents && it.contents.length);
             var open = isContainer && !it.closed;
-            var ekey = "g" + groundTarget(it);
+            // Expand-state key WITHOUT the handle's ordinal: "2.corpse.rat"
+            // becomes "1.corpse.rat" when an earlier duplicate goes away, and
+            // an ordinal-bearing key would silently drop the expansion (and
+            // accrete stale variants in localStorage). Same-keyword duplicates
+            // sharing one expand state is the lesser wart.
+            var ekey = "g" + targetOf(it.keywords || it.name);
             var canExpand = open && hasContents;
             var isOpen = canExpand && !!expanded[ekey];
             var kids = [];
@@ -2923,10 +2939,13 @@
                 text: a.label,
                 onclick: function () {
                     if (a.disabled) return;
+                    // Close BEFORE running the action: an fn may open its own
+                    // surface (icon picker, a confirm submenu) and a
+                    // close-after would immediately dismiss it.
+                    closeMenu();
                     if (a.fn) a.fn();
                     else if (a.prefill != null) api.prefill(a.prefill);
                     else if (a.cmd) sendCmd(a.cmd);
-                    closeMenu();
                     // `keep`: informational rows shouldn't throw away the
                     // phone sheet the menu was opened from.
                     if (!a.keep && sheetName && mqMobile.matches) setSheet(null);
@@ -3043,7 +3062,7 @@
     // Actions for a ground object (Room.Contents item). Commands target the
     // server-computed handle so duplicates ("2.corpse.rat") resolve to the
     // exact instance; the server re-validates everything.
-    function groundItemActions(it) {
+    function groundItemActions(it, anchor) {
         var h = groundTarget(it);
         var acts = [{ label: "Look", cmd: "look " + h }];
         var isContainer = it.type === "container";
@@ -3052,19 +3071,39 @@
             if (hasContents) acts.push({ label: "Loot all", cmd: "get all from " + h });
             if (it.harvest) acts.push(harvestAction(it.harvest, h));
         } else if (isContainer) {
-            if (it.closeable) acts.push(it.closed ? { label: "Open", cmd: "open " + h } : { label: "Close", cmd: "close " + h });
+            if (it.locked) {
+                // Honest verb: the game refuses Open on a locked container,
+                // so surface the state instead of a dead action.
+                acts.push({ label: "Locked", disabled: true });
+            } else if (it.closeable) {
+                acts.push(it.closed ? { label: "Open", cmd: "open " + h } : { label: "Close", cmd: "close " + h });
+            }
             if (!it.closed && hasContents) acts.push({ label: "Get all from", cmd: "get all from " + h });
         }
         // no_take = scenery ("You can't seem to budge...") — omit dead verbs.
         if (!it.no_take && !it.is_corpse) acts.push({ label: "Get", cmd: "get " + h });
-        // Sacrifice lives HERE and only here: the command takes a corpse in
-        // the room, never a carried item. Last and danger-styled.
-        if (it.is_corpse) acts.push({ label: "Sacrifice", cmd: "sacrifice " + h, danger: true });
+        if (it.is_corpse) {
+            // Sacrifice lives HERE and only here (the command takes a corpse
+            // on the ground, never a carried item) — last, danger-styled, and
+            // behind a confirm: it destroys the corpse AND any unlooted
+            // contents, and a thumb-slip on a 44px row is one tap away.
+            acts.push({
+                label: "Sacrifice…", danger: true, keep: true,
+                fn: function () {
+                    openMenu("Sacrifice " + stripColor(it.name || "corpse") + "?", [
+                        { label: "Confirm — destroys it" + (hasContents ? " and its contents" : ""), cmd: "sacrifice " + h, danger: true },
+                        { label: "Cancel", fn: function () {} }
+                    ], anchor);
+                }
+            });
+        }
         return acts;
     }
     function harvestAction(hv, target) {
         var hs = harvestStanding(hv);
-        if (hs.untrained) return { label: "Harvest — untrained", disabled: true };
+        if (hs.untrained) {
+            return { label: "Harvest — requires " + (hv.profession || "training"), disabled: true };
+        }
         if (!hs.ok) return { label: "Harvest (r" + hs.req + ") — rank too low", disabled: true };
         return { label: "Harvest (r" + hs.req + ")", cmd: "harvest " + target, tier: hs.tier || undefined };
     }
@@ -3277,7 +3316,7 @@
             openMenu(ds.name || ds.target, itemActions(ds), anchor);
         } else if (kind === "grounditem") {
             var gi = (S.roomItems || [])[Number(host.getAttribute("data-idx"))];
-            if (gi) openMenu(stripColor(gi.name || ""), groundItemActions(gi), anchor);
+            if (gi) openMenu(stripColor(gi.name || ""), groundItemActions(gi, anchor), anchor);
         } else if (kind === "groundcontent") {
             var gds = readDataset(host);
             openMenu(gds.name || gds.target, groundContentActions(gds), anchor);
@@ -3666,7 +3705,7 @@
             ] },
             "Room.Contents": { items: [
                 { name: "the corpse of a sewer rat", keywords: "corpse rat", handle: "1.corpse.rat", type: "container", vnum: -1, count: 1, is_corpse: true,
-                  harvest: { profession_id: 1, required_rank: 30 },
+                  harvest: { profession_id: 1, profession: "Alchemy", required_rank: 30 },
                   closeable: false, closed: false, locked: false, contents: [
                     { name: "a pitted short sword", keywords: "sword short pitted", type: "weapon", vnum: 301, count: 1 },
                     { name: "a mangy rat pelt", keywords: "pelt rat mangy", type: "other", vnum: 302, count: 2 }
@@ -3679,9 +3718,9 @@
                 { name: "a glowing potion", keywords: "potion glowing", handle: "1.potion.glowing", type: "potion", vnum: 10, count: 2 },
                 { name: "a marble fountain", keywords: "fountain marble", handle: "1.fountain.marble", type: "drink", vnum: 312, count: 1, no_take: true }
             ], nodes: [
-                { name: "a vein of glittering ore", keywords: "vein ore", profession_id: 2, required_rank: 16 },
-                { name: "a tangle of silverleaf", keywords: "silverleaf tangle", profession_id: 1, required_rank: 41 },
-                { name: "a seam of rough crystal", keywords: "seam crystal", profession_id: 3, required_rank: 5 }
+                { name: "a vein of glittering ore", keywords: "vein ore", profession_id: 2, profession: "Enchanting", required_rank: 16 },
+                { name: "a tangle of silverleaf", keywords: "silverleaf tangle", profession_id: 1, profession: "Alchemy", required_rank: 41 },
+                { name: "a seam of rough crystal", keywords: "seam crystal", profession_id: 3, profession: "Artificing", required_rank: 5 }
             ] },
             "Char.Equipment": { items: [
                 { name: "a magnificent helmet of red dragonscales", keywords: "helmet dragonscales", type: "armor", vnum: 1, location: "Head", condition: 100 },

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1265,11 +1265,12 @@ inventory row language (`.item-row`, `row-name`, `×N` tags, `⋯` menu, the
 - **Corpses** lead with a red `☠`, show a tier-colored `⛏ rN` chip when
   harvestable, and fold their loot behind the standard caret (a dim "N inside"
   count keeps it glanceable). Menu: Look · Loot all · Harvest (rank-gated) ·
-  Sacrifice (danger-styled, dead last, and behind a **confirm submenu** — it
-  destroys the corpse and its unlooted contents, and danger styling alone is
-  no guard against a thumb-slip on a 44px row). Menus opened *from* a menu
-  item's `fn` now work generally: the parent closes before the action runs
-  (this also fixes the latent icon-picker-from-menu ordering bug).
+  Sacrifice (danger-styled, dead last; deliberately **no confirm** — the game
+  offers none, and sacrificing spills a corpse's contents onto the ground
+  rather than destroying them, so a mis-tap costs only the body). Menus
+  opened *from* a menu item's `fn` now work generally: the parent closes
+  before the action runs (this fixes the latent icon-picker-from-menu
+  ordering bug and enables future confirm flows should one ever be needed).
 - **Ground containers** must be **opened before contents show** — the feed
   itself only carries open-container contents (what `look in` reveals), so the
   panel can't leak traps or closed contents by construction. Open-container

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1265,7 +1265,11 @@ inventory row language (`.item-row`, `row-name`, `×N` tags, `⋯` menu, the
 - **Corpses** lead with a red `☠`, show a tier-colored `⛏ rN` chip when
   harvestable, and fold their loot behind the standard caret (a dim "N inside"
   count keeps it glanceable). Menu: Look · Loot all · Harvest (rank-gated) ·
-  Sacrifice (danger-styled, dead last — never adjacent to the loot actions).
+  Sacrifice (danger-styled, dead last, and behind a **confirm submenu** — it
+  destroys the corpse and its unlooted contents, and danger styling alone is
+  no guard against a thumb-slip on a 44px row). Menus opened *from* a menu
+  item's `fn` now work generally: the parent closes before the action runs
+  (this also fixes the latent icon-picker-from-menu ordering bug).
 - **Ground containers** must be **opened before contents show** — the feed
   itself only carries open-container contents (what `look in` reveals), so the
   panel can't leak traps or closed contents by construction. Open-container
@@ -1279,7 +1283,14 @@ inventory row language (`.item-row`, `row-name`, `×N` tags, `⋯` menu, the
   meet renders as a visible requirement ("Harvest (r41) — rank too low")
   instead of silently missing — the menu teaches.
 - **Verb map fixes:** `tome → Use` (learn), `deck → Draw`; **Sacrifice removed
-  from carried-item menus** — it lives only on ground corpses.
+  from carried-item menus** — it lives only on ground corpses (and the game
+  command itself was re-scoped to room-only resolution, ishar-mud#1827, so a
+  handle tap can never resolve to a carried corpse). A locked ground
+  container shows an inert "Locked" row instead of a dead Open action.
+- **One body, one row:** slain occupants stay in the Room.Occupants feed
+  (they hold parser ordinal slots) but are no longer rendered — the ground
+  corpse row is the single representation of a body, so the post-kill moment
+  shows one actionable row instead of a dead person row + a corpse row.
 
 **Data.** New per-viewer GMCP feed `Room.Contents` (ishar-mud#1827,
 contract 11.5.0): items with server-computed `"N.dotted.keywords"` handles

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1246,3 +1246,51 @@ rather than adding one-off symbols to the game-icons subset.
 token, motion gated behind `prefers-reduced-motion`, and the icon sits inside
 the existing bar's row (no new tap target). Verify with `/connect?demo=1`
 (the demo feed now carries `food`/`water` so both a low and a crit state show).
+
+## 2026-07-17 — Room panel carries the ground: items, corpses, harvest nodes
+
+**Context.** The Room (occupants) panel listed only persons. Everything else a
+player interacts with in a room — the corpse they just made, dropped items,
+ground containers, harvest nodes — was invisible to the HUD, and the item
+menus over-offered verbs: **Sacrifice on every carried item** (the command only
+accepts a corpse on the ground, so it could never succeed), no verb for tomes
+(`use` learns them) or decks (`draw`).
+
+**Decision.** The Room panel is the room's **whole interaction surface**: the
+persons list, then **On the ground** (Room.Contents items), then **Nodes** —
+one panel, one mental model, nearest the input. Ground rows reuse the
+inventory row language (`.item-row`, `row-name`, `×N` tags, `⋯` menu, the
+`row-caret` expand pattern) rather than inventing a parallel one:
+
+- **Corpses** lead with a red `☠`, show a tier-colored `⛏ rN` chip when
+  harvestable, and fold their loot behind the standard caret (a dim "N inside"
+  count keeps it glanceable). Menu: Look · Loot all · Harvest (rank-gated) ·
+  Sacrifice (danger-styled, dead last — never adjacent to the loot actions).
+- **Ground containers** must be **opened before contents show** — the feed
+  itself only carries open-container contents (what `look in` reveals), so the
+  panel can't leak traps or closed contents by construction. Open-container
+  loot rows are tap-to-take (`get X from <handle>`), the corpse-looting hot
+  path on phones.
+- **Nodes** lead with an accent `✦` and the same `⛏ rN` chip; Harvest is
+  **enabled/disabled by a client-side join** against `Char.Professions`
+  (has the profession + `rank + 5 ≥ required`, mirroring the game's
+  `harvest_rank_allows`), tier-colored with the standard `.tier-*` buckets.
+- **Menu rows can now be `disabled`** (inert, dim, no hover): a gate you don't
+  meet renders as a visible requirement ("Harvest (r41) — rank too low")
+  instead of silently missing — the menu teaches.
+- **Verb map fixes:** `tome → Use` (learn), `deck → Draw`; **Sacrifice removed
+  from carried-item menus** — it lives only on ground corpses.
+
+**Data.** New per-viewer GMCP feed `Room.Contents` (ishar-mud#1827,
+contract 11.5.0): items with server-computed `"N.dotted.keywords"` handles
+(exact-instance targeting for duplicate corpses), `no_take` scenery flag,
+corpse `harvest` standing, and the active node list with `required_rank`
+(exactly what `look` reveals — nothing more). Targeting rule: objects use the
+handle; **nodes use a single bare keyword token** (the game matches node
+keywords exactly, not via the object parser).
+
+**Notes.** Row count in the header becomes persons+items+nodes ("Room (18)").
+Empty state is "Nothing else here." only when all three lists are empty.
+Discipline unchanged: `el()`/`textContent`, tokens only, no new tap-target
+patterns. Verify with the demo feed (corpse with loot, locked chest, scenery
+fountain, three nodes across the tier spread).


### PR DESCRIPTION
The Room (occupants) panel now displays the complete interaction surface of a room: persons, ground items (corpses, drops, containers), and harvest nodes. This consolidates what was previously scattered across invisible ground state and over-offered item menus.

## Changes

**Data & State**
- Added `Room.Contents` GMCP feed support: `roomItems` and `roomNodes` state arrays, populated by a new message handler
- Ground items carry server-computed handles (for exact-instance targeting of duplicates), `no_take` scenery flag, corpse harvest standing, and nested contents
- Harvest nodes include `required_rank` and profession gating

**Room Panel Rendering**
- Slain occupants no longer render in the panel (they stay in the feed for parser ordinals, but the ground corpse is the single body representation)
- Added "On the ground" section with expandable containers (reusing `.item-row` + `.row-caret` patterns from inventory)
- Added "Nodes" section with tier-colored harvest chips
- Room header count now includes items + nodes: "Room (18)"
- Empty state changed to "Nothing else here." when all three lists are empty

**Ground Item Actions**
- Corpses: Look · Loot all · Harvest (rank-gated) · Sacrifice (danger-styled, no confirm)
- Containers: Look · Open/Close · Get all from (if open and has contents)
- Regular items: Look · Get
- Locked containers show an inert "Locked" row instead of a dead Open action
- Corpse loot rows are tap-to-take (`get X from <handle>`) — the hot path on phones

**Harvest Gating**
- Client-side eligibility join against `Char.Professions`: must hold the profession and `rank + 5 ≥ required`
- Disabled menu rows now render visibly with the requirement ("Harvest (r41) — rank too low") instead of silently missing
- Nodes use a single bare keyword token for targeting (not the object parser)

**Verb Map Fixes**
- Added `tome → Use` (learn recipe/skill) and `deck → Draw` (pull card from Fateweaver's Deck)
- Removed Sacrifice from carried-item menus (the command only accepts ground corpses; game-side re-scoped to room-only resolution)

**Menu Infrastructure**
- Menu actions now support `disabled` flag (inert, dim, no hover)
- Menu close moved before action execution (fixes latent icon-picker-from-menu ordering; enables future confirm flows)

**Styling**
- Ground icons: `☠` (corpse, red), `✦` (node, accent)
- Harvest chip: `⛏ rN` with tier-colored text (`.tier-open`, `.tier-*`)
- Reused inventory row language (`.item-row`, `row-name`, `×N` tags, `⋯` menu, `.row-caret`)

## Notes

Verify with the demo feed: corpse with loot, locked chest, scenery fountain, three nodes across the tier spread. Discipline unchanged: `el()`/`textContent`, tokens only, no new tap-target patterns.

https://claude.ai/code/session_01RLGGQJqMVS2PWdBz4t3ydT