### PR TITLE
Rebuild the HUD night-sky readout as a fixed comet + four-moon strip

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -26,6 +26,7 @@
     --hud-edge: #d08a3a;
     --hud-event: #e8b04b;
     --hud-moon: #9aa6c8;
+    --hud-moon-down: rgba(154, 166, 200, .22);
     --hud-hostile: var(--ac-danger);
     --hud-friendly: var(--ac-ok);
     --hud-group: #3fb6a8;
@@ -188,8 +189,9 @@ body.connect-page #content { padding: .5rem !important; }
 .v-clock { color: var(--ac-text); white-space: nowrap; }
 .v-season { color: var(--ac-accent); font-weight: 700; white-space: nowrap; padding: 1px 8px; border: 1px solid rgba(255, 170, 119, .45); background: var(--ac-wash); border-radius: 999px; }
 .v-event { color: var(--hud-event); white-space: nowrap; }
-.v-moon { color: var(--hud-moon); white-space: nowrap; }
-.v-moon-icon { font-weight: 700; }
+.v-moons { display: inline-flex; align-items: center; gap: 5px; }
+.v-moon { color: var(--hud-moon); font-weight: 700; font-size: 1.05em; line-height: 1; cursor: default; }
+.v-moon.is-down { color: var(--hud-moon-down); }
 
 @media (max-width: 767.98px) {
     #hud-topbar { gap: 8px; }

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -660,18 +660,29 @@
         return { n: "N", s: "S", e: "E", w: "W", ne: "NE", nw: "NW", se: "SE", sw: "SW" }[d] || String(d);
     }
 
