### PR TITLE
Show what an alchemy/artificing recipe makes in the professions menu

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -1302,6 +1302,14 @@ button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 .recipe-effects-label { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--ac-dim); }
 .recipe-effect { font-size: .74rem; padding: 1px 0; color: var(--ac-text); }
 
+/* What a craft recipe produces (the info Result block). Informational-blue
+   border sets "what you get" apart from the amber "what it does" effects. */
+.recipe-result { padding: 2px 0 6px 10px; border-left: 2px solid var(--ac-info); margin-left: 2px; margin-bottom: 4px; }
+.recipe-result-label { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--ac-dim); }
+.recipe-result-name { font-size: .78rem; color: var(--ac-text); }
+.recipe-result-meta { font-size: .7rem; color: var(--ac-dim); font-variant-numeric: tabular-nums; }
+.recipe-result-prop { font-size: .74rem; padding: 1px 0; color: var(--ac-text); }
+
 /* Batch-craft queue (targetless recipes): stepper + editable count + Max +
    Craft ×N. Mirrors the game's `<verb> <recipe> <count>` chain (cap 99). */
 .recipe-queue {

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -3447,6 +3447,30 @@
         return block;
     }
 
+    // What a targetless craft (alchemy/artificing) recipe produces — the item,
+    // its type/quantity/level, and a short "what it does" list (Char.Recipes
+    // `result`, game-formatted). Enchants act on existing gear and carry none.
+    function recipeResultBlock(r) {
+        var res = r && r.result;
+        if (!res) return null;
+        var meta = [];
+        if (res.type) meta.push(stripColor(res.type));
+        var qty = Number(res.qty) || 1;
+        var qtyMax = Number(res.qty_max) || 0;
+        meta.push("×" + qty + (qtyMax > qty ? "–" + qtyMax : ""));
+        if (res.level) meta.push("lvl " + res.level);
+        if (res.bind_on_craft) meta.push("binds");
+        var block = el("div", { class: "recipe-result" }, [
+            el("div", { class: "recipe-result-label", text: "Makes" }),
+            el("div", { class: "recipe-result-name", text: stripColor(res.name || "an item") }),
+            el("div", { class: "recipe-result-meta", text: meta.join(" · ") })
+        ]);
+        ((res.props) || []).map(stripColor).filter(Boolean).forEach(function (text) {
+            block.appendChild(el("div", { class: "recipe-result-prop", text: text }));
+        });
+        return block;
+    }
+
     function recipeRow(p, r, counts, treasure) {
         var rank = Number(p.rank) || 0;
         var tier = profTier((Number(r.min_rank) || 1) - rank);
@@ -3508,6 +3532,8 @@
         ]);
         var wrap = el("div", { class: "recipe-item" }, [row]);
         if (isOpen) {
+            var res = recipeResultBlock(r);
+            if (res) wrap.appendChild(res);
             var fx = recipeEffectsBlock(r);
             if (fx) wrap.appendChild(fx);
             wrap.appendChild(recipeCompsBlock(r, counts, treasure));
@@ -5401,16 +5427,22 @@
             ] },
             "Char.Recipes": { recipes: [
                 { id: 101, profession_id: 1, name: "minor healing draught", category: "Draughts", min_rank: 30, duration: 20,
+                  result: { name: "a minor healing draught", type: "Potion", qty: 2, props: ["Restores 4d8+5 health"] },
                   components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 2 }, { kind: "item", vnum: 9003, name: "a sprig of nightshade", count: 1 }] },
                 { id: 102, profession_id: 1, name: "tincture of stone", category: "Draughts", min_rank: 39, duration: 30,
+                  result: { name: "a tincture of stone", type: "Potion", qty: 1, level: 20, props: ["Quaff to cast stone skin (level 20)"] },
                   components: [{ kind: "item", vnum: 9099, name: "a lump of granite dust", count: 1 }, { kind: "treasure", amount: 500 }] },
                 { id: 106, profession_id: 1, name: "weak salve", category: "Draughts", min_rank: 10, duration: 15,
+                  result: { name: "a weak salve", type: "Potion", qty: 1, props: ["Cures poison"] },
                   components: [{ kind: "item", vnum: 9003, name: "a sprig of nightshade", count: 1 }] },
                 { id: 103, profession_id: 1, name: "alchemist's fire", category: "Reagents", min_rank: 22, duration: 25,
+                  result: { name: "a flask of alchemist's fire", type: "Weapon oil", qty: 1 },
                   components: [{ kind: "item", vnum: 9001, name: "a pinch of sulfur", count: 4 }, { kind: "location", label: "a forge" }] },
                 { id: 104, profession_id: 1, name: "spark reagent", category: "Reagents", min_rank: 30, duration: 18,
+                  result: { name: "a spark reagent", type: "Component", qty: 1, qty_max: 3 },
                   components: [{ kind: "item", vnum: 9002, name: "a vial of powdered silver", count: 2 }] },
                 { id: 105, profession_id: 1, name: "elixir of vigor", category: "Elixirs", min_rank: 45, duration: 40,
+                  result: { name: "an elixir of vigor", type: "Potion", qty: 1, bind_on_craft: true, props: ["Restores 25 stamina", "It causes your muscles to swell with power. (+2 Strength)"] },
                   components: [{ kind: "item", vnum: 9004, name: "a shard of frost quartz", count: 3 }, { kind: "treasure", amount: 300 }] },
                 { id: 201, profession_id: 2, name: "minor soothing", category: "Head", min_rank: 8, duration: 20, target_gear_type: 6,
                   effects: ["It soothes your mind and steadies your focus. (+3 Focus)"],


### PR DESCRIPTION
Relates to IsharMud/ishar-mud#1855 (web half; the game-side feed change is IsharMud/ishar-mud#1856)

### Problem

The HUD professions menu shows an Effects block for enchant recipes (#164), but alchemy and artificing recipes *produce an item* rather than granting stat effects — and the menu showed those with only a rank, a component cost, and a Craft button. Nothing about what you'd get or whether it's worth making. Since the HUD has no rich item card and "detail" is just the game's `examine` command, a phone player had no in-menu way to compare, say, two draughts or two weapons before committing components.

### Solution

The `Char.Recipes` GMCP feed now carries a `result` object on craft recipes (game-side companion PR). This renders a new `recipeResultBlock(r)` ("Makes") leading the expanded recipe detail — built with `el()`/`textContent` and `stripColor` like every other feed string, no `innerHTML`.

Design call: the block gets an informational-blue left border (`--ac-info`), distinct from the amber effects border and the plain component border, so the disclosed detail reads top-to-bottom as **what you get** (blue) → what it does, for enchants (amber) → **what it costs** (plain). The item name leads, then a dim meta line (type · quantity · use level · binds), then the game-formatted property lines. Shown only for recipes that carry a `result`; enchants keep their effects block, and the two never co-occur.

### Verification

`node --check` on `hud.js` is clean. I built the throwaway self-contained `preview.html` (inlining the `.recipe-*` CSS + the render helpers) and rendered it with headless Chromium at 390px phone width across all the shapes: a potion (restore/spell/cure lines), a weapon (`2d6+2 damage`, mod line), armor (AC + mod), a quantity-range component with no props, and a bound result. All read cleanly and the blue "Makes" block is clearly distinct from components. Screenshot shared with the owner. **Left for on-prod: a live browse once both this and the game-side feed change are deployed.**

### Deploy notes

`apps/connect/static/` is gitignored (collectstatic target); `hud.js` and `hud.css` are already-tracked source, re-staged with `git add -f`. No new tracked assets — `collectstatic` on container start picks up the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACEX8DDeTpGMFrmuA6oEkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACEX8DDeTpGMFrmuA6oEkW)_