### PR TITLE
Operate survey lifecycle from the surveys page and link the admin builder

### DIFF
--- a/apps/surveys/templates/surveys.html
+++ b/apps/surveys/templates/surveys.html
@@ -52,6 +52,17 @@
 {% if user.is_eternal %}
                 <a class="ac-btn ac-btn--info" href="{% url 'survey_results' survey.slug %}#results">Results</a>
 {% endif %}
+{% if user.is_god %}
+{% if survey.status == "open" %}
+                <button class="ac-btn ac-btn--warn sv-state" data-slug="{{ survey.slug }}" data-status="closed"
+                        title="Stop accepting responses">Close</button>
+{% else %}
+                <button class="ac-btn ac-btn--ok sv-state" data-slug="{{ survey.slug }}" data-status="open"
+                        title="Start accepting responses">{% if survey.status == "closed" %}Reopen{% else %}Open{% endif %}</button>
+{% endif %}
+                <a class="ac-btn" href="{{ survey.get_admin_url }}" target="_blank"
+                   title="Edit questions in Administration">{% bi "pencil-square" label="Edit in Administration" %}</a>
+{% endif %}
             </div>
         </div>
 {% endfor %}
@@ -63,5 +74,38 @@
     </div>
 {% endif %}
 
+{% if user.is_forger %}
+    <div class="mt-2">
+        <a class="ac-btn ac-btn--accent" href="{% url 'admin:surveys_survey_add' %}" target="_blank">
+            {% bi "plus-lg" %} New survey {% bi "box-arrow-up-right" label="Opens in Administration, in a new window." %}
+        </a>
+    </div>
+{% endif %}
+
 </div>
+
+{% if user.is_god %}
+<script>
+    // Lifecycle flip (draft/open/closed) straight from the list; the reload
+    // refreshes pills, buttons, and the awaiting-answers counts together.
+    async function surveyState(button) {
+        button.disabled = true
+        const resp = await fetch(`/surveys/${button.dataset.slug}/state/`, {
+            method: "POST",
+            headers: {"X-CSRFToken": "{{ csrf_token }}"},
+            body: new URLSearchParams({status: button.dataset.status}),
+        })
+        const data = await resp.json().catch(() => ({ok: false}))
+        if (data.ok) {
+            location.reload()
+        } else {
+            button.disabled = false
+            alert(data.message || "The change failed.")
+        }
+    }
+    document.querySelectorAll(".sv-state").forEach((el) => {
+        el.addEventListener("click", () => surveyState(el))
+    })
+</script>
+{% endif %}
 {% endblock content %}