-    // Moons: per-moon colour (matching the game's @c tints) + an illumination
-    // glyph by phase. Ready for a richer Game.Time.moons feed
-    // ({name, phase 0-7, phase_name, up}); degrades to a plain glyph for the
-    // current name-only payload.
-    var MOON_COLOR = { shavar: "#cfd6e6", tregalien: "#e8c14b", fandaro: "#6fce7a", chenchir: "#d05a5a" };
-    var MOON_GLYPH = ["○", "◔", "◑", "◕", "●", "◕", "◑", "◔"];   // new → waning crescent
-    function moonColor(m) {
-        var key = String(m.name || "").toLowerCase().replace(/[^a-z].*$/, "");
-        return MOON_COLOR[key] || "var(--hud-moon)";
-    }
+    // The night-sky strip: Saorin (the wandering comet) then the four moons, in
+    // fixed celestial order so the world bar never reflows as bodies rise and
+    // set. Game.Time carries only the above-horizon moons (matching a normal
+    // player's `look sky`), each keyed by `id`; a moon absent from the feed is
+    // down and drawn as an unlit disc, its phase never revealed. Saorin is a
+    // stub — no feed data yet — and holds its slot as an unlit comet.
+    var MOON_SLOTS = [
+        { id: 0, name: "Shavar",    color: "#cfd6e6" },
+        { id: 1, name: "Tregalien", color: "#e8c14b" },
+        { id: 2, name: "Fandaro",   color: "#6fce7a" },
+        { id: 3, name: "Chenchir",  color: "#d05a5a" }
+    ];
+    var MOON_PHASE_GLYPH = ["○", "◔", "◑", "◕", "●", "◕", "◑", "◔"];   // new → waning crescent
     function moonGlyph(m) {
-        return (typeof m.phase === "number" && m.phase >= 0 && m.phase <= 7) ? MOON_GLYPH[m.phase] : "☽";
+        return (typeof m.phase === "number" && m.phase >= 0 && m.phase <= 7) ? MOON_PHASE_GLYPH[m.phase] : "☽";
+    }
+    // Hover detail mirrors `look sky`: "Name — phase", then position · luminosity.
+    function moonTip(name, m) {
+        var tip = name + " — " + (m.phase_name || "up");
+        var detail = [];
+        if (m.position) detail.push(m.position);
+        if (m.light) detail.push(m.light);
+        return detail.length ? tip + "\n" + detail.join(" · ") : tip;
     }
 
     function completions() {
@@ -997,13 +1008,28 @@
             (tm.events || []).forEach(function (e) {
                 world.appendChild(el("span", { class: "v-event", title: "Global event", text: "⚑ " + e.name + (e.seconds ? " (" + fmtDur(e.seconds) + ")" : "") }));
             });
-            (tm.moons || []).forEach(function (m) {
-                var span = el("span", { class: "v-moon", title: "Moon" + (m.phase_name ? " — " + m.phase_name : "") }, [
-                    el("span", { class: "v-moon-icon", style: "color:" + moonColor(m), text: moonGlyph(m) }),
-                    " " + m.name + (m.phase_name ? " (" + m.phase_name + ")" : "")
-                ]);
-                world.appendChild(span);
+            var moons = el("div", { class: "v-moons" });
+            moons.appendChild(el("span", {
+                class: "v-moon v-comet is-down", text: "☄",
+                title: "Saorin — the wandering comet is not in the sky"
+            }));
+            var upById = {};
+            (tm.moons || []).forEach(function (m) { if (m && m.id != null) upById[m.id] = m; });
+            MOON_SLOTS.forEach(function (slot) {
+                var m = upById[slot.id];
+                if (m) {
+                    moons.appendChild(el("span", {
+                        class: "v-moon is-up", style: "color:" + slot.color,
+                        title: moonTip(slot.name, m), text: moonGlyph(m)
+                    }));
+                } else {
+                    moons.appendChild(el("span", {
+                        class: "v-moon is-down", text: "●",
+                        title: slot.name + " — not currently in the sky"
+                    }));
+                }
             });
+            world.appendChild(moons);
         } else {
             world.appendChild(el("span", { class: "v-clock dim", text: "☾ —" }));
         }
@@ -4663,7 +4689,7 @@
         var feeds = {
             "Char.Status": { name: "Aelwyn", "class": "Magician", race: "Elf", position: "Standing", level: 45, align: 350, xp: 1250000, tnl: 48000, gold: 18230, bank: 500000, remort: 3 },
             "Char.Vitals": { hp: 412, maxhp: 480, mp: 130, maxmp: 300, move: 198, maxmove: 240, position: "Standing", opponent_hp_pct: 35, metamagic: 60, metamagic_max: 100, metamagic_regen: 5, food: 27, water: 9 },
-            "Game.Time": { hour: 21, hour12: 9, ampm: "pm", day: 14, day_name: "Sunday", month: 6, month_name: "the Long Shadows", year: 1247, night: true, season_id: 15, season_end: 0, events: [{ name: "Double Essence", seconds: 5400 }, { name: "Festival of Flames" }], moons: [{ name: "Shavar", phase: 4, phase_name: "full", up: true }, { name: "Chenchir", phase: 6, phase_name: "last quarter", up: true }] },
+            "Game.Time": { hour: 21, hour12: 9, ampm: "pm", day: 14, day_name: "Sunday", month: 6, month_name: "the Long Shadows", year: 1247, night: true, season_id: 15, season_end: 0, events: [{ name: "Double Essence", seconds: 5400 }, { name: "Festival of Flames" }], moons: [{ id: 0, name: "Shavar", phase: 4, phase_name: "full", position: "almost directly overhead", light: "blazing bright", up: true }, { id: 3, name: "Chenchir", phase: 6, phase_name: "last quarter", position: "lowering through the western sky", light: "fading", up: true }] },
             "Room.Info": { num: 3001, name: "The Grand Concourse", area: "Ishar Nexus", environment: "City", exits: { n: 3002, e: 3005, s: 3008, w: 3010, u: 3100, d: 3200, into: 3500 } },
             "Room.Occupants": { occupants: [
                 { keyword: "guard", short_desc: "a towering city guard", handle: "1.guard", is_player: false, is_dead: false, is_shopkeeper: false, hostile_hint: "neutral", position: "Standing", is_loyal_follower: false, is_my_follower: false, fighting_you: false, is_your_target: false },

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1919,3 +1919,31 @@ Empty state is "Nothing else here." only when all three lists are empty.
 Discipline unchanged: `el()`/`textContent`, tokens only, no new tap-target
 patterns. Verify with the demo feed (corpse with loot, locked chest, scenery
 fountain, three nodes across the tier spread).
+
+## 2026-07-19 — HUD night-sky strip: fixed comet + four moons, detail on hover
+
+**Problem.** The world bar printed each visible moon inline as `icon Name
+(phase)`, so its width jumped every time a moon rose or set — motion in a bar
+players glance at mid-combat — and each moon carried only a name and phase where
+`look sky` also gives sky position and luminosity.
+
+**Decision.** Render a fixed five-slot strip (`.v-moons`): Saorin (the wandering
+comet) then the four moons in celestial order (Shavar, Tregalien, Fandaro,
+Chenchir). Slots are always present, so the bar never reflows:
+
+- An **up** moon shows its phase glyph (`○◔◑◕●…`) tinted to the game's `@c`
+  colour; a **down** moon is an unlit disc (`--hud-moon-down`); **Saorin** is a
+  stub with no feed data yet and holds its slot as an unlit comet (`☄`).
+- **Detail moves to the native `title` tooltip**: `Name — phase`, then
+  `position · luminosity` — the same descriptors `look sky` prints.
+
+**Data.** Game.Time `moons[]` gains `position` + `light` per moon (ishar-mud
+#1843, GMCP contract 11.7.0). The feed still carries only above-horizon moons
+(a normal player's `look sky`), so a down moon's phase is never revealed — the
+client fills the missing slots itself from the fixed four-moon set (keyed by
+`id`). Saorin data is deferred; the comet is inert today.
+
+**Notes.** Phase glyphs stay Unicode (Bootstrap Icons has no partial phases);
+the comet is `☄`. Discipline unchanged: `el()`/`textContent`, tokens only,
+motion-free. Verified with the demo feed plus a self-contained CSS preview
+(up/down mix, all-phases legibility, nothing-up, 390px).

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -109,7 +109,8 @@ rest have no site-wide equivalent:
 | `--hud-mm` | `#a05ad0` | Metamagic bar. |
 | `--hud-edge` | `#d08a3a` | Edge resource bar. |
 | `--hud-event` | `#e8b04b` | World event flags. |
-| `--hud-moon` | `#9aa6c8` | Moon phases. |
+| `--hud-moon` | `#9aa6c8` | Moon phases (default; each up moon is tinted to its game `@c` colour inline). |
+| `--hud-moon-down` | `rgba(154,166,200,.22)` | An unlit body in the night-sky strip — a down moon or the Saorin comet stub. |
 | `--hud-ter-*` | see below | Map terrain fills (canvas reads them via `getComputedStyle`). |
 
 **Map terrain fills** (`--hud-ter-*`): muted, desaturated room fills for the


### PR DESCRIPTION
Closes #152

### Problem

The world bar rendered one span per visible moon as `icon Name (phase)`, so its width jumped every time a moon rose or set — motion in a bar players glance at mid-combat — and each moon carried only a name and phase where `look sky` also gives sky position and luminosity. Several players and the developer drive the game from phones, where a reflowing bar and verbose labels waste scarce width.

### Solution

A fixed five-slot strip (`.v-moons`): Saorin (the wandering comet) then the four moons in celestial order (Shavar, Tregalien, Fandaro, Chenchir). The slots are always present, so the bar never reflows as bodies rise and set:

- an **up** moon shows its phase glyph (`○◔◑◕●…`, Unicode — Bootstrap Icons has no partial phases) tinted to the game's `@c` colour;
- a **down** moon is an unlit disc (new `--hud-moon-down` token);
- **Saorin** is a stub — no feed data yet — and holds its slot as an unlit comet (`☄`).

Everything else moves to the native `title` tooltip: `Name — phase`, then `position · luminosity`, mirroring `look sky`. The client keys up-moons by `id` and fills the remaining slots from the fixed four-moon set, so a below-horizon moon's phase is never shown (matching what the feed already withholds). Needs the paired `position`/`light` fields from isharmud/ishar-mud#1843. ADR recorded in `docs/design/decisions.md`.

### Verification

- `node --check apps/connect/static/js/hud.js` — parses.
- Rendered a faithful self-contained `preview.html` (the touched CSS + the exact DOM `renderVitals` builds) with headless Chromium across four states: the demo feed (Shavar full + Chenchir last-quarter up, Tregalien/Fandaro down, comet stub), an all-four-up phase-legibility row, the nothing-up daytime state, and 390px phone width. All read cleanly and the strip holds a stable width in every state; up moons are colour-distinct, down moons and the comet read as unlit.
- Not run against the live websocket bridge; the demo `Game.Time` feed was updated to carry `id`/`position`/`light` and exercises the new render path.

### Deploy notes

`static/` is gitignored; `hud.css` and `hud.js` were force-added. `collectstatic` runs on container start, so the deploy picks them up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mcj3wQ8iKA626q6eXomVhh)_