### PR TITLE
connect: stop Chat pane crowding Tracked Spells below its cap

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -738,8 +738,11 @@ button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 #hud-right { display: flex; flex-direction: column; gap: 6px; min-height: 0; }
 /* Chat fills the column below Tracked Spells: a flex stack of header · filter
    tabs · scrolling log · input. The inner .chat-log is the scroll container
-   (appendChat pins to its scrollTop); collapsed, the pane shrinks to its head. */
-#hud-right .panel-chat { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+   (appendChat pins to its scrollTop); collapsed, the pane shrinks to its head.
+   flex-basis 0 (not auto) is load-bearing: it makes Chat size to the *leftover*
+   space, not to its message history — otherwise a long log inflates Chat's basis
+   and the flex-shrink split lets it crowd Tracked Spells below its 42% cap. */
+#hud-right .panel-chat { flex: 1 1 0; min-height: 0; display: flex; flex-direction: column; }
 #hud-right .panel-chat.collapsed { flex: 0 0 auto; }
 /* Tracked Spells is pinned above Chat (order, since placePanels can't preserve
    DOM order across a phone↔desktop swap) and height-capped so a long maintained


### PR DESCRIPTION
### Problem

On the desktop HUD, the right column stacks **Tracked Spells** over **Chat**. Tracked Spells is capped at 42% of the column so a long maintained-spell list scrolls instead of crowding Chat out. But the two panes were fighting the *other* direction: a busy chat log would squeeze Tracked Spells **below** its 42% cap — down to ~2 visible rows with a full backlog — hiding the maintained spells you're actively watching for expiry.

Root cause: `.panel-chat` used `flex: 1 1 auto`, so its `flex-basis` was `auto` — i.e. its own content (the entire message history). In a fixed-height flex column, the flex-shrink split is weighted by basis, so as chat history grew, Chat's basis grew and it stole height from Tracked Spells.

### Solution

One line — `flex: 1 1 auto` → `flex: 1 1 0` on `.panel-chat`. With `flex-basis: 0`, Chat sizes to the **leftover** space rather than to its message history; the long log scrolls inside its own `.chat-log` (already `min-height: 0; overflow-y: auto`). Tracked Spells now reliably holds `min(content, 42%)` and scrolls internally.

This is exactly what the layout comments already described ("Chat fills the column below Tracked Spells") — the `auto` basis was silently defeating that intent. Preferred over bolting a fixed `max-height` onto Chat, which would leave dead space when few spells are tracked; making Chat *yield* to Tracked is the self-adjusting cap. Collapsed states (`.panel-chat.collapsed`, collapsed/empty Tracked) are unaffected.

### Verification

- **CSS integrity:** brace balance checked (834/834); edit confirmed present, old value gone.
- **Visual before/after:** rendered the two variants (`flex: 1 1 auto` vs `flex: 1 1 0`) with the project's throwaway-`preview.html` + headless-Chromium method, using the real right-column rules and design tokens. Before: Tracked Spells crushed to 2 rows by a full chat backlog. After: Tracked Spells holds its 42% cap and scrolls; Chat fills the remainder and scrolls in its own log.
- **Not run** against the live websocket/game DB (not reachable from this environment) — the change is pure CSS layout and fully demonstrated above, but worth an eyeball on prod after deploy.
- **Phone width:** no change — on mobile the panels re-home into the bottom sheet (`placePanels`), so these desktop right-column flex rules don't apply.

### Deploy notes

Touches a tracked static asset (`apps/connect/static/css/hud.css`). `static/` is gitignored, so it was **force-added** (`git add -f`); `collectstatic` on container start picks it up on the normal deploy path — no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UDRZZEKzXAwAcYZ4LK6SR

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDRZZEKzXAwAcYZ4LK6SR)_