### PR TITLE
HUD map: all-explored-zones picker, death marker, and group-mate markers

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -27,6 +27,7 @@
     --hud-moon: #9aa6c8;
     --hud-hostile: var(--ac-danger);
     --hud-friendly: var(--ac-ok);
+    --hud-group: #3fb6a8;
     --hud-dock-h: 3.5rem;
     /* Map terrain fills (hud-map.js reads these once via getComputedStyle —
        canvas needs literals). Muted and desaturated on purpose: the map is
@@ -431,6 +432,9 @@ body.connect-page #content { padding: .5rem !important; }
 }
 /* The zone picker is the signposted way across a border — tint it accent. */
 .map-zones { color: var(--ac-accent); }
+/* Jump-to-marker (last death / group-mate) shares the accent-tint signposting. */
+.map-jump { color: var(--ac-accent); }
+.map-jump[hidden] { display: none; }
 .map-z { display: inline-flex; gap: 2px; }
 .map-search {
     flex: 1 1 8rem; min-width: 6rem; max-width: 14rem; font-size: 16px;
@@ -473,6 +477,40 @@ body.connect-page #content { padding: .5rem !important; }
 .note-text:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: 1px; }
 .note-actions { display: flex; gap: 6px; justify-content: flex-end; }
 .note-del { color: var(--ac-danger); }
+
+/* Zone picker popover — a filterable list of adjacent + explored zones. Sits
+   on the note-editor's tier, above the overlay window. */
+.map-zone-pop {
+    position: fixed; z-index: 1039;
+    width: min(300px, calc(100vw - 16px));
+    display: flex; flex-direction: column; gap: 6px; padding: 8px;
+    background: var(--ac-panel); border: 1px solid var(--ac-border-2);
+    border-radius: var(--ac-radius); box-shadow: 0 16px 44px rgba(0, 0, 0, .6);
+}
+.map-zone-pop[hidden] { display: none; }
+.zone-pick-head { display: flex; gap: 6px; align-items: center; }
+.zone-pick-search { flex: 1 1 auto; max-width: none; }
+.zone-pick-list {
+    display: flex; flex-direction: column; gap: 1px;
+    max-height: min(46vh, 320px); overflow-y: auto;
+}
+.zone-pick-h {
+    font-size: .62rem; font-weight: 700; letter-spacing: .05em;
+    text-transform: uppercase; color: var(--ac-dim);
+    padding: 6px 4px 2px; position: sticky; top: 0; background: var(--ac-panel);
+}
+.zone-pick-row {
+    text-align: left; padding: 7px 8px; cursor: pointer;
+    font-size: .74rem; color: var(--ac-text);
+    background: transparent; border: 0; border-radius: var(--ac-radius-sm);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.zone-pick-row:hover { background: var(--ac-elev); color: var(--ac-accent); }
+.zone-pick-row:focus-visible { outline: 2px solid var(--ac-accent); outline-offset: -2px; }
+.zone-pick-empty { padding: 10px 4px; font-size: .72rem; color: var(--ac-dim); }
+@media (pointer: coarse) {
+    .zone-pick-row { padding: 11px 8px; }
+}
 
 /* Overlay footer: show-path step list / walking progress. */
 .map-foot {

--- a/apps/connect/static/js/hud-map.js
+++ b/apps/connect/static/js/hud-map.js
@@ -48,6 +48,10 @@
     var dirty = [];         // discovered vnums not yet flushed to the server
     var flushTimer = null;
     var pendingFocus = null; // vnum to refocus the big map on once its zone loads
+    // Live overlays fed by GMCP (isharmud/ishar-mud#1834), not persisted:
+    var groupMates = [];    // non-self group members carrying a location
+    var deathMark = null;   // {vnum, roomName, zoneName, time} — last death
+    var exploredZones = null; // cached [{id,name,count,anchor}] for the picker
 
     // ------------------------------------------------------------------
     // Geometry
@@ -91,6 +95,7 @@
             warn: v("--ac-warn", "#f80"),
             danger: v("--ac-danger", "#d64b4b"),
             panel: v("--ac-panel", "#131316"),
+            group: v("--hud-group", "#3fb6a8"),
             ter: {}
         };
         ["indoor", "city", "field", "forest", "hill", "mountain", "water",
@@ -574,6 +579,58 @@
                                box + 8, box + 8);
             }
         }
+
+        // ---- last-death marker (personal, session-only; #1834) ----
+        // A danger ring + skull, distinct from a death-TRAP room's red corner
+        // triangle: this is "you fell here," a route-back anchor.
+        if (opts.deathVnum != null) {
+            var dpos = L.pos[opts.deathVnum];
+            if (dpos && dpos.z === view.z &&
+                dpos.x >= minWX && dpos.x <= maxWX &&
+                dpos.y >= minWY && dpos.y <= maxWY) {
+                var dxp = sx(dpos.x), dyp = sy(dpos.y);
+                ctx.strokeStyle = palette.danger;
+                ctx.lineWidth = 2;
+                ctx.strokeRect(dxp - half - 2.5, dyp - half - 2.5, box + 5, box + 5);
+                ctx.font = Math.round(box * 0.82) + "px sans-serif";
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                ctx.fillText("💀", dxp, dyp + box * 0.04);
+            }
+        }
+
+        // ---- group-mate markers (same-zone; #1834) ----
+        // One pip per room a mate is in, at the bottom edge; a lone mate shows
+        // their initial, a shared room shows the count. Names live in the
+        // tooltip / jump menu.
+        if (opts.groupMarks) {
+            var gkeys = Object.keys(opts.groupMarks);
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            for (var gi = 0; gi < gkeys.length; gi++) {
+                var gpos = L.pos[gkeys[gi]];
+                if (!gpos || gpos.z !== view.z) continue;
+                if (gpos.x < minWX || gpos.x > maxWX ||
+                    gpos.y < minWY || gpos.y > maxWY) continue;
+                var mates = opts.groupMarks[gkeys[gi]];
+                var pr = Math.max(3, box * 0.19);
+                var gxp = sx(gpos.x), gyp = sy(gpos.y) + half - pr;
+                ctx.fillStyle = palette.group;
+                ctx.beginPath();
+                ctx.arc(gxp, gyp, pr, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.strokeStyle = palette.panel;
+                ctx.lineWidth = 1;
+                ctx.stroke();
+                var badge = mates.length > 1 ? String(mates.length)
+                    : (mates[0].name ? mates[0].name.charAt(0).toUpperCase() : "");
+                if (badge && box >= 16) {
+                    ctx.fillStyle = "#08110f";
+                    ctx.font = "700 " + Math.round(pr * 1.35) + "px system-ui, sans-serif";
+                    ctx.fillText(badge, gxp, gyp + 0.5);
+                }
+            }
+        }
     }
 
     // Invert a canvas point to a room vnum (grid hit-test).
