### PR TITLE
HUD map: visible "Zones ▾" cross-zone picker

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -429,6 +429,8 @@ body.connect-page #content { padding: .5rem !important; }
 .map-zone.offzone::after {
     content: " · viewing"; color: var(--ac-dim); font-weight: 400;
 }
+/* The zone picker is the signposted way across a border — tint it accent. */
+.map-zones { color: var(--ac-accent); }
 .map-z { display: inline-flex; gap: 2px; }
 .map-search {
     flex: 1 1 8rem; min-width: 6rem; max-width: 14rem; font-size: 16px;

--- a/apps/connect/static/js/hud-map.js
+++ b/apps/connect/static/js/hud-map.js
@@ -889,6 +889,15 @@
         var wrap = H.el("div", { class: "map-big" }, [canvas, anchor]);
 
         var zoneLabel = H.el("span", { class: "map-zone", text: "" });
+        // Cross-zone picker: the discoverable home for "look at / walk to
+        // another zone" (the per-room border menu is the shortcut, not the
+        // signpost). Lists the neighbors reachable from explored borders.
+        var btnZones = H.el("button", {
+            type: "button", class: "map-btn map-zones", text: "Zones ▾",
+            title: "View or jump to an adjacent zone",
+            "aria-label": "View or jump to an adjacent zone",
+            onclick: function () { openZoneJump(btnZones); }
+        });
         var zRow = H.el("span", { class: "map-z" });
         var search = H.el("input", {
             class: "map-search", type: "search", placeholder: "Find room…",
@@ -905,13 +914,13 @@
             title: "Center on me", "aria-label": "Center on my room",
             onclick: function () { bigView.follow = true; centerOnMe(); redraw(); } });
         var toolbar = H.el("div", { class: "map-toolbar" },
-            [zoneLabel, zRow, search, count, btnOut, btnIn, btnMe]);
+            [zoneLabel, btnZones, zRow, search, count, btnOut, btnIn, btnMe]);
         var foot = H.el("div", { class: "map-foot" });
         foot.hidden = true;
         var root = H.el("div", { class: "map-app" }, [toolbar, wrap, foot]);
         big = { root: root, canvas: canvas, wrap: wrap, zoneLabel: zoneLabel,
                 zRow: zRow, search: search, count: count, anchor: anchor,
-                foot: foot, btnMe: btnMe };
+                foot: foot, btnMe: btnMe, btnZones: btnZones };
 
         // --- search: filter discovered rooms, Enter cycles + centers ---
         search.addEventListener("input", function () {
@@ -1102,6 +1111,51 @@
         updateZoneLabel(); updateZRow(); updateSearchCount(); updateMeButton();
         redrawBig();
     }
+    // Toolbar "Zones ▾" menu: every neighbor reachable from an explored
+    // border of the viewed zone, plus a "back to my location" when off-zone.
+    function openZoneJump(anchor) {
+        var zid = viewedZone();
+        if (zid == null || !zones[zid]) return;
+        var zone = zones[zid], fs = fogSet(zid);
+        var acts = [];
+        if (cur.zone != null && zid !== cur.zone) {
+            acts.push({
+                label: "◎ Back to my location",
+                fn: function () { bigView.follow = true; centerOnMe(); redraw(); }
+            });
+        }
+        // One entry per adjacent zone, keyed off discovered border rooms so
+        // we only surface crossings the player has actually found.
+        var byZone = {};
+        zone.graph.rooms.forEach(function (r) {
+            if (!fs[r.v]) return;
+            (zone.layout.outFrom[r.v] || []).forEach(function (o) {
+                if (!byZone[o.zone]) byZone[o.zone] = o;
+            });
+        });
+        var keys = Object.keys(byZone);
+        keys.sort(function (a, b) {
+            var na = byZone[a].zname || "", nb = byZone[b].zname || "";
+            return na < nb ? -1 : na > nb ? 1 : 0;
+        });
+        keys.forEach(function (k) {
+            var o = byZone[k];
+            acts.push({
+                label: "Go to " + (o.zname || "zone " + o.zone) + " →",
+                fn: (function (oo) {
+                    return function () { goToZone(oo.zone, oo.t, oo.zname); };
+                })(o)
+            });
+        });
+        if (!keys.length) {
+            acts.push({
+                label: "Walk to a zone border to unlock jumps",
+                fn: function () {}, keep: true
+            });
+        }
+        H.openMenu("Jump to zone", acts, anchor);
+    }
+
     // Menu action: jump the map to an adjacent zone, loading it if needed.
     function goToZone(zoneId, vnum, zname) {
         if (zones[zoneId]) { focusZone(zoneId, vnum); return; }
@@ -1761,6 +1815,7 @@
             shownPath: function () { return shownPath; },
             viewedZone: viewedZone,
             focusZone: focusZone,
+            openZoneJump: openZoneJump,
             walking: function () { return !!walk; }
         }
     };

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -520,11 +520,14 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   `.map-search` + `.map-count`, `.map-btn` zoom −/+/◎) over `.map-big`
   (pan/pinch/wheel canvas, `touch-action:none`) over `.map-foot` (show-path
   step list / walking progress). **Cross-zone:** the big map can view an