--- a/apps/surveys/urls.py
+++ b/apps/surveys/urls.py
@@ -4,6 +4,7 @@ from .views import (
     SurveyListView,
     SurveyResultsCSVView,
     SurveyResultsView,
+    SurveyStateView,
     SurveySubmissionView,
     SurveySubmitView,
     SurveyView,
@@ -14,6 +15,7 @@ urlpatterns = [
     path("", SurveyListView.as_view(), name="surveys"),
     path("<slug:slug>/", SurveyView.as_view(), name="survey"),
     path("<slug:slug>/submit/", SurveySubmitView.as_view(), name="survey_submit"),
+    path("<slug:slug>/state/", SurveyStateView.as_view(), name="survey_state"),
     path("<slug:slug>/results/", SurveyResultsView.as_view(), name="survey_results"),
     path(
         "<slug:slug>/results/export/",

--- a/apps/surveys/views/__init__.py
+++ b/apps/surveys/views/__init__.py
@@ -1,4 +1,5 @@
 from .list import SurveyListView
+from .state import SurveyStateView
 from .take import SurveySubmitView, SurveyView
 from .results import (
     SurveyResultsCSVView,

--- a/apps/surveys/views/state.py
+++ b/apps/surveys/views/state.py
@@ -1,0 +1,36 @@
+from django.http import Http404, JsonResponse
+from django.utils import timezone
+from django.views.generic.base import View
+
+from apps.core.views.mixins import GodRequiredMixin, NeverCacheMixin
+
+from ..models import Survey, SurveyState
+
+
+class SurveyStateView(GodRequiredMixin, NeverCacheMixin, View):
+    """Lifecycle flip from the surveys page: POST { status: draft|open|closed }."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            survey = Survey.objects.get(slug=kwargs["slug"])
+        except Survey.DoesNotExist:
+            raise Http404
+        status = request.POST.get("status")
+        if status not in SurveyState.values:
+            return JsonResponse(
+                {"ok": False, "message": "Unknown status."}, status=400,
+            )
+        survey.status = status
+        # Reopening past a stale window would stay effectively closed —
+        # an explicit Open clears an already-elapsed closes_at.
+        if (status == SurveyState.OPEN and survey.closes_at
+                and survey.closes_at <= timezone.now()):
+            survey.closes_at = None
+        survey.save()
+        return JsonResponse({
+            "ok": True,
+            "state_label": survey.state_label,
+            "state_pill": survey.state_pill,
+        })

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -41,6 +41,12 @@ scores), `.ac-table` (matrix grids), `.ac-quote` (free text).
 **Notes.** `{% crumb %}` gained a prebuilt-`url` param for routes needing
 arguments. The nav/portal "Surveys" pill (`SURVEYS_OPEN`) counts accepting
 surveys the account hasn't answered, mirroring `PATCH_NOTES_UNREAD`.
+Lifecycle is driven from the site, not only the admin: the surveys list gives
+Gods Open/Close/Reopen buttons (POST + `JsonResponse`, the action-view
+convention) plus edit/new links into the admin builder — Django admin is where
+structure is *authored*, the site page is where a survey is *operated*
+(consistent with the deploy/season console split). An explicit Open clears an
+already-elapsed `closes_at` so "Reopen" never lands in a still-closed window.
 
 ## 2026-07-17 — HUD map fast-follow: cross-zone viewing + navigation
 


### PR DESCRIPTION
Closes #134

### Problem

The survey engine from #133 has no visible way to operate a survey: the Draft/Open/Closed switch lives only inside Django admin (Administration → Survey), and nothing on the site points there. First real use hit this — the seeded Fated survey was visible on the player side with no discoverable mechanism to turn it on or edit it. For a staff crew that drives everything from phones, a control that requires knowing a Django admin path is effectively hidden.

### Solution

Apply the repo's deploy/season console split — structure is *authored* in admin, but a survey is *operated* on the site. The surveys list now gives Gods contextual lifecycle buttons per survey (Draft → **Open**, Open → **Close**, Closed → **Reopen**) backed by a new God-gated POST + `JsonResponse` action view (`SurveyStateView`, 404 for everyone else per the site convention). The one non-obvious rule: an explicit Open clears an already-elapsed `closes_at`, because "Reopen" that lands inside a still-closed schedule window would silently stay closed — the confusing state the button exists to prevent.

Discoverability of the builder rides along: each row gets an edit link to that survey's admin change page, and Forgers+ get a "New survey" link to the admin add form, so the authoring path is reachable from the page staff are already on. On success the page reloads rather than patching the DOM — pills, button labels, and the awaiting-answers counts all shift together, and the list is cheap. Decision logged in `docs/design/decisions.md`.

### Verification

On the sqlite fixture environment (live MariaDB not reachable from this environment):

- 12 endpoint checks: anonymous / mortal / Eternal-non-God all 404 the state endpoint; God flips persist to the DB; elapsed `closes_at` cleared on Open; unknown status → 400; GET → 405.
- Playwright real-browser click-through at 390px: Open → Close → Reopen with the pill and button relabeling verified after each reload, no JS errors, no horizontal overflow.
- `py_compile`, `manage.py check`, and the full prior survey e2e suite still pass.

Left to on-prod test: one flip of the Fated survey on the live DB. Phone-width screenshots were reviewed in the working session (staff list showing OPEN pill + Results/Close/edit buttons and the New survey entry point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G1MwiF7eVWsMD4jL9uLJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015G1MwiF7eVWsMD4jL9uLJZ)_