@@ -779,10 +836,94 @@
         setShownPath(null);
         cur.vnum = null;
         cur.unseen = false;
+        // Live overlays belong to the character/session just left; the server
+        // re-primes them on the next entry.
+        groupMates = [];
+        deathMark = null;
         redraw();
     }
     function onConnected(on) {
         if (!on) cancelWalk("disconnected");
+    }
+
+    // ------------------------------------------------------------------
+    // Live overlays — group-mate + last-death markers (#1834). Both are
+    // GMCP-fed and never persisted; they clear on reset and re-prime from the
+    // server on reconnect. The game already gates what we're allowed to show:
+    // a member's exact `vnum` arrives only when they share the player's zone.
+    // ------------------------------------------------------------------
+    function onGroup(data) {
+        if (!enabled()) return;
+        var self = (H && H.selfName ? H.selfName() : "").toLowerCase();
+        var members = (data && data.members) || [];
+        groupMates = members.filter(function (m) {
+            return m && String(m.name || "").toLowerCase() !== self;
+        }).map(function (m) {
+            return {
+                name: H ? H.stripColor(String(m.name || "")) : String(m.name || ""),
+                vnum: typeof m.vnum === "number" ? m.vnum : null,
+                room: m.room ? (H ? H.stripColor(String(m.room)) : String(m.room)) : "",
+                area: m.area ? (H ? H.stripColor(String(m.area)) : String(m.area)) : "",
+                leader: !!m.leader
+            };
+        });
+        redraw();
+    }
+
+    function onDeath(data) {
+        if (!enabled()) return;
+        if (!data || typeof data.vnum !== "number" || !(data.vnum > 0)) {
+            deathMark = null; redraw(); return;
+        }
+        deathMark = {
+            vnum: data.vnum,
+            roomName: data.name ? (H ? H.stripColor(String(data.name)) : String(data.name)) : "",
+            zoneName: data.zone ? (H ? H.stripColor(String(data.zone)) : String(data.zone)) : "",
+            time: typeof data.time === "number" ? data.time : null
+        };
+        redraw();
+    }
+
+    // The death room, but only when it lives in `zoneId` and its graph is
+    // loaded (so a position exists to draw on).
+    function deathVnumInZone(zoneId) {
+        if (!deathMark || zoneId == null) return null;
+        return vnumZone[deathMark.vnum] === zoneId ? deathMark.vnum : null;
+    }
+    // Same-zone mates grouped by the room they're standing in.
+    function groupMarksInZone(zoneId) {
+        var byVnum = {};
+        if (zoneId == null) return byVnum;
+        groupMates.forEach(function (m) {
+            if (m.vnum == null || vnumZone[m.vnum] !== zoneId) return;
+            (byVnum[m.vnum] = byVnum[m.vnum] || []).push(m);
+        });
+        return byVnum;
+    }
+    function hasLocatedMate() {
+        return groupMates.some(function (m) {
+            return m.vnum != null && vnumZone[m.vnum] != null;
+        });
+    }
+    function agoSuffix(t) {
+        if (!t) return "";
+        var s = Math.floor(Date.now() / 1000) - t;
+        if (s < 0) return "";
+        if (s < 90) return " · just now";
+        if (s < 3600) return " · " + Math.round(s / 60) + "m ago";
+        if (s < 86400) return " · " + Math.round(s / 3600) + "h ago";
+        return " · " + Math.round(s / 86400) + "d ago";
+    }
+    // Focus the big map on any vnum, loading its zone graph first if needed —
+    // a death can sit in a zone not loaded this session, unlike a same-zone
+    // mate. Mirrors goToZone but keyed purely on the vnum.
+    function jumpToVnum(vnum, label) {
+        var zid = vnumZone[vnum];
+        if (zid != null && zones[zid]) { focusZone(zid, vnum); return; }
+        pendingFocus = vnum;
+        if (!bigOpen() && H && H.toggleOverlay) H.toggleOverlay("map");
+        if (big && big.zoneLabel) big.zoneLabel.textContent = (label || "Loading") + " …";
+        requestGraph(vnum);
     }
 
     // ------------------------------------------------------------------
