### PR TITLE
HUD map: fix the "Zones ▾" picker not opening

### DIFF
--- a/apps/connect/static/js/hud-map.js
+++ b/apps/connect/static/js/hud-map.js
@@ -892,8 +892,12 @@
         // Cross-zone picker: the discoverable home for "look at / walk to
         // another zone" (the per-room border menu is the shortcut, not the
         // signpost). Lists the neighbors reachable from explored borders.
+        // `menu-opener`: the toolbar button opens a menu, so it must be
+        // exempt from hud.js's document outside-click dismissal — otherwise
+        // the same click that opens the picker bubbles up and closes it
+        // (the map canvas carries this class for exactly this reason).
         var btnZones = H.el("button", {
-            type: "button", class: "map-btn map-zones", text: "Zones ▾",
+            type: "button", class: "map-btn map-zones menu-opener", text: "Zones ▾",
             title: "View or jump to an adjacent zone",
             "aria-label": "View or jump to an adjacent zone",
             onclick: function () { openZoneJump(btnZones); }


### PR DESCRIPTION
## Bug

The cross-zone picker (#130) added a **"Zones ▾"** toolbar button, but tapping it did nothing — the menu opened and instantly closed.

**Cause:** the button opens its menu via `H.openMenu`, but the same click bubbles to hud.js's document-level outside-click handler, which dismisses any open menu unless the click target matches `[data-menu]`, `.row-more`, or `.menu-opener`. The map canvas already carries `.menu-opener` for exactly this reason; the new toolbar button was missing it, so the opening click closed the picker it had just opened.

**Fix:** add `menu-opener` to the button's class (one line).

## Verification

Reproduced and fixed against the **real `hud.js`** in a faithful DOM harness (headless Chromium), driving actual click events:

- **Before:** clicking "Zones ▾" left `#hud-menu` hidden with no children.
- **After:** it stays open and lists the neighbor ("Go to Kingdom of Jolnara →").
- Confirmed on **desktop (1200px)** and **mobile (390px)** viewports.

While there, I also verified in the same harness that the **abilities icon selector is not broken** — it opens correctly via the ability row's ⋯ ("More actions") menu → "Choose icon…" (and via long-press / right-click on a hotbar slot, a `contextmenu` path that never hits the click-dismiss handler). That icon grid rendered on both viewports. If it's still misbehaving for you on the live build, the exact tap sequence would help me repro — see the PR discussion.

Relates to #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CW1sQpozWWLsKaeKa9dgdF)_