### PR TITLE
Add target cycling and the attack/assist cluster to the HUD

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -172,6 +172,9 @@ body.connect-page #content { padding: .5rem !important; }
 .v-tgt { font-size: .7rem; font-weight: 700; padding: 1px 8px; border-radius: 999px; border: 1px solid; max-width: 12rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .v-tgt.hostile { color: var(--hud-hostile); border-color: rgba(214, 75, 75, .5); background: var(--ac-danger-wash); }
 .v-tgt.friendly { color: var(--hud-friendly); border-color: rgba(76, 187, 23, .5); background: var(--ac-ok-wash); }
+/* The hostile chip is a button (tap = cycle); keep the pill look. */
+button.v-tgt { font-family: inherit; margin: 0; cursor: pointer; }
+button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 /* Target-of-target readout beside the Foe bar: who your foe is swinging at. */
 .v-foe-tgt { flex: none; font-size: .7rem; color: var(--ac-dim); white-space: nowrap; align-self: center; }
 .v-foe-tgt.you { color: var(--hud-hostile); font-weight: 700; }
@@ -601,6 +604,8 @@ body.connect-page #content { padding: .5rem !important; }
 .occ-row.friendly { border-left-color: var(--hud-friendly); }
 .occ-row.neutral { border-left-color: var(--ac-border-2); }
 .occ-row.is-dead { opacity: .5; cursor: default; }
+/* The ⚔ target's row — the Alt+T cycle is legible in the panel, not just the chip. */
+.occ-row.is-tgt { background: var(--ac-danger-wash); }
 .occ-icon { flex: none; width: 1rem; text-align: center; color: var(--ac-dim); }
 .occ-row.hostile .occ-icon { color: var(--hud-hostile); }
 .occ-row.friendly .occ-icon { color: var(--hud-friendly); }
@@ -1099,6 +1104,38 @@ body.connect-page #content { padding: .5rem !important; }
    hidden — the dock is the phone's micro-menu. */
 #hud-actionrow { display: flex; gap: 8px; align-items: center; flex: none; min-width: 0; }
 #hud-actionrow #hud-hotbar { flex: 1 1 auto; min-width: 0; }
+
+/* ----- Attack cluster: the attack/assist tile + the ⚔ target chip it fires at.
+   Heads the action row; the chip is the phone's target readout (the vitals
+   target chips are desktop-only). Armed = a target is set (kill); otherwise
+   the tile assists (joins the group's fight). ----- */
+#hud-attack { display: flex; align-items: center; gap: 5px; flex: none; min-width: 0; }
+#hud-attack[hidden] { display: none; }
+.skill--attack .skill-icon { color: var(--ac-text); }
+.skill--attack.armed { border-bottom-color: var(--ac-danger); }
+.skill--attack.armed .skill-icon { color: var(--hud-hostile); }
+.atk-chip { display: flex; align-items: stretch; min-width: 0; }
+.atk-tgt {
+    min-width: 0; max-width: 9rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-family: inherit; font-size: .7rem; font-weight: 700; line-height: 1.2;
+    margin: 0; padding: 2px 8px; cursor: pointer;
+    color: var(--ac-dim); background: var(--ac-elev);
+    border: 1px solid var(--ac-border); border-radius: 999px;
+}
+.atk-tgt:hover { border-color: var(--ac-accent); color: var(--ac-text); }
+.atk-tgt.hostile {
+    color: var(--hud-hostile); background: var(--ac-danger-wash);
+    border-color: rgba(214, 75, 75, .5); border-radius: 999px 0 0 999px; border-right: 0;
+}
+.atk-tgt.hostile:hover { color: var(--hud-hostile); border-color: rgba(214, 75, 75, .8); }
+.atk-tgt.fired { border-color: var(--ac-accent); }
+.atk-x {
+    flex: none; margin: 0; padding: 2px 8px 2px 6px; cursor: pointer;
+    font-family: inherit; font-size: .7rem; font-weight: 700; line-height: 1.2;
+    color: var(--hud-hostile); background: var(--ac-danger-wash);
+    border: 1px solid rgba(214, 75, 75, .5); border-left: 0; border-radius: 0 999px 999px 0;
+}
+.atk-x:hover { color: #fff; }
 #hud-micro { display: flex; gap: 4px; flex: none; margin-left: auto; }
 .micro-btn {
     position: relative; width: 32px; height: 32px; padding: 0; cursor: pointer; overflow: hidden;
@@ -1122,7 +1159,7 @@ body.connect-page #content { padding: .5rem !important; }
     background: var(--hud-event); pointer-events: none;
 }
 .micro-strip[hidden] { display: none; }
-@media (max-width: 767.98px) { #hud-micro { display: none; } }
+@media (max-width: 767.98px) { #hud-micro { display: none; } .atk-tgt { max-width: 7rem; } }
 
 /* ----- Overlay window (micro-menu apps, desktop) ----- */
 #hud-overlay {

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -982,7 +982,7 @@
         // Active default targets, so target-aware casting is legible at a glance.
         if (S.tgtHostile || S.tgtFriendly) {
             var tk = [];
-            if (S.tgtHostile) tk.push(el("span", { class: "v-tgt hostile", title: "Offensive spells target this", text: "⚔ " + S.tgtHostile.desc }));
+            if (S.tgtHostile) tk.push(el("button", { type: "button", class: "v-tgt hostile", "data-act": "cycle-target", title: "Offensive spells + Attack target this — tap to cycle (Alt+T)", text: "⚔ " + S.tgtHostile.desc }));
             if (S.tgtFriendly) tk.push(el("span", { class: "v-tgt friendly", title: "Beneficial spells target this", text: "✚ " + S.tgtFriendly.desc }));
             groups.push(el("div", { class: "v-group v-targets" }, tk));
         }
@@ -1168,6 +1168,7 @@
         renderGroup();       // member menus map onto occupant handles
         renderVitals();      // target chip + tank line live near the foe bar
         tickHotbar();        // target-aware labels
+        updateAttack();      // armed state + cycle count track the room
     }
 
     function setTarget(slot, occ) {
@@ -1178,6 +1179,63 @@
         renderOccupants();
         renderVitals();
         tickHotbar();
+        updateAttack();
+    }
+
+    // What Alt+T / Tab may aim the ⚔ target at: live NPCs that aren't vendors,
+    // followers, or friendly-hinted — those stay context-menu-only (the
+    // misclick-safety rule), as do players (PK is never one accidental
+    // keystroke). Hostiles and anyone beating on you outrank neutrals; within
+    // a tier, feed order (= parser order).
+    function attackables() {
+        var hot = [], cold = [];
+        (S.occupants || []).forEach(function (o) {
+            if (o.is_dead || o.is_player || o.is_shopkeeper) return;
+            if (o.is_loyal_follower || o.is_my_follower) return;
+            if (o.hostile_hint === "friendly") return;
+            (o.hostile_hint === "hostile" || o.fighting_you ? hot : cold).push(o);
+        });
+        return hot.concat(cold);
+    }
+    function cycleTarget(dir) {
+        var list = attackables();
+        if (!list.length) return false;
+        dir = dir < 0 ? -1 : 1;
+        var i = -1;
+        if (S.tgtHostile) {
+            for (var j = 0; j < list.length; j++) {
+                if (list[j].handle === S.tgtHostile.handle) { i = j; break; }
+            }
+        }
+        var o = i < 0 ? list[dir > 0 ? 0 : list.length - 1]
+                      : list[(i + dir + list.length) % list.length];
+        S.tgtHostile = { handle: o.handle, desc: stripColor(o.short_desc || o.keyword) };
+        renderOccupants();
+        renderVitals();
+        tickHotbar();
+        updateAttack(true);
+        return true;
+    }
+    function clearTarget() {
+        if (!S.tgtHostile) return;
+        S.tgtHostile = null;
+        renderOccupants();
+        renderVitals();
+        tickHotbar();
+        updateAttack();
+    }
+
+    // The attack control resolves at press time: kill the ⚔ target, else bare
+    // `assist` — the game then picks whoever is fighting you or your group,
+    // so "no target" is the join-the-fight path, never an auto-picked victim.
+    function attackCommand() {
+        return S.tgtHostile ? "kill " + S.tgtHostile.handle : "assist";
+    }
+    function fireAttack() {
+        if (!S.connected) return false;
+        sendCmd(attackCommand());
+        if (dom.attackBtn) flashSlot(dom.attackBtn);
+        return true;
     }
 
     function occHostileClass(o) {
@@ -1264,8 +1322,9 @@
                     var ptag = (o.position && posLower(o) !== "standing")
                         ? posLower(o) : "";
                     var fight = occFightLabel(o);
+                    var isTgt = S.tgtHostile && S.tgtHostile.handle === o.handle;
                     var row = el("li", {
-                        class: "occ-row " + occHostileClass(o),
+                        class: "occ-row " + occHostileClass(o) + (isTgt ? " is-tgt" : ""),
                         "data-menu": "occupant", "data-idx": i,
                         title: "Tap for actions"
                     }, [
@@ -2540,6 +2599,63 @@
     }
 
     // ------------------------------------------------------------------
+    // Attack cluster (#hud-attack) — the persistent attack/assist tile plus
+    // the ⚔ target chip that feeds it. Heads the action row so target and
+    // act sit together, and stays visible on phones (the vitals target
+    // chips are desktop-only).
+    // ------------------------------------------------------------------
+    function buildAttack() {
+        if (!dom.attack) return;
+        dom.attackBtn = el("button", {
+            type: "button", class: "skill skill--attack", "data-act": "attack"
+        }, [
+            iconSvg("crossed-swords", "gi skill-icon"),
+            el("span", { class: "skill-key", text: "A" })
+        ]);
+        dom.attackChip = el("span", { class: "atk-chip" });
+        dom.attack.appendChild(dom.attackBtn);
+        dom.attack.appendChild(dom.attackChip);
+        updateAttack();
+    }
+    function updateAttack(pulse) {
+        if (!dom.attackBtn) return;
+        dom.attack.hidden = !S.connected;
+        var t = S.tgtHostile;
+        dom.attackBtn.classList.toggle("armed", !!t);
+        dom.attackBtn.setAttribute("aria-label",
+            (t ? "Attack " + t.desc : "Assist — join your group's fight") + " (Alt+A)");
+        var kids = [el("button", {
+            type: "button", class: "atk-tgt" + (t ? " hostile" : ""),
+            "data-act": "cycle-target",
+            "aria-label": (t ? "Target: " + t.desc : "No target") + " — cycle (Alt+T)",
+            text: t ? "⚔ " + t.desc : "⌖ no target"
+        })];
+        if (t) kids.push(el("button", {
+            type: "button", class: "atk-x", "data-act": "clear-target",
+            "aria-label": "Clear target", text: "✕"
+        }));
+        fill(dom.attackChip, kids);
+        if (pulse) flashSlot(dom.attackChip.firstChild);
+        if (tipAnchor && dom.attack.contains(tipAnchor)) hideTip();
+    }
+    // Structured tips for the cluster (tipDataFor routes here): each control
+    // names its hotkey and previews the exact command it will send.
+    function attackTipData(act) {
+        var t = S.tgtHostile;
+        if (act === "attack") {
+            return t ? { name: "Attack " + t.desc, key: "Alt+A", sub: "kill " + t.handle }
+                     : { name: "Assist", key: "Alt+A", sub: "join your group's fight — no ⚔ target" };
+        }
+        if (act === "cycle-target") {
+            var n = attackables().length;
+            return { name: t ? t.desc : "No ⚔ target", key: "Alt+T",
+                     sub: n ? "cycle " + n + " target" + (n === 1 ? "" : "s") + " · Tab on empty input"
+                            : "nothing attackable here" };
+        }
+        return { name: "Clear target" };
+    }
+
+    // ------------------------------------------------------------------
     // Tooltip convention (.hud-tip)
     // ------------------------------------------------------------------
     // The HUD's one hover/focus tooltip. Deliberately terse — a title line, an
@@ -2597,12 +2713,14 @@
             var s = skillById(ab.getAttribute("data-ability"));
             return s ? skillTipData(s, ab.getAttribute("data-key")) : null;
         }
+        var atk = t.closest && dom.attack && t.closest("#hud-attack [data-act]");
+        if (atk) return attackTipData(atk.getAttribute("data-act"));
         if (t.getAttribute && t.getAttribute("data-tip")) return { name: t.getAttribute("data-tip") };
         return null;
     }
     function wireTooltips() {
         if (!dom.app) return;
-        var SEL = ".skill[data-ability],[data-tip]";
+        var SEL = ".skill[data-ability],#hud-attack [data-act],[data-tip]";
         dom.app.addEventListener("mouseover", function (e) {
             if (!mqHover.matches) return;
             var t = e.target.closest(SEL);
@@ -2670,11 +2788,14 @@
         });
     }
 
-    // Global hotkeys: Alt/Ctrl + 1..0 fire the visible bar's slots; Alt+` pages.
+    // Global hotkeys: Alt/Ctrl + 1..0 fire the visible bar's slots; Alt+` pages;
+    // Alt+T cycles the ⚔ target (Shift reverses) and Alt+A attacks/assists.
     // Browsers reserve Ctrl+digit for tab-switching and web content usually can't
     // veto that, so Alt+digit is the reliable path (works in Chrome/Chromium/
     // Safari; Firefox reserves Alt+digit too). Ctrl is offered as a bonus that
     // comes fully alive when the HUD runs installed/fullscreen (no tab strip).
+    // Alt+letter is the "act" family (Ctrl+letter opens overlays); Ctrl+T could
+    // never work anyway — the browser owns it.
     function wireHotkeys() {
         document.addEventListener("keydown", function (e) {
             // Overlay keys are gated on the HUD only, not the connection —
@@ -2707,6 +2828,18 @@
                 }
             }
             if (!S.connected) return;
+            // Combat keys — Alt+letter (the "act" modifier, like the bar's
+            // Alt+digit). By e.code, not e.key: macOS Alt+letter yields
+            // composed characters ("†"), Shift changes case.
+            var altCombo = e.altKey && !e.ctrlKey && !e.metaKey;
+            if (altCombo && e.code === "KeyT") {
+                if (cycleTarget(e.shiftKey ? -1 : 1)) e.preventDefault();
+                return;
+            }
+            if (altCombo && !e.shiftKey && e.code === "KeyA") {
+                if (fireAttack()) e.preventDefault();
+                return;
+            }
             if (e.key === "`" && e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
                 if (usedPages() > 1) { e.preventDefault(); flipHotbarPage(); }
                 return;
@@ -4157,6 +4290,15 @@
         var lockBtn = e.target.closest("[data-lock]");
         if (lockBtn && dom.app.contains(lockBtn)) { toggleBarLock(); return; }
 
+        // 2a2) Attack cluster + the vitals ⚔ chip: fire, cycle, or clear.
+        var act = e.target.closest("[data-act]");
+        if (act && dom.app.contains(act)) {
+            var an = act.getAttribute("data-act");
+            if (an === "attack") { fireAttack(); return; }
+            if (an === "cycle-target") { cycleTarget(1); return; }
+            if (an === "clear-target") { clearTarget(); return; }
+        }
+
         // 2b) Edit mode (unlocked): a tap on a slot rearranges instead of firing —
         // pick a slot, then tap where it should go. Prevents accidental casts.
         if (!barLocked) {
@@ -4412,6 +4554,7 @@
     function setConnected(on) {
         S.connected = !!on;
         renderVitals();
+        updateAttack();
         if (mapMod) mapMod.onConnected(S.connected);
     }
 
@@ -4435,7 +4578,8 @@
     function renderAll() {
         renderVitals(); renderSelfAffects(); renderRoom(); renderOccupants(); renderGroup();
         renderEquipment(); renderInventory(); renderTrain(); renderXp(); renderTracked();
-        renderWho(); renderChat(); renderHotbar(); renderAbilities(); renderProfessions(); updateMicro();
+        renderWho(); renderChat(); renderHotbar(); renderAbilities(); renderProfessions();
+        updateMicro(); updateAttack();
     }
     function reset() {
         S.vitals = null; S.status = null; S.time = null; S.room = null;
@@ -4485,6 +4629,7 @@
         dom.chat = document.getElementById("panel-chat");
         dom.who = document.getElementById("panel-who");
         dom.hotbar = document.getElementById("hud-hotbar");
+        dom.attack = document.getElementById("hud-attack");
         dom.xpstrip = document.getElementById("hud-xpstrip");
         dom.xpFill = dom.xpstrip && dom.xpstrip.querySelector(".xp-fill");
         dom.xpLabel = dom.xpstrip && dom.xpstrip.querySelector(".xp-label");
@@ -4511,6 +4656,7 @@
         dom.app.addEventListener("click", onAppClick);
         dom.app.addEventListener("contextmenu", onAppContext);
         wireHotbarDrag();
+        buildAttack();
         wireHotkeys();
         wireTooltips();
         loadQuestTracked();
@@ -4810,5 +4956,5 @@
         setConnected(true);
     }
 
-    window.IsharHUD = { init: init, onGmcp: onGmcp, reset: reset, setConnected: setConnected, completions: completions, demo: demo, registerMap: registerMap };
+    window.IsharHUD = { init: init, onGmcp: onGmcp, reset: reset, setConnected: setConnected, completions: completions, cycleTarget: cycleTarget, demo: demo, registerMap: registerMap };
 })();

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -190,6 +190,9 @@
            docs/design/decisions.md "The HUD extension model". Buttons are
            revealed by hud.js when the matching feed has data. -->
         <div id="hud-actionrow">
+            <!-- Attack cluster (attack/assist tile + ⚔ target chip); hud.js
+               builds and maintains it. Alt+A fires, Alt+T / chip-tap cycles. -->
+            <div id="hud-attack"></div>
             <div id="hud-hotbar" class="empty"></div>
             <nav id="hud-micro" aria-label="Overlay windows">
                 <button type="button" class="micro-btn" data-overlay="inventory" hidden
@@ -909,6 +912,11 @@
                 sysln("Tab completes from your history and the game (exits, skills, names);");
                 sysln("Shift+Tab cycles backward. Arrows recall history (clock button on touch).");
                 sysln("Ctrl+L clears. PageUp/PageDown scroll. Ctrl+Shift+F searches scrollback.");
+                sysln("Targeting: Alt+T (or Tab on an empty line) cycles the ⚔ target through");
+                sysln("      the room's attackables; Shift reverses; the chip by the action bar");
+                sysln("      shows it (tap to cycle, ✕ to clear). Alt+A / the crossed-swords");
+                sysln("      tile attacks it — with no target it sends `assist` to join your");
+                sysln("      group's fight.");
                 sysln("Action bar: Alt+1..0 fire the bar's slots (Ctrl+1..0 too when the page");
                 sysln("      is installed/fullscreen — tabbed browsers reserve Ctrl+digit). Alt+`");
                 sysln("      switches bar pages. Pin skills from the Abilities panel and");
@@ -1135,6 +1143,14 @@
     commandInput.addEventListener("keydown", function(e) {
         if (e.key === "Tab") {
             e.preventDefault();
+            // Completion owns Tab only once a word precedes the caret; on an
+            // empty line Tab cycles the HUD's ⚔ target instead (the MUD
+            // tab-targeting reflex — Alt+T works everywhere too).
+            var head = commandInput.value.slice(0, commandInput.selectionStart);
+            if (!tabState && !/\S/.test(head) && window.IsharHUD && window.IsharHUD.cycleTarget) {
+                window.IsharHUD.cycleTarget(e.shiftKey ? -1 : 1);
+                return;
+            }
             tabComplete(e.shiftKey);
             return;
         }

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -501,6 +501,16 @@ same conventions (radii, focus, coarse-pointer, reduced-motion). Highlights:
   and 2026-07-19 decisions. Hotkeys: **Alt/Ctrl+1…0** fire, **Alt+`** pages.
   **Locked by default** (taps fire); unlock to edit — `#hud-hotbar.editing` gets
   grab cursors and a `.skill.picked` slot awaits its destination (tap-to-swap).
+- **`#hud-attack` attack/assist cluster** — heads the action row: a
+  `.skill--attack` tile (crossed swords, key badge "A") + the `.atk-tgt`
+  target chip (with `.atk-x` clear). `Alt+A`/tap sends `kill <handle>` when
+  the ⚔ target is set (`.armed`, danger accent), bare `assist` when not.
+  `Alt+T` / chip tap / `Tab` on an empty input cycles the target (hostiles +
+  anyone fighting you first, then neutrals; never players/shopkeepers/
+  followers/friendlies). The chip is the phone's target readout; the vitals
+  ⚔ chip (`button.v-tgt`) cycles too, and the targeted Room row gets
+  `.occ-row.is-tgt`. Hidden until connected. Structured `.hud-tip`s preview
+  the exact command. See decisions.md 2026-07-19 (HUD combat layer II).
 - **Game-Icons.net sprite** (`img/game-icons.svg`, CC BY 3.0, self-hosted) —
   the **skill-art** vocabulary, a scoped exception to the Bootstrap-Icons-only
   rule (see decision). Referenced like `bi` but with class `gi`:

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,51 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-19 — HUD combat layer II: target cycling + the attack/assist cluster (Alt = act)
+
+**Decision.** The ⚔ default target graduates from a context-menu toggle to a
+first-class combat control, and attack becomes one press. Three pieces
+(isharmud/ishar-web#153):
+
+- **Cycling.** `Alt+T` (Shift reverses) — and `Tab` on an *empty* input line,
+  the MUD tab-targeting reflex; completion keeps Tab once a word precedes the
+  caret, so the two never collide. The cycle order is the Room panel's own:
+  hostiles and anyone `fighting_you` first, then neutrals, feed (= parser)
+  order within a tier, wrap-around. It never lands on players, shopkeepers,
+  followers, or friendly-hinted occupants — those stay context-menu-only
+  deliberate acts (the misclick-safety rule from combat layer I). Neutrals
+  ARE included: killable neutral mobs are the normal grind, and a
+  hostiles-only cycle would be useless most nights.
+- **The attack/assist cluster** (`#hud-attack`) heads the action row: a
+  `.skill`-chrome tile (crossed swords, key badge "A") plus the `.atk-tgt`
+  target chip. `Alt+A` / tap resolves at press time: target set →
+  `kill <handle>` (the server-computed round-trippable handle, never a name);
+  no target → bare `assist`, which the game resolves to whoever is fighting
+  you or your group. "No target" is thus the *join-the-fight* path — the
+  client never auto-picks a victim. Armed state = danger accent on tile +
+  chip; chip tap cycles, its `✕` clears, and the structured tooltip previews
+  the exact command (`kill 1.thug` / "join your group's fight").
+- **Surfacing.** The chip is the phone's target readout (vitals `.v-targets`
+  chips are desktop-only); the vitals ⚔ chip becomes a button that also
+  cycles; the targeted Room row gets an `.is-tgt` wash; `/help` documents the
+  keys. The cluster hides until connected — no dead furniture on the login
+  screen.
+
+**Why.** Melee had no HUD fast path for the game's most common action (three
+taps through a menu), and nothing surfaced `assist` at all. The pieces —
+handles, `S.tgtHostile`, target-aware casting — already existed; this is the
+missing input layer, not a new data model.
+
+**Notes.** Hotkey families are now: `Ctrl+letter` opens overlays,
+`Alt+letter/digit` **acts** (bar slots, `Alt+``` paging, now T/A). Combat keys
+match on `e.code` (`KeyT`/`KeyA`) — macOS Alt+letter composes characters and
+Shift changes case, so `e.key` is unreliable there. `Ctrl+T` was never an
+option (browser-reserved, uninterceptable). Stale-handle safety is unchanged:
+`applyOccupants` drops a dead/absent target, and the server re-validates every
+command. Verified end-to-end in the demo harness: simulated Alt+T/Alt+A and
+empty-input Tab produced `kill 1.thug` → `kill 1.bandit` → `assist` through
+the real keydown → `sendCmd` path, plus desktop/phone screenshots.
+
 ## 2026-07-19 — Quest Log overlay app + the tracked-objectives surface (a scoped tier-model amendment)
 
 **Decision.** The Quest Log ships as the seventh overlay app — **Ctrl+Q**,


### PR DESCRIPTION
Closes #153

### Problem

Melee characters had no HUD fast path for the game's most common action: the ⚔ default target could only be set by opening an occupant's context menu, and "attack" lived three taps deep inside that same menu — while casters already got target-aware bar slots. Nothing surfaced the game's `assist` command at all, even though it's the natural join-the-group's-fight action. On a phone, where several of the ~11 players live, that's the difference between joining the pull in time and typing `kill thug` into a moving scrollback.

### Solution

A new input layer over the *existing* target model — no new data model, no game changes (verified against `cmd_attack`/`cmd_assist` in ishar-mud and the `Room.Occupants` handle contract: handles round-trip through the same parser path `kill` uses, and bare `assist` already resolves to whoever is fighting you or your group).

- **Cycle:** `Alt+T` (Shift reverses) — and `Tab` on an *empty* input line, the MUD tab-target reflex. Tab was free to claim there because completion only owns Tab once a word precedes the caret, so the two paths can't collide. Cycling drives the existing `S.tgtHostile`, so target-aware casting benefits too. Order: hostiles + anyone `fighting_you` first, then neutrals, parser order, wrap-around — and it never lands on players, shopkeepers, followers, or friendlies (those stay deliberate context-menu acts, per the misclick-safety ADR). Neutrals are included on purpose: killable neutral mobs are the normal grind, and a hostiles-only cycle would be useless most nights.
- **Attack/assist:** `Alt+A`, mirrored by a crossed-swords tile heading the action row. The one non-obvious call: the command resolves **at press time** — target set → `kill N.keyword` (the server-computed round-trippable handle, never a display name); no target → bare `assist`. "No target" is therefore the join-the-fight path, and the client never auto-picks a victim.
- **Surfacing:** a live target chip beside the tile (tap = cycle, ✕ = clear) doubles as the phone's target readout, since the vitals `.v-targets` chips are desktop-only. Armed = danger accent on tile + chip; the vitals ⚔ chip became a cycle button; the targeted Room row gets an `.is-tgt` wash; tooltips carry the hotkey and preview the exact command; `/help` documents the keys. The cluster hides until connected.

Hotkey grammar is now: `Ctrl+letter` opens overlays, `Alt+letter/digit` acts. Combat keys match on `e.code` (`KeyT`/`KeyA`) because macOS Alt+letter composes characters and Shift changes case; `Ctrl+T` was never an option (browser-reserved, uninterceptable). Design call recorded in `docs/design/decisions.md` ("HUD combat layer II") plus a component-catalog entry.

### Verification

No live game/DB reachable from this environment; verified as far as the demo harness allows:

- `node --check` on `hud.js` and the extracted `connect.html` script block; Django template compile under stub settings.
- A demo-mode `preview.html` harness driving **real keydown events through the production code path**, with the send seam instrumented: simulated `Alt+T, Alt+A, Alt+T, Alt+A` produced `kill 1.thug` → `kill 1.bandit`; empty-input `Tab`/`Tab` cycled thug → bandit; chip-tap cycled, ✕ cleared, then `Alt+A` produced `assist`.
- Headless-Chromium screenshots at 1440px (armed state, assist state, Room-row highlight + panel chip) and **390px phone width** (tile + chip legible and tappable in the action row); screenshots delivered in the working session.
- Left to the on-prod test: the live websocket round-trip and feel-of-use in a real fight.

### Deploy notes

`hud.js` and `hud.css` are gitignored (`static/`) and were **force-added**; `collectstatic` on container start picks them up — no other deploy steps.