@@ -839,7 +980,9 @@
         if (cur.zone != null) {
             drawMap(mini.canvas, cur.zone, miniView(), {
                 curVnum: cur.vnum, unseen: cur.unseen,
-                pathVnums: walkPathVnums(), pathEdges: walkPathEdges()
+                pathVnums: walkPathVnums(), pathEdges: walkPathEdges(),
+                deathVnum: deathVnumInZone(cur.zone),
+                groupMarks: groupMarksInZone(cur.zone)
             });
         } else {
             var ctx = mini.canvas.getContext("2d");
@@ -917,14 +1060,23 @@
         var btnMe = H.el("button", { type: "button", class: "map-btn", text: "◎",
             title: "Center on me", "aria-label": "Center on my room",
             onclick: function () { bigView.follow = true; centerOnMe(); redraw(); } });
+        // Jump to a live marker — your last death, or a group-mate. Hidden
+        // until there's somewhere to jump (#1834).
+        var btnJump = H.el("button", {
+            type: "button", class: "map-btn map-jump menu-opener", text: "Jump ▾",
+            title: "Jump to a group-mate or where you died",
+            "aria-label": "Jump to a group-mate or where you died",
+            onclick: function () { openMarkerJump(btnJump); }
+        });
+        btnJump.hidden = true;
         var toolbar = H.el("div", { class: "map-toolbar" },
-            [zoneLabel, btnZones, zRow, search, count, btnOut, btnIn, btnMe]);
+            [zoneLabel, btnZones, btnJump, zRow, search, count, btnOut, btnIn, btnMe]);
         var foot = H.el("div", { class: "map-foot" });
         foot.hidden = true;
         var root = H.el("div", { class: "map-app" }, [toolbar, wrap, foot]);
         big = { root: root, canvas: canvas, wrap: wrap, zoneLabel: zoneLabel,
                 zRow: zRow, search: search, count: count, anchor: anchor,
-                foot: foot, btnMe: btnMe, btnZones: btnZones };
+                foot: foot, btnMe: btnMe, btnZones: btnZones, btnJump: btnJump };
 
         // --- search: filter discovered rooms, Enter cycles + centers ---
         search.addEventListener("input", function () {
@@ -1060,11 +1212,13 @@
         big.anchor.style.width = (halfBox * 2) + "px";
         big.anchor.style.height = (halfBox * 2) + "px";
         if (!fs[v]) { H.showTip(big.anchor, { name: "Unexplored" }); return; }
+        var parts = [room.t];
+        if (deathMark && v === deathMark.vnum) parts.push("💀 you died here");
+        var here = groupMates.filter(function (m) { return m.vnum === v; });
+        if (here.length) parts.push(here.map(function (m) { return m.name; }).join(", "));
         var note = noteFor(v);
-        H.showTip(big.anchor, {
-            name: H.stripColor(room.n),
-            sub: room.t + (note ? " · " + firstLine(note) : "")
-        });
+        if (note) parts.push(firstLine(note));
+        H.showTip(big.anchor, { name: H.stripColor(room.n), sub: parts.join(" · ") });
     }
     function firstLine(s) {
         var line = String(s).split("\n")[0];
@@ -1115,49 +1269,187 @@
         updateZoneLabel(); updateZRow(); updateSearchCount(); updateMeButton();
         redrawBig();
     }
-    // Toolbar "Zones ▾" menu: every neighbor reachable from an explored
-    // border of the viewed zone, plus a "back to my location" when off-zone.
-    function openZoneJump(anchor) {
-        var zid = viewedZone();
-        if (zid == null || !zones[zid]) return;
-        var zone = zones[zid], fs = fogSet(zid);
-        var acts = [];
-        if (cur.zone != null && zid !== cur.zone) {
-            acts.push({
-                label: "◎ Back to my location",
-                fn: function () { bigView.follow = true; centerOnMe(); redraw(); }
-            });
-        }
-        // One entry per adjacent zone, keyed off discovered border rooms so
-        // we only surface crossings the player has actually found.
-        var byZone = {};
+    // ------------------------------------------------------------------
+    // Zone picker — a filterable popover, not a flat menu, because a veteran
+    // account can have discovered dozens of zones. Adjacent zones (reachable
+    // from an explored border of the viewed zone) pin to the top; every other
+    // explored zone follows, alphabetical, filtered live.
+    // ------------------------------------------------------------------
+    var zonePop = null;   // {root, input, list}
+
+    function buildZonePop() {
+        var input = H.el("input", {
+            class: "map-search zone-pick-search", type: "search",
+            placeholder: "Filter zones…", "aria-label": "Filter zones by name"
+        });
+        var closeBtn = H.el("button", { type: "button", class: "map-btn",
+            text: "Close", onclick: closeZonePop });
+        var head = H.el("div", { class: "zone-pick-head" }, [input, closeBtn]);
+        var list = H.el("div", { class: "zone-pick-list" });
+        var root = H.el("div", { class: "map-zone-pop menu-opener", role: "dialog",
+            "aria-label": "Jump to zone" }, [head, list]);
+        root.hidden = true;
+        document.body.appendChild(root);
+        input.addEventListener("input", function () { renderZoneList(input.value); });
+        input.addEventListener("keydown", function (ev) {
+            if (ev.key === "Escape") { ev.stopPropagation(); closeZonePop(); }
+        });
+        // Dismiss on an outside tap (the toolbar button is exempt so its own
+        // click doesn't immediately re-close the popover it just opened).
+        document.addEventListener("pointerdown", function (ev) {
+            if (!zonePop || zonePop.root.hidden) return;
+            if (zonePop.root.contains(ev.target)) return;
+            if (big && big.btnZones && big.btnZones.contains(ev.target)) return;
+            closeZonePop();
+        }, true);
+        zonePop = { root: root, input: input, list: list };
+    }
+
+    // Adjacent zones = crossings found from an explored border of the viewed
+    // zone (the old picker's whole content; now just the pinned section).
+    function adjacentZones() {
+        var zid = viewedZone(), out = [];
+        if (zid == null || !zones[zid]) return out;
+        var zone = zones[zid], fs = fogSet(zid), byZone = {};
         zone.graph.rooms.forEach(function (r) {
             if (!fs[r.v]) return;
             (zone.layout.outFrom[r.v] || []).forEach(function (o) {
                 if (!byZone[o.zone]) byZone[o.zone] = o;
             });
         });
-        var keys = Object.keys(byZone);
-        keys.sort(function (a, b) {
-            var na = byZone[a].zname || "", nb = byZone[b].zname || "";
-            return na < nb ? -1 : na > nb ? 1 : 0;
-        });
-        keys.forEach(function (k) {
+        Object.keys(byZone).forEach(function (k) {
             var o = byZone[k];
-            acts.push({
-                label: "Go to " + (o.zname || "zone " + o.zone) + " →",
-                fn: (function (oo) {
-                    return function () { goToZone(oo.zone, oo.t, oo.zname); };
-                })(o)
-            });
+            out.push({ id: Number(o.zone), name: o.zname || ("zone " + o.zone), vnum: o.t });
         });
-        if (!keys.length) {
-            acts.push({
-                label: "Walk to a zone border to unlock jumps",
-                fn: function () {}, keep: true
+        out.sort(function (a, b) { return byName(a.name, b.name); });
+        return out;
+    }
+    function byName(a, b) {
+        a = (a || "").toLowerCase(); b = (b || "").toLowerCase();
+        return a < b ? -1 : a > b ? 1 : 0;
+    }
+    function zoneRow(label, fn) {
+        return H.el("button", { type: "button", class: "zone-pick-row",
+            text: label, onclick: fn });
+    }
+    function renderZoneList(q) {
+        if (!zonePop) return;
+        q = (q || "").trim().toLowerCase();
+        var zid = viewedZone(), kids = [];
+        if (cur.zone != null && zid !== cur.zone) {
+            kids.push(zoneRow("◎ Back to my location", function () {
+                closeZonePop(); bigView.follow = true; centerOnMe(); redraw();
+            }));
+        }
+        var adj = adjacentZones();
+        var adjIds = {};
+        adj.forEach(function (z) { adjIds[z.id] = true; });
+        var adjShown = adj.filter(function (z) {
+            return !q || z.name.toLowerCase().indexOf(q) !== -1;
+        });
+        if (adjShown.length) {
+            kids.push(H.el("div", { class: "zone-pick-h", text: "Adjacent" }));
+            adjShown.forEach(function (z) {
+                kids.push(zoneRow("→ " + z.name, function () {
+                    closeZonePop(); goToZone(z.id, z.vnum, z.name);
+                }));
             });
         }
-        H.openMenu("Jump to zone", acts, anchor);
+        var explored = (exploredZones || []).filter(function (z) {
+            return z.id !== cur.zone && z.id !== zid && !adjIds[z.id] &&
+                   (!q || (z.name || "").toLowerCase().indexOf(q) !== -1);
+        });
+        if (explored.length) {
+            kids.push(H.el("div", { class: "zone-pick-h", text: "Explored" }));
+            explored.forEach(function (z) {
+                kids.push(zoneRow(z.name + "  (" + z.count + ")", function () {
+                    closeZonePop(); goToZone(z.id, z.anchor, z.name);
+                }));
+            });
+        }
+        if (!adjShown.length && !explored.length) {
+            kids.push(H.el("div", { class: "zone-pick-empty",
+                text: exploredZones == null ? "Loading…" : "No zones found." }));
+        }
+        H.fill(zonePop.list, kids);
+    }
+    function positionZonePop(anchor) {
+        var pop = zonePop.root;
+        pop.hidden = false;
+        pop.style.left = "-9999px"; pop.style.top = "0px";
+        var pw = pop.offsetWidth, ph = pop.offsetHeight;
+        var vw = window.innerWidth, vh = window.innerHeight;
+        var r = anchor && anchor.getBoundingClientRect
+            ? anchor.getBoundingClientRect() : null;
+        var left = r ? Math.min(r.left, vw - pw - 8) : (vw - pw) / 2;
+        var top = r ? Math.min(r.bottom + 6, vh - ph - 8) : (vh - ph) / 2;
+        pop.style.left = Math.max(8, left) + "px";
+        pop.style.top = Math.max(8, top) + "px";
+    }
+    function closeZonePop() { if (zonePop) zonePop.root.hidden = true; }
+
+    function fetchExploredZones() {
+        if (cfg.demo) {
+            exploredZones = demoExploredZones();
+            if (zonePop && !zonePop.root.hidden) renderZoneList(zonePop.input.value);
+            return;
+        }
+        if (!cfg.urls || !cfg.urls.zones) {
+            if (exploredZones == null) exploredZones = [];
+            return;
+        }
+        fetch(cfg.urls.zones, { credentials: "same-origin" })
+            .then(function (r) { if (!r.ok) throw new Error("zones " + r.status); return r.json(); })
+            .then(function (d) { exploredZones = (d && d.zones) || []; })
+            .catch(function () { if (exploredZones == null) exploredZones = []; })
+            .then(function () {
+                if (zonePop && !zonePop.root.hidden) renderZoneList(zonePop.input.value);
+            });
+    }
+
+    // Toolbar "Zones ▾": open the picker, (re)load the explored-zone list.
+    function openZoneJump(anchor) {
+        if (!zonePop) buildZonePop();
+        positionZonePop(anchor);
+        zonePop.input.value = "";
+        renderZoneList("");
+        fetchExploredZones();
+        try { zonePop.input.focus({ preventScroll: true }); } catch (e) { zonePop.input.focus(); }
+    }
+
+    // Toolbar "Jump ▾": jump to a live marker — where you died, or a group-mate.
+    function openMarkerJump(anchor) {
+        var acts = [];
+        if (deathMark) {
+            acts.push({
+                label: "💀 " + (deathMark.roomName || "Where you died") + agoSuffix(deathMark.time),
+                fn: function () { jumpToVnum(deathMark.vnum, deathMark.zoneName || "Where you died"); }
+            });
+            if (cur.vnum != null && !cur.unseen && vnumZone[deathMark.vnum] != null) {
+                var dsteps = findPath(cur.vnum, deathMark.vnum);
+                if (dsteps) acts.push({
+                    label: "Walk back (" + dsteps.length + " step" +
+                        (dsteps.length === 1 ? "" : "s") + ")",
+                    fn: function () { startWalk(dsteps); }
+                });
+            }
+        }
+        groupMates.forEach(function (m) {
+            if (m.vnum == null || vnumZone[m.vnum] == null) return;
+            var zn = zones[vnumZone[m.vnum]] ? zones[vnumZone[m.vnum]].name : m.room;
+            acts.push({
+                label: "◎ " + m.name + (m.room ? " — " + m.room : ""),
+                fn: function () { jumpToVnum(m.vnum, zn); }
+            });
+        });
+        if (!acts.length) {
+            acts.push({ label: "No markers to jump to yet", fn: function () {}, keep: true });
+        }
+        H.openMenu("Jump to", acts, anchor);
+    }
+    function updateJumpButton() {
+        if (!big || !big.btnJump) return;
+        big.btnJump.hidden = !(deathMark || hasLocatedMate());
     }
 
     // Menu action: jump the map to an adjacent zone, loading it if needed.
@@ -1236,6 +1528,7 @@
         updateZoneLabel();
         updateZRow();
         updateMeButton();
+        updateJumpButton();
         rebuildSearch();
         updateSearchCount();
         requestAnimationFrame(redrawBig);
@@ -1247,7 +1540,9 @@
         drawMap(big.canvas, zid, bigView, {
             curVnum: cur.vnum, unseen: cur.unseen,
             pathVnums: walkPathVnums(), pathEdges: walkPathEdges(),
-            searchVnum: searchState.i >= 0 ? searchState.list[searchState.i] : null
+            searchVnum: searchState.i >= 0 ? searchState.list[searchState.i] : null,
+            deathVnum: deathVnumInZone(zid),
+            groupMarks: groupMarksInZone(zid)
         });
     }
 
@@ -1646,6 +1941,7 @@
         }
         updateZoneLabel();
         updateMeButton();
+        updateJumpButton();
         redrawBig();
     }
 
@@ -1774,6 +2070,19 @@
         notes[91] = { 5003: "rare reagents restock at dawn" };
         fogStamp++;
     }
+    // What the /connect/map/zones/ endpoint would return for the demo account:
+    // the two seeded zones plus a few "explored in a past session" zones with
+    // no loaded graph, so the picker's Explored section (and its filter) has
+    // something to show beyond the current + adjacent zones.
+    function demoExploredZones() {
+        return [
+            { id: 90, name: "Ishar Nexus", count: 14, anchor: 3001 },
+            { id: 91, name: "Kingdom of Jolnara", count: 3, anchor: 5001 },
+            { id: 42, name: "The Ashen Waste", count: 26, anchor: 4201 },
+            { id: 57, name: "Sunspire Catacombs", count: 41, anchor: 5701 },
+            { id: 63, name: "Tidewrack Shoals", count: 12, anchor: 6301 }
+        ];
+    }
 
     // ------------------------------------------------------------------
     // Public surface
@@ -1784,6 +2093,8 @@
         onRoom: onRoom,
         onReset: onReset,
         onConnected: onConnected,
+        onGroup: onGroup,
+        onDeath: onDeath,
         renderMini: renderMini,
         renderOverlay: renderOverlay,
         currentNote: currentNote,

--- a/apps/connect/static/js/hud-map.js
+++ b/apps/connect/static/js/hud-map.js
@@ -862,12 +862,39 @@
             return {
                 name: H ? H.stripColor(String(m.name || "")) : String(m.name || ""),
                 vnum: typeof m.vnum === "number" ? m.vnum : null,
+                zone: typeof m.zone === "number" ? m.zone : null,
                 room: m.room ? (H ? H.stripColor(String(m.room)) : String(m.room)) : "",
                 area: m.area ? (H ? H.stripColor(String(m.area)) : String(m.area)) : "",
                 leader: !!m.leader
             };
         });
         redraw();
+    }
+
+    // A zone the account has explored (has fog for, or the server listed as
+    // discovered). This is the "don't overshare" gate: a mate's exact room and
+    // jump are revealed only for zones you've actually mapped.
+    function zoneDiscovered(zoneId) {
+        if (zoneId == null) return false;
+        var fs = fog[zoneId];
+        if (fs && fs.set) { for (var k in fs.set) { if (fs.set[k]) return true; } }
+        return (exploredZones || []).some(function (z) { return z.id === zoneId; });
+    }
+    // Location string the group panel shows for a mate not in your room — from
+    // a raw Group.Update member. Exact room when you've discovered its zone,
+    // else the coarse area name (or "elsewhere"): never the exact room of a
+    // zone you've never been to.
+    function memberWhere(m) {
+        if (!m) return "";
+        var z = typeof m.zone === "number" ? m.zone : null;
+        var room = m.room && H ? H.stripColor(String(m.room)) : "";
+        var area = m.area && H ? H.stripColor(String(m.area)) : "";
+        if (z != null && zoneDiscovered(z) && room) return room;
+        return area || "elsewhere";
+    }
+    // A mate we can actually plot / jump to: located, in a discovered zone.
+    function mateLocatable(m) {
+        return !!(m && m.vnum != null && zoneDiscovered(m.zone));
     }
 
     function onDeath(data) {
@@ -890,10 +917,12 @@
         if (!deathMark || zoneId == null) return null;
         return vnumZone[deathMark.vnum] === zoneId ? deathMark.vnum : null;
     }
