### PR TITLE
Show what an enchant recipe does in the professions menu

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -1296,6 +1296,12 @@ button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 .recipe-comp.missing { color: var(--ac-danger); }
 .recipe-comp.loc { color: var(--ac-dim); }
 
+/* What an enchant recipe does (the info Effects block). Accent-tinted border
+   reads it as the outcome, distinct from the plain-bordered component cost. */
+.recipe-effects { padding: 2px 0 6px 10px; border-left: 2px solid var(--ac-accent); margin-left: 2px; margin-bottom: 4px; }
+.recipe-effects-label { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--ac-dim); }
+.recipe-effect { font-size: .74rem; padding: 1px 0; color: var(--ac-text); }
+
 /* Batch-craft queue (targetless recipes): stepper + editable count + Max +
    Craft ×N. Mirrors the game's `<verb> <recipe> <count>` chain (cap 99). */
 .recipe-queue {

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -3431,6 +3431,22 @@
         ]);
     }
 
+    // What an enchant recipe *does* — the stat outcome the in-game `info`
+    // Effects block shows (Char.Recipes `effects`, pre-formatted server-side).
+    // Enchant recipes only; other professions convey outcome via the crafted
+    // item. Returns null when there's nothing to show.
+    function recipeEffectsBlock(r) {
+        var lines = ((r && r.effects) || []).map(stripColor).filter(Boolean);
+        if (!lines.length) return null;
+        var block = el("div", { class: "recipe-effects" }, [
+            el("div", { class: "recipe-effects-label", text: "Effects" })
+        ]);
+        lines.forEach(function (text) {
+            block.appendChild(el("div", { class: "recipe-effect", text: text }));
+        });
+        return block;
+    }
+
     function recipeRow(p, r, counts, treasure) {
         var rank = Number(p.rank) || 0;
         var tier = profTier((Number(r.min_rank) || 1) - rank);
@@ -3492,6 +3508,8 @@
         ]);
         var wrap = el("div", { class: "recipe-item" }, [row]);
         if (isOpen) {
+            var fx = recipeEffectsBlock(r);
+            if (fx) wrap.appendChild(fx);
             wrap.appendChild(recipeCompsBlock(r, counts, treasure));
             if (!targeted) wrap.appendChild(recipeQueue(p, r, count));
         }
@@ -5395,14 +5413,19 @@
                 { id: 105, profession_id: 1, name: "elixir of vigor", category: "Elixirs", min_rank: 45, duration: 40,
                   components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 3 }, { kind: "treasure", amount: 300 }] },
                 { id: 201, profession_id: 2, name: "minor soothing", category: "Head", min_rank: 8, duration: 20, target_gear_type: 6,
+                  effects: ["It soothes your mind and steadies your focus. (+3 Focus)"],
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 1 }] },
                 { id: 204, profession_id: 2, name: "warding sigil", category: "Body", min_rank: 10, duration: 22, target_gear_type: 2,
+                  effects: ["It hums with a protective ward. (+5 Armor)", "It steels you against harm. (fire Resistance)"],
                   components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 1 }] },
                 { id: 205, profession_id: 2, name: "fleetfoot glyph", category: "Feet", min_rank: 14, duration: 22, target_gear_type: 5,
+                  effects: ["Time seems to quicken around you. (+10% Haste)"],
                   components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 1 }] },
                 { id: 202, profession_id: 2, name: "keened edge", category: "Weapon", min_rank: 16, duration: 30, target_gear_type: 0,
+                  effects: ["Its edge bites deeper. (+2 Damage)", "Its swing is straight and true. (+1 Attack)"],
                   components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 2 }, { kind: "treasure", amount: 800 }] },
                 { id: 206, profession_id: 2, name: "aegis boon", category: "Shield", min_rank: 22, duration: 28, target_gear_type: 1,
+                  effects: ["It turns aside blows meant for you. (+4 Armor)"],
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 1 }] },
                 { id: 203, profession_id: 2, name: "greater arcane dust", category: "Transmutation", min_rank: 20, duration: 10,
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 2 }] }


### PR DESCRIPTION
Relates to IsharMud/ishar-mud#1853 (web half; the game-side feed change is IsharMud/ishar-mud#1854)

### Problem

The HUD professions/crafting browser showed a recipe's rank, components, and craftability but not its outcome. For enchanting that's the entire value of the recipe — an enchant appeared with a component cost and an "Enchant…" button and no indication of what it grants, so players had to leave the HUD and run the raw `enchant info <recipe>` telnet command to find out. Several players (and the developer) drive the game from phones, where dropping to a raw command is exactly the friction the HUD exists to remove.

### Solution

The `Char.Recipes` GMCP feed now carries an `effects` array on enchant recipes (game-side companion PR). This renders it in the expanded recipe detail via a new `recipeEffectsBlock(r)`, built with `el()`/`textContent` and run through `stripColor` like every other feed string (no `innerHTML`).

Design call: the effects lead the disclosed detail, above the component block, with an amber (accent) left border versus the component block's plain border. The recipe browser answers "is this worth making?" — so the outcome (the benefit) reads first, the cost second, and the color split lets the eye separate them at a glance. Effects render only when present, so alchemy/artificing rows (whose outcome is the crafted item, not effects) are unchanged.

### Verification

`node --check` on `hud.js` is clean. I built the throwaway self-contained `preview.html` (inlining the `.recipe-*` CSS layer + the render helpers) and rendered it with headless Chromium at 390px phone width — enchant recipes show the amber **Effects** block above the component cost, mult modifiers (`+10% Haste`), force resistances (`fire Resistance`), and multi-effect recipes all read correctly, and the alchemy recipe shows no effects block. Screenshot shared with the owner. **Left for on-prod: a live browse once both this and the game-side feed change are deployed.**

### Deploy notes

`apps/connect/static/` is gitignored (collectstatic target); both `hud.js` and `hud.css` are already-tracked source and were re-staged with `git add -f`. No new tracked assets, so `collectstatic` on container start picks them up with no further action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACEX8DDeTpGMFrmuA6oEkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACEX8DDeTpGMFrmuA6oEkW)_