-  adjacent zone without moving the player — a border room's menu offers
-  "Go to &lt;zone&gt; →", `.map-zone.offzone` appends a "· viewing" cue, and
-  ◎ (`.map-btn.active`) becomes "return to my location"; pathfinding and
-  autowalk route across zone borders (the minimap always stays on the
-  player's zone). `.map-note-pop` is the room-note editor
+  adjacent zone without moving the player — the toolbar's **`.map-zones`
+  "Zones ▾"** button (accent-tinted, beside the zone name) is the signpost:
+  it lists every neighbor reachable from an explored border, plus "◎ Back
+  to my location" when off-zone (a border room's own menu keeps the same
+  "Go to &lt;zone&gt; →" as a shortcut). `.map-zone.offzone` appends a
+  "· viewing" cue and ◎ (`.map-btn.active`) becomes "return to my
+  location"; pathfinding and autowalk route across zone borders (the
+  minimap always stays on the player's zone). `.map-note-pop` is the room-note editor
   (Save/Delete/Close, 2000-char cap); the current room's note renders as
   the `.rose-note` clamped line in the Room panel. `.map-walk` is the
   autowalk cancel chip above the action row — the whole chip cancels


### PR DESCRIPTION
## What & why

Follow-up to the cross-zone mapper (#128, merged). That change let you view and route into adjacent zones, but the only entry point was a *discovered border room*'s tap menu — undiscoverable unless you knew which room was a border and thought to open its menu.

This adds a signposted control. The big-map toolbar gains a **"Zones ▾"** button (accent-tinted, beside the zone name) that opens a menu of every adjacent zone reachable from an explored border of the viewed zone, plus **"◎ Back to my location"** when you're viewing a neighbor. The per-room "Go to &lt;zone&gt; →" entry stays as the shortcut. When no borders are explored yet the menu says *"Walk to a zone border to unlock jumps"* so the control never dead-ends.

## Changes

- `apps/connect/static/js/hud-map.js` — `openZoneJump()` builds the neighbor list from discovered border rooms (deduped by destination zone, sorted by name) and reuses the existing `H.openMenu` component; new `.map-zones` toolbar button wired to it.
- `apps/connect/static/css/hud.css` — `.map-zones` accent tint so the picker reads as the zone control.
- `docs/design/components.md` — map entry now names the "Zones ▾" picker as the primary cross-zone affordance.

## Verification

Verified headlessly with the preinstalled Chromium via the module's debug seams:

- Picker contents on your own zone (lists the neighbor, no "Back" entry) vs. while viewing a neighbor (adds "◎ Back to my location" + the return crossing).
- Toolbar renders the button next to the zone name.
- Existing cross-zone pathfinding / shown-path regression suite still green (19/19).

Not provable here (owner's on-prod test): the live GMCP round-trip.

Relates to #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CW1sQpozWWLsKaeKa9dgdF)_