-    // Same-zone mates grouped by the room they're standing in.
+    // Mates grouped by the room they're in, for the given zone — but only when
+    // that zone is discovered, so cross-zone *viewing* a neighbor you haven't
+    // explored never plots a mate standing in it.
     function groupMarksInZone(zoneId) {
         var byVnum = {};
-        if (zoneId == null) return byVnum;
+        if (zoneId == null || !zoneDiscovered(zoneId)) return byVnum;
         groupMates.forEach(function (m) {
             if (m.vnum == null || vnumZone[m.vnum] !== zoneId) return;
             (byVnum[m.vnum] = byVnum[m.vnum] || []).push(m);
@@ -901,9 +930,7 @@
         return byVnum;
     }
     function hasLocatedMate() {
-        return groupMates.some(function (m) {
-            return m.vnum != null && vnumZone[m.vnum] != null;
-        });
+        return groupMates.some(mateLocatable);
     }
     function agoSuffix(t) {
         if (!t) return "";
@@ -1435,8 +1462,9 @@
             }
         }
         groupMates.forEach(function (m) {
-            if (m.vnum == null || vnumZone[m.vnum] == null) return;
-            var zn = zones[vnumZone[m.vnum]] ? zones[vnumZone[m.vnum]].name : m.room;
+            if (!mateLocatable(m)) return;
+            var loaded = vnumZone[m.vnum] != null && zones[vnumZone[m.vnum]];
+            var zn = loaded ? zones[vnumZone[m.vnum]].name : (m.area || m.room);
             acts.push({
                 label: "◎ " + m.name + (m.room ? " — " + m.room : ""),
                 fn: function () { jumpToVnum(m.vnum, zn); }
@@ -2095,6 +2123,7 @@
         onConnected: onConnected,
         onGroup: onGroup,
         onDeath: onDeath,
+        memberWhere: memberWhere,
         renderMini: renderMini,
         renderOverlay: renderOverlay,
         currentNote: currentNote,
@@ -2110,6 +2139,10 @@
             if (/[?&]demo=1/.test(window.location.search)) seedDemo();
             // Discovery must not be lost to a tab close mid-batch.
             window.addEventListener("pagehide", function () { doFlush(true); });
+            // Learn which zones this account has explored up front, so a mate's
+            // room reveals as soon as their Group.Update arrives — without
+            // waiting for the zone picker to be opened.
+            fetchExploredZones();
             wireWalkCancels();
             if (H) { H.updateMicro(); H.rerenderRoom(); }
         },

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -1672,8 +1672,36 @@
         if (kind === "member") {
             var nm = firstWord(String(x.name || ""));
             var self = S.status && String(S.status.name || "").toLowerCase() === nm.toLowerCase();
-            if (nm && !self) acts.push({ label: "Tell…", prefill: "tell " + nm + " " });
+            if (nm && !self) {
+                acts.push({ label: "Tell…", prefill: "tell " + nm + " " });
+                regroupActions(nm).forEach(function (a) { acts.push(a); });
+            }
         }
+        return acts;
+    }
+
+    // Regroup spells offered on an away mate's menu, only when the caster knows
+    // them — the game enforces mana / range / anti-magic / group-bond itself, so
+    // a shown action can still be refused in play. translocate moves you to the
+    // mate; summon brings the mate to you.
+    function knownSpell(name) {
+        var hits = (S.skills || []).filter(function (s) {
+            return s.type === "spell" && nameOf(s.name).toLowerCase() === name;
+        });
+        return hits.length ? hits[0] : null;
+    }
+    function regroupActions(nm) {
+        var acts = [];
+        [["translocate", "Translocate to "], ["summon", "Summon "]].forEach(function (p) {
+            var s = knownSpell(p[0]);
+            if (!s) return;
+            var blocked = abilityBlock(s);
+            acts.push({
+                label: p[1] + nm + (blocked ? " (" + blocked.reason + ")" : ""),
+                cmd: "cast '" + p[0] + "' " + nm,
+                disabled: !!blocked
+            });
+        });
         return acts;
     }
 
@@ -3690,7 +3718,9 @@
             { id: 9, name: "disarm", type: "skill", percent: 45, usable: true, category: "damage", target_type: "none", min_position: "Fighting" },
             { id: 10, name: "second attack", type: "passive", percent: 75, usable: false, category: "misc", target_type: "none", min_position: "Standing" },
             { id: 91, name: "Metamagic: Clarity", type: "skill", percent: 100, usable: true, category: "misc", target_type: "none", min_position: "Standing" },
-            { id: 92, name: "Shield Slam", type: "skill", percent: 72, usable: true, category: "damage", target_type: "none", min_position: "Fighting" }
+            { id: 92, name: "Shield Slam", type: "skill", percent: 72, usable: true, category: "damage", target_type: "none", min_position: "Fighting" },
+            { id: 60, name: "translocate", type: "spell", percent: 84, usable: true, category: "misc", target_type: "defensive", mana_pct: 25, mana: 75, min_position: "Standing" },
+            { id: 61, name: "summon", type: "spell", percent: 79, usable: true, category: "misc", target_type: "defensive", mana_pct: 33, mana: 100, min_position: "Standing" }
         ];
         // Pad to demonstrate the immortal overflow the browser now bounds.
         for (var i = 11; i <= 90; i++) bigSkills.push({ id: i, name: "spell " + i, type: (i % 3 ? "spell" : "skill"), percent: 40 + (i % 60), usable: (i % 4 !== 0), category: ["damage", "heal", "misc"][i % 3], target_type: ["offensive", "defensive", "none"][i % 3], mana_pct: 20 + (i % 40), mana: (20 + (i % 40)) * 3, min_position: "Standing" });

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -1597,12 +1597,13 @@
         if (x.fighting_name) chips.push(el("span", { class: "grp-fight", title: "Fighting", text: "⚔ " + stripColor(x.fighting_name) }));
         var p = String(x.position || "").toLowerCase();
         if (p && p !== "standing") chips.push(el("span", { class: "grp-pos", text: p }));
-        // Where a mate is when they're not with you — the room name the game now
-        // shares (parity with the `group` command), zone-qualified when far.
+        // Where a mate is when they're not with you. The map owns the reveal
+        // rule (exact room only for a zone you've discovered, else the area),
+        // so the HUD never shows more than you've earned; fall back to a plain
+        // "away" if the mapper isn't loaded.
         if (x.in_room === false) {
-            var whereText = x.room
-                ? stripColor(x.room) + (x.area ? " · " + stripColor(x.area) : "")
-                : "away";
+            var whereText = (mapMod && mapMod.memberWhere) ? mapMod.memberWhere(x) : "";
+            if (!whereText) whereText = "away";
             chips.push(el("span", { class: "grp-away", title: "Not in your room", text: whereText }));
         }
         var main = el("div", { class: "grp-main" }, [
@@ -3760,10 +3761,12 @@
                 { name: "a shard of frost quartz", keywords: "quartz frost shard", vnum: 9004, count: 5 }
             ], treasure: 620 },
             "Char.Affects": { buffs: [{ name: "Stoneskin", id: 101, duration: 1800 }, { name: "Haste", id: 102, duration: 240 }], debuffs: [{ name: "Poison", id: 201, duration: 45 }], maintained: [{ name: "Detect Invisibility", id: 301, duration: 600, target: "self" }, { name: "Shroud", id: 302, duration: 900, target: "Boric", skill: "shroud", handle: "1.boric", releasable: true }] },
-            "Group.Update": { leader: "Aelwyn", size: 3, members: [
-                { name: "Aelwyn", level: 45, hp_pct: 86, mp_pct: 85, mv_pct: 82, position: "Standing", race: "Elf", "class": "Magician", leader: true, in_room: true, is_tank: false, fighting_name: "a scarred alley thug", threat: 40, tank_threat: 120, threat_level: "low", room: "The Grand Concourse", vnum: 3001 },
-                { name: "Boric", level: 43, hp_pct: 30, mp_pct: 40, mv_pct: 75, position: "Standing", race: "Dwarf", "class": "Warrior", leader: false, in_room: true, is_tank: true, fighting_name: "a scarred alley thug", threat: 120, room: "The Grand Concourse", vnum: 3001 },
-                { name: "Selra", level: 41, hp_pct: 95, mp_pct: 90, mv_pct: 88, position: "Sleeping", race: "Human", "class": "Cleric", leader: false, in_room: false, is_tank: false, room: "Cramped Alcove", vnum: 3014 }
+            "Group.Update": { leader: "Aelwyn", size: 5, members: [
+                { name: "Aelwyn", level: 45, hp_pct: 86, mp_pct: 85, mv_pct: 82, position: "Standing", race: "Elf", "class": "Magician", leader: true, in_room: true, is_tank: false, fighting_name: "a scarred alley thug", threat: 40, tank_threat: 120, threat_level: "low", room: "The Grand Concourse", vnum: 3001, zone: 90 },
+                { name: "Boric", level: 43, hp_pct: 30, mp_pct: 40, mv_pct: 75, position: "Standing", race: "Dwarf", "class": "Warrior", leader: false, in_room: true, is_tank: true, fighting_name: "a scarred alley thug", threat: 120, room: "The Grand Concourse", vnum: 3001, zone: 90 },
+                { name: "Selra", level: 41, hp_pct: 95, mp_pct: 90, mv_pct: 88, position: "Sleeping", race: "Human", "class": "Cleric", leader: false, in_room: false, is_tank: false, room: "Cramped Alcove", vnum: 3014, zone: 90 },
+                { name: "Kael", level: 39, hp_pct: 72, mp_pct: 60, mv_pct: 80, position: "Standing", race: "Human", "class": "Ranger", leader: false, in_room: false, is_tank: false, room: "Village Square", vnum: 5003, zone: 91, area: "Kingdom of Jolnara" },
+                { name: "Doran", level: 44, hp_pct: 88, mp_pct: 55, mv_pct: 66, position: "Standing", race: "Dwarf", "class": "Cleric", leader: false, in_room: false, is_tank: false, room: "Ashen Hollow", vnum: 4210, zone: 99, area: "Shrouded Vale" }
             ], allies: [
                 { name: "a large timber wolf", owner: "Aelwyn", hp_pct: 55, mp_pct: 100, mv_pct: 95, position: "Resting", in_room: true, is_tank: false }
             ] },

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -597,7 +597,13 @@
                 break;
             case "Char.Train": S.train = data; renderTrain(); break;
             case "Char.Affects": S.affects = data; stampAffectExpiry(data); renderStatus(); break;
-            case "Group.Update": S.group = data; renderGroup(); break;
+            case "Group.Update":
+                S.group = data; renderGroup();
+                if (mapMod && mapMod.onGroup) mapMod.onGroup(data);
+                break;
+            case "Char.Death":
+                if (mapMod && mapMod.onDeath) mapMod.onDeath(data);
+                break;
             case "Char.Who": S.who = data; renderWho(); break;
             case "Char.Skills": S.skills = (data && data.skills) || []; renderHotbar(); renderAbilities(); break;
             case "Char.Professions": applyProfessions(data); break;
@@ -1591,7 +1597,14 @@
         if (x.fighting_name) chips.push(el("span", { class: "grp-fight", title: "Fighting", text: "⚔ " + stripColor(x.fighting_name) }));
         var p = String(x.position || "").toLowerCase();
         if (p && p !== "standing") chips.push(el("span", { class: "grp-pos", text: p }));
-        if (x.in_room === false) chips.push(el("span", { class: "grp-away", title: "Not in your room", text: "away" }));
+        // Where a mate is when they're not with you — the room name the game now
+        // shares (parity with the `group` command), zone-qualified when far.
+        if (x.in_room === false) {
+            var whereText = x.room
+                ? stripColor(x.room) + (x.area ? " · " + stripColor(x.area) : "")
+                : "away";
+            chips.push(el("span", { class: "grp-away", title: "Not in your room", text: whereText }));
+        }
         var main = el("div", { class: "grp-main" }, [
             el("div", { class: "grp-line" }, [
                 el("span", { class: "grp-name", text: stripColor(String(x.name || "")) + (x.leader ? " ★" : "") }),
@@ -3643,6 +3656,7 @@
             toggleOverlay: toggleOverlay,
             overlayVisible: overlayVisible,
             isMobile: function () { return mqMobile.matches; },
+            selfName: function () { return S.status ? String(S.status.name || "") : ""; },
             markUnread: function (on) { markOverlayUnread("map", on); },
             updateMicro: updateMicro,
             rerenderRoom: function () { if (dom.room) renderRoom(); },
@@ -3747,9 +3761,9 @@
             ], treasure: 620 },
             "Char.Affects": { buffs: [{ name: "Stoneskin", id: 101, duration: 1800 }, { name: "Haste", id: 102, duration: 240 }], debuffs: [{ name: "Poison", id: 201, duration: 45 }], maintained: [{ name: "Detect Invisibility", id: 301, duration: 600, target: "self" }, { name: "Shroud", id: 302, duration: 900, target: "Boric", skill: "shroud", handle: "1.boric", releasable: true }] },
             "Group.Update": { leader: "Aelwyn", size: 3, members: [
-                { name: "Aelwyn", level: 45, hp_pct: 86, mp_pct: 85, mv_pct: 82, position: "Standing", race: "Elf", "class": "Magician", leader: true, in_room: true, is_tank: false, fighting_name: "a scarred alley thug", threat: 40, tank_threat: 120, threat_level: "low" },
-                { name: "Boric", level: 43, hp_pct: 30, mp_pct: 40, mv_pct: 75, position: "Standing", race: "Dwarf", "class": "Warrior", leader: false, in_room: true, is_tank: true, fighting_name: "a scarred alley thug", threat: 120 },
-                { name: "Selra", level: 41, hp_pct: 95, mp_pct: 90, mv_pct: 88, position: "Sleeping", race: "Human", "class": "Cleric", leader: false, in_room: true, is_tank: false }
+                { name: "Aelwyn", level: 45, hp_pct: 86, mp_pct: 85, mv_pct: 82, position: "Standing", race: "Elf", "class": "Magician", leader: true, in_room: true, is_tank: false, fighting_name: "a scarred alley thug", threat: 40, tank_threat: 120, threat_level: "low", room: "The Grand Concourse", vnum: 3001 },
+                { name: "Boric", level: 43, hp_pct: 30, mp_pct: 40, mv_pct: 75, position: "Standing", race: "Dwarf", "class": "Warrior", leader: false, in_room: true, is_tank: true, fighting_name: "a scarred alley thug", threat: 120, room: "The Grand Concourse", vnum: 3001 },
+                { name: "Selra", level: 41, hp_pct: 95, mp_pct: 90, mv_pct: 88, position: "Sleeping", race: "Human", "class": "Cleric", leader: false, in_room: false, is_tank: false, room: "Cramped Alcove", vnum: 3014 }
             ], allies: [
                 { name: "a large timber wolf", owner: "Aelwyn", hp_pct: 55, mp_pct: 100, mv_pct: 95, position: "Resting", in_room: true, is_tank: false }
             ] },
@@ -3786,7 +3800,8 @@
                 { id: 203, profession_id: 2, name: "greater arcane dust", category: "Transmutation", min_rank: 20, duration: 10,
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 2 }] }
             ] },
-            "Char.Craft": { active: true, kind: "craft", name: "minor healing draught", profession_id: 1, remaining: 14, duration: 20, quantity: 2, chain_remaining: 3 }
+            "Char.Craft": { active: true, kind: "craft", name: "minor healing draught", profession_id: 1, remaining: 14, duration: 20, quantity: 2, chain_remaining: 3 },
+            "Char.Death": { vnum: 3020, name: "Crumbled Ledge", zone: "Ishar Nexus", time: Math.floor(Date.now() / 1000) - 240 }
         };
         Object.keys(feeds).forEach(function (k) { onGmcp(k, JSON.stringify(feeds[k])); });
         [

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -1000,6 +1000,7 @@
             urls: {
                 graph: "{% url 'map_graph' vnum=0 %}",
                 state: "{% url 'map_state' zone_id=0 %}",
+                zones: "{% url 'map_zones' %}",
                 discover: "{% url 'map_discover' %}",
                 note: "{% url 'map_note' %}"
             }

--- a/apps/connect/urls.py
+++ b/apps/connect/urls.py
@@ -2,7 +2,8 @@
 from django.urls import path
 
 from .views import (
-    ConnectView, MapDiscoverView, MapNoteView, MapStateView, ZoneGraphView,
+    ConnectView, MapDiscoverView, MapNoteView, MapStateView, MapZonesView,
+    ZoneGraphView,
 )
 
 
@@ -10,6 +11,7 @@ urlpatterns = [
     path("", ConnectView.as_view(), name="connect"),
     path("map/graph/<int:vnum>/", ZoneGraphView.as_view(), name="map_graph"),
     path("map/state/<int:zone_id>/", MapStateView.as_view(), name="map_state"),
+    path("map/zones/", MapZonesView.as_view(), name="map_zones"),
     path("map/discover/", MapDiscoverView.as_view(), name="map_discover"),
     path("map/note/", MapNoteView.as_view(), name="map_note"),
 ]

--- a/apps/connect/views/__init__.py
+++ b/apps/connect/views/__init__.py
@@ -1,2 +1,4 @@
 from .connect import ConnectView
-from .map import MapDiscoverView, MapNoteView, MapStateView, ZoneGraphView
+from .map import (
+    MapDiscoverView, MapNoteView, MapStateView, MapZonesView, ZoneGraphView,
+)

--- a/apps/connect/views/map.py
+++ b/apps/connect/views/map.py
@@ -22,6 +22,7 @@ import json
 import re
 
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Count, Min
 from django.http import HttpResponse, JsonResponse
 from django.views.generic.base import View
 
@@ -228,6 +229,46 @@ class MapStateView(MapJSONMixin, NeverCacheMixin, View):
             ).values("room_vnum", "text")
         }
         return JsonResponse({"discovered": discovered, "notes": notes})
