### PR TITLE
Make "Play Now" the site's first-class action

### DIFF
--- a/apps/clients/templates/clients.html
+++ b/apps/clients/templates/clients.html
@@ -85,7 +85,7 @@
         <span>
             Do not be afraid to try a few, as they all have different strengths and weaknesses.
             After you download a client, tell it to connect to <code>isharmud.com</code> on
-            port number <code>23</code> or <code>9999</code> to join the game &mdash;
+            port number <code>23</code> to join the game &mdash;
             and check out our
             <a href="{% url 'start' %}#start" title="getting started guide">getting started guide</a> as well!
         </span>

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -1186,6 +1186,9 @@ a.ac-link--featured:visited .ac-link__name { color: var(--ac-accent); }
 @media (max-width: 575.98px) {
     .ac-hero { flex-wrap: wrap; padding: .9rem 1rem; }
     .ac-hero__status { align-self: stretch; min-width: 0; }
+    /* A hero's primary CTA fills the width once the hero wraps, so the flagship
+       action is a full tap target on phones. */
+    .ac-hero__status:has(.ac-cta) { width: 100%; }
     /* Never clip a hero pill on a phone — let its text wrap instead. */
     .ac-hero__status .ac-pill { white-space: normal; }
     .ac-hero__badge { width: 2.6rem; height: 2.6rem; }

--- a/apps/core/static/css/style.css
+++ b/apps/core/static/css/style.css
@@ -94,6 +94,25 @@ svg.bi:not([width]) { width: 1em; height: 1em; }
 .nav-link .bi { color: var(--ishar-color); }
 footer a .bi { color: var(--ac-dim); }
 
+/* Play Now — the one amber-filled item in the bar. Playing is the site's
+   first-class action, so its nav entry reads as a button, not a text link. */
+.navbar .nav-link.nav-cta {
+    color: #231005;
+    background: linear-gradient(180deg, #ffb385 0%, #dd8a52 100%);
+    border-radius: 999px;
+    padding: .3rem .9rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: filter .15s, box-shadow .15s;
+}
+.navbar .nav-link.nav-cta:hover,
+.navbar .nav-link.nav-cta:focus-visible {
+    color: #231005;
+    filter: brightness(1.08);
+    box-shadow: 0 0 0 .2rem var(--ac-wash);
+}
+.navbar .nav-cta .bi { color: #231005; }
+
 .icon-link-hover { --bs-icon-link-transform: translate3d(0, -.3rem, 0); }
 /* Hover affordances are hover-only: on touch, taps must not leave icons
    stuck mid-lift (mobile friendliness — see docs/design/decisions.md). */

--- a/apps/core/templates/home.html
+++ b/apps/core/templates/home.html
@@ -17,7 +17,7 @@
             <p class="ac-hero__sub">
                 Free to play, no download &mdash; jump straight into the live game.
                 Prefer your own <a href="{% url 'clients' %}#clients">MUD client</a>?
-                Point it at <code>isharmud.com</code> port <code>23</code> or <code>9999</code>.
+                Point it at <code>isharmud.com</code> port <code>23</code>.
             </p>
         </div>
         <div class="ac-hero__status">

--- a/apps/core/templates/home.html
+++ b/apps/core/templates/home.html
@@ -8,35 +8,25 @@
 {% block content %}
 <div class="ac">
 
-    <!-- Latest news -->
+    <!-- Play now: the flagship banner — the site is the best way to play Ishar,
+         so the play action leads the page. -->
     <header class="ac-hero">
-        <span class="ac-hero__badge">{% bi "newspaper" %}</span>
+        <span class="ac-hero__badge">{% bi "controller" %}</span>
         <div class="ac-hero__text">
-            <h2 class="ac-hero__title">{{ news.subject|default:"Welcome" }}</h2>
-{% if news %}
+            <h2 class="ac-hero__title">Play Ishar in your browser</h2>
             <p class="ac-hero__sub">
-                {{ news.account.get_username|title }} &mdash;
-                <time datetime="{{ news.created|date:'c' }}" title="{{ news.created|date:'l, F jS, Y' }}">
-                    {{ news.created|date:"l, F jS, Y" }}
-                </time>
+                Free to play, no download &mdash; jump straight into the live game.
+                Prefer your own <a href="{% url 'clients' %}#clients">MUD client</a>?
+                Point it at <code>isharmud.com</code> port <code>23</code> or <code>9999</code>.
             </p>
-{% else %}
-            <p class="ac-hero__sub">The world ends, and then it begins again.</p>
-{% endif %}
         </div>
         <div class="ac-hero__status">
-            <a class="ac-btn ac-btn--accent" href="{% url 'news' %}?page=2#news">
-                {% bi "newspaper" %}
-                Past News
+            <a class="ac-cta ac-cta--accent" href="{% url 'connect' %}">
+                {% bi "play-fill" %}
+                Play Now
             </a>
         </div>
     </header>
-
-{% if news %}
-    <div class="ac-panel">
-        {% autoescape off %}{{ news.body }}{% endautoescape %}
-    </div>
-{% endif %}
 
     <!-- The pitch -->
     <div class="ac-panel">
@@ -65,23 +55,25 @@
         </p>
     </div>
 
-    <!-- Play now -->
+    <!-- Latest news -->
     <div class="ac-panel">
-        <div class="ac-panel__h">{% bi "controller" %} Play Now</div>
+        <div class="ac-panel__h">{% bi "newspaper" %} Latest News</div>
+{% if news %}
         <p class="ac-panel__hint">
-            Free to play &mdash; right here in your browser, or with any
-            <a href="{% url 'clients' %}#clients">MUD client</a> pointed at the game server.
+            <strong class="text-ishar">{{ news.subject }}</strong> &mdash;
+            {{ news.account.get_username|title }},
+            <time datetime="{{ news.created|date:'c' }}" title="{{ news.created|date:'l, F jS, Y' }}">
+                {{ news.created|date:"F jS, Y" }}
+            </time>
         </p>
-        <a class="ac-cta ac-cta--accent" href="{% url 'connect' %}">
-            {% bi "globe" %}
-            Play in your browser
+        {% autoescape off %}{{ news.body }}{% endautoescape %}
+        <a class="ac-btn ac-btn--accent mt-3" href="{% url 'news' %}?page=2#news">
+            {% bi "newspaper" %}
+            Past News
         </a>
-        <dl class="ac-kv mt-3 mb-0">
-            <dt>Host</dt>
-            <dd><code>isharmud.com</code></dd>
-            <dt>Ports</dt>
-            <dd><code>23</code> or <code>9999</code></dd>
-        </dl>
+{% else %}
+        <p class="ac-panel__hint mb-0">The world ends, and then it begins again.</p>
+{% endif %}
     </div>
 
 </div>

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -108,10 +108,10 @@
                                 Home
                             </a>
                         </li>
-                        <li class="nav-item" title="Connect to {{ WEBSITE_TITLE }}">
-                            <a class="nav-link icon-link icon-link-hover" href="{% url 'connect' %}">
-                                {% bi "globe" %}
-                                Connect
+                        <li class="nav-item" title="Play {{ WEBSITE_TITLE }} now — free, in your browser">
+                            <a class="nav-link nav-cta icon-link" href="{% url 'connect' %}">
+                                {% bi "play-fill" %}
+                                Play Now
                             </a>
                         </li>
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -358,6 +358,20 @@ Collapsible with an amber `summary` (`.h5 text-ishar`) + `.anchor-link` "#"
 affordance, inside an `.ac-panel`. Used: FAQ. Fine to reuse where content is
 genuinely collapsible; don't use it as a section header substitute.
 
+### Nav "Play Now" CTA — `.nav-cta`
+The one amber-*filled* pill in the navbar (`style.css`), marking the site's
+first-class action (playing). A `.nav-link.nav-cta` with a `play-fill` icon;
+reads as a button, not a text link, and stays a distinct pill in the collapsed
+phone menu. Use only for the single primary nav action — the rest of the bar
+stays text links. Status: **formalized** (see decisions.md 2026-07-19).
+
+### `.ac-hero` with a primary CTA
+A hero whose `.ac-hero__status` holds an `.ac-cta`/`.ac-cta--accent` (not just a
+pill or `.ac-btn`) is the page's flagship call to action — e.g. the home "Play
+Now" banner. The CTA sits top-right on desktop and, via
+`.ac-hero__status:has(.ac-cta)`, fills the width once the hero wraps on phones.
+Status: **formalized** (see decisions.md 2026-07-19).
+
 ### Global nav "Portal" dropdown
 `apps/core/templates/layout.html` — the staff/admin menu (Administration,
 Deploy, Feedback Triage, …), gated by `is_staff`/`is_god`/`is_eternal`. The

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,38 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-19 — "Play Now" is the site's first-class action (nav CTA + home flagship)
+
+**Decision.** The web client is the best way to play Ishar, so playing is treated
+as the site's primary action rather than one link among many.
+
+- **Nav.** The navbar's "Connect" (a vague amber text link with a `globe` icon,
+  indistinguishable from its neighbours and sharing the glyph with Wiki/World)
+  becomes **"Play Now"** — a `play-fill` icon on the one amber-*filled* pill in
+  the bar (`.nav-cta` in `style.css`). It reads as a button, not a link; on the
+  collapsed phone menu it stays a distinct amber pill.
+- **Home.** The play call-to-action, previously the *last* panel on the page
+  (buried below news + lore), is promoted to the **flagship `.ac-hero`** at the
+  top: `controller` badge, "Play Ishar in your browser", host/ports folded into
+  the sub, and an `.ac-cta--accent` "Play Now" button. Page order is now
+  **Play → The World (pitch) → Latest News**. News steps down from a hero to an
+  `.ac-panel` (headline + byline + body + "Past News"), so the page has one
+  unambiguous hero.
+- **Full-width hero CTA on phones.** `.ac-hero__status:has(.ac-cta)` spans the
+  full width once the hero wraps (≤575.98px), so the flagship action is a full
+  tap target on the device the playerbase mostly uses. Pill-only hero statuses
+  (deploy, feedback) are unaffected.
+
+**Why.** The primary conversion action was the least prominent thing on the home
+page, and "Connect" is jargon a first-time visitor has to decode. Amber is
+reserved for brand/focus/**primary actions** (tokens.md) — a single filled play
+button is exactly that use, not accent overuse. Green-field: optimise for the
+best design, don't preserve the buried layout.
+
+**Notes.** `.nav-cta` uses the `.ac-cta--accent` amber gradient + `#231005` ink
+for consistency with the home CTA. Every real "go play" control now uses
+`play-fill` + "Play Now"; `controller` stays the decorative game badge.
+
 ## 2026-07-19 — HUD combat layer II: target cycling + the attack/assist cluster (Alt = act)
 
 **Decision.** The ⚔ default target graduates from a context-menu toggle to a


### PR DESCRIPTION
Closes #160

### Problem

The web client is the best way to play Ishar, but the play action was the least prominent thing on the site. On the home page it was the *last* panel — a first-time visitor scrolled past an in-game news post and the lore pitch before reaching the button — and the navbar labelled it "Connect," jargon on a `globe` icon shared with Wiki and World. The single most important conversion action was buried, on every device the playerbase (mostly phones) and any newcomer lands on.

### Solution

- **Nav:** "Connect" → **"Play Now"**, restyled as the one amber-*filled* pill in the bar (`.nav-cta`) with a `play-fill` icon. It reads as a button, not a text link, and stays a distinct pill in the collapsed phone menu. Amber is reserved for primary actions in the token system, so a single filled play control is on-spec, not accent overuse.
- **Home:** the play CTA is promoted to the flagship `.ac-hero` at the top; page order is now **Play → The World (pitch) → Latest News**. The one non-obvious call: News steps *down* from a hero to an `.ac-panel` (headline + byline + body + "Past News") so the page has a single, unambiguous hero rather than two competing amber banners. Host/port folds into the hero sub.
- **Mobile:** a hero's primary CTA now fills the width once the hero wraps (`.ac-hero__status:has(.ac-cta)`), so the flagship action is a full tap target at phone width. Pill-only hero statuses (deploy, feedback) are unaffected.

Design call recorded in `docs/design/decisions.md`; component catalog updated with `.nav-cta` and the hero-CTA pattern.

Also on this branch (related, connection instructions): **dropped port `9999`** from the home hero and the MUD-clients page — only telnet port `23` currently accepts connections.

### Verification

- **Templates:** `layout.html`, `home.html`, and `clients.html` compiled through Django's template engine under stub settings (exercises `{% load ishar %}`, every `{% bi %}`/`{% url %}` and the `{% if %}`/`{% autoescape %}`/`{% block %}` tags). `manage.py check` needs the shared MariaDB and wasn't run.
- **CSS proven end-to-end:** a throwaway `preview.html` linked the *real* edited `style.css`/`admin-console.css` and rendered in headless Chromium at **1200px** and **390px** — the amber nav pill, the flagship hero, and the full-width mobile CTA all applied correctly; the collapsed mobile nav shows the "Play Now" pill standing out among the text links. Screenshots were shared with the owner in-session (can't inline-attach via automation).
- **Not** verified against the live DB: the news panel renders `{{ news.body }}` exactly as before, so that path is unchanged, but it's left to the owner's on-prod check.

### Deploy notes

Touches tracked static CSS (`apps/core/static/css/style.css`, `admin-console.css`) — both force-added past the `static/` gitignore. `collectstatic` runs on container start, so the styles land automatically on the next deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYPWqWohBQ5GKZTyQqPGR8)_