### PR TITLE
Surface Open/Close on locked containers in HUD

### DIFF
--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -3113,11 +3113,12 @@
             if (hasContents) acts.push({ label: "Loot all", cmd: "get all from " + h });
             if (it.harvest) acts.push(harvestAction(it.harvest, h));
         } else if (isContainer) {
-            if (it.locked) {
-                // Honest verb: the game refuses Open on a locked container,
-                // so surface the state instead of a dead action.
-                acts.push({ label: "Locked", disabled: true });
-            } else if (it.closeable) {
+            // Offer Open/Close on any closeable container, locked included: a
+            // locked coffer is closed, so this reads "Open" and the game
+            // refuses it server-side ("It's locked.") — surfacing the verb the
+            // player would reach for beats a dead "Locked" row that offers no
+            // way to try. Mirrors the inventory container menu.
+            if (it.closeable) {
                 acts.push(it.closed ? { label: "Open", cmd: "open " + h } : { label: "Close", cmd: "close " + h });
             }
             if (!it.closed && hasContents) acts.push({ label: "Get all from", cmd: "get all from " + h });


### PR DESCRIPTION
## Summary

Changed the container action menu in the HUD to offer Open/Close verbs on locked containers instead of showing a disabled "Locked" row. This aligns with game behavior (the server refuses the action with "It's locked.") and mirrors the inventory container menu UX.

## Changes

- Removed the special case that displayed a disabled "Locked" action for locked containers
- Restructured the condition to offer Open/Close on any closeable container, regardless of lock state
- Updated the comment to explain the rationale: a locked container is still closed, so "Open" is the verb a player would reach for; letting the game refuse it server-side is better UX than a dead action that offers no way to try

## Implementation Details

The change treats locked containers like any other closeable container. When a player attempts to open a locked container, the game responds with "It's locked." — surfacing the action the player expects to work (rather than a disabled "Locked" row) reduces friction and matches the behavior of the inventory container menu.

https://claude.ai/code/session_01AyJrAJjt4qJPovLBo1FYhH