+
+
+class MapZonesView(MapJSONMixin, NeverCacheMixin, View):
+    """GET every zone this account has explored (has any discovered room).
+
+    Backs the expanded map's zone picker: the client already knows the zones
+    it has loaded graphs for this session, but not the ones discovered in
+    prior sessions. Each entry carries a room ``count`` and an ``anchor`` vnum
+    (the lowest discovered vnum — stable and always inside explored fog) the
+    client loads + focuses when the zone is picked.
+    """
+
+    http_method_names = ("get",)
+
+    def get(self, request, *args, **kwargs):
+        account_id = request.user.account_id
+        rows = list(
+            RoomDiscovery.objects.filter(account_id=account_id)
+            .values("zone_id")
+            .annotate(count=Count("room_vnum"), anchor=Min("room_vnum"))
+        )
+        names = {
+            z["id"]: z["name"]
+            for z in Zone.objects.filter(
+                id__in=[r["zone_id"] for r in rows],
+            ).values("id", "name")
+        }
+        zones = sorted(
+            (
+                {
+                    "id": r["zone_id"],
+                    "name": names.get(r["zone_id"], ""),
+                    "count": r["count"],
+                    "anchor": r["anchor"],
+                }
+                for r in rows
+            ),
+            key=lambda z: (z["name"] or "").lower(),
+        )
+        return JsonResponse({"zones": zones})
 
 
 class MapDiscoverView(MapJSONMixin, NeverCacheMixin, View):


