### PR TITLE
Fix zone-pick list scrolling by preventing flex shrinkage

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -494,6 +494,10 @@ body.connect-page #content { padding: .5rem !important; }
     display: flex; flex-direction: column; gap: 1px;
     max-height: min(46vh, 320px); overflow-y: auto;
 }
+/* overflow:hidden on a row zeroes its automatic min-height, so without this the
+   flex column shrinks rows to fit the cap — squashing names — instead of
+   scrolling. Children keep their natural height; the list scrolls. */
+.zone-pick-h, .zone-pick-row, .zone-pick-empty { flex-shrink: 0; }
 .zone-pick-h {
     font-size: .62rem; font-weight: 700; letter-spacing: .05em;
     text-transform: uppercase; color: var(--ac-dim);

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -97,8 +97,7 @@
                 <input type="checkbox" data-setting="titleBadge">
                 <span>Unread count in the tab title</span>
             </label>
-            {# Desktop notifications — the whole group hides when the browser
-               has no Notification API (e.g. iOS Safari outside a PWA). #}
+            {# Group hidden when the browser has no Notification API (e.g. iOS Safari outside a PWA). #}
             <div class="setting-group setting-notify-group">
                 <div class="setting-group-h">Notify while the tab is hidden</div>
                 <label class="setting-row setting-notify">


### PR DESCRIPTION
## Summary

Fixes a layout bug in the zone-pick list where the flex column was shrinking rows to fit the max-height cap instead of scrolling, causing character names to be squashed.

## Changes

- **CSS (`hud.css`):** Added `flex-shrink: 0` to `.zone-pick-h`, `.zone-pick-row`, and `.zone-pick-empty` to preserve their natural heights while allowing the parent container to scroll. Included an explanatory comment documenting why this is necessary (overflow:hidden on the parent zeroes automatic min-height, causing unwanted shrinkage).

- **Template (`connect.html`):** Simplified an overly verbose comment about desktop notifications to a single line, removing redundant phrasing while preserving the essential information about iOS Safari PWA behavior.

## Implementation Details

The fix leverages a CSS flexbox quirk: when a flex container has `overflow: hidden`, its children lose their automatic min-height, causing the flex column to shrink rows to fit the cap rather than scroll. Setting `flex-shrink: 0` on the row elements prevents this shrinkage and allows the list to scroll naturally while children maintain their natural height.

https://claude.ai/code/session_01H2YvYrbKH9vZgxV6ZbCH3P