### PR DESCRIPTION
Closes #136, closes #138

### Problem

The expanded HUD map (#125) is still a fairly passive fog-of-war drawing for the players who navigate Ishar from their phones. Three gaps: the "Zones ▾" picker only lists zones bordering the one you're looking at, so hopping to a zone you mapped last week means walking there; after a death there's no anchor for "where do I run back to?"; and when a group splits up you can't see where anyone is — and can't regroup without dropping to the command line.

### Solution

- **Zone picker → every explored zone.** A new `GET /connect/map/zones/` returns the account's explored zones (any discovered room) with a room count and an anchor vnum. "Zones ▾" becomes a filterable popover rather than a flat menu — a veteran can have dozens of zones — with **Adjacent** pinned on top (the old border logic) and **Explored** alphabetical below.
- **Death marker.** `onDeath` consumes the new `Char.Death` GMCP feed; a 💀 with a danger ring marks the last-death room on both maps, deliberately distinct from a death-*trap* room's corner triangle. "Jump ▾" focuses it (fetching the zone graph first if needed) and offers "Walk back"; routing reuses the existing `findPath`/`startWalk`.
- **Group-mate markers.** `onGroup` places a pip per mate and lists each in "Jump ▾". The one design rule worth knowing: the HUD shows exactly what the game reveals, gated by **discovered zone** — an exact room / marker / jump appears only for a zone you've explored (fog or the explored-zones list, fetched on init); a mate in an unexplored zone shows only the coarse area name, no marker, no jump. The reveal rule lives in one place (`memberWhere` in the mapper). This also closes a subtle over-share: cross-zone *viewing* a neighbor you haven't explored never plots a mate standing in it.
- **Regroup spells on the away-mate menu (#138).** When the caster knows the spell, an away mate's group-panel menu now offers "Summon <name>" (pull them to you) and "Translocate to <name>" (go to them), cast as `cast '<spell>' <name>` and disabled with a reason on a client-known block. No game change — both are existing commands.

### Verification

The site needs the shared MariaDB + host agent to run end-to-end, so this was verified as far as the sandbox allows:

- **Visual proof against the real code:** a headless-Chromium harness drives the actual `hud-map.js` with demo data and screenshots the result — the 💀 skull + danger ring, teal group pips with initials, the filterable picker (Adjacent + Explored), and the Jump menu. The discovered-zone gate is proven with a 5-person demo group: a mate in an explored neighbor is offered as a cross-zone jump while a mate in a never-visited zone is withheld. Screenshots were shared with the owner in the session.
- The regroup-menu logic (exact-name match, `cast` syntax, mana-gated disable) is unit-checked in node; the menu render path itself needs the full HUD DOM, so it's left to the owner's demo-mode check (both spells were added to the demo skill list).
- `node --check` on both changed JS files; `python3 -m py_compile` on the views/urls.
- **Not verified here:** `manage.py check` / the new endpoint against a live DB (Django isn't installed in the sandbox) — an on-prod sanity check with an account spanning several zones is left to the owner.

Game-side enablers: isharmud/ishar-mud#1834 (PR isharmud/ishar-mud#1835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAJiPoNRLU8yo1o5zYTKSW