### PR TITLE
Store the HUD action bar per character, server-side

### DIFF
--- a/apps/connect/migrations/0003_hudbar.py
+++ b/apps/connect/migrations/0003_hudbar.py
@@ -1,0 +1,65 @@
+import apps.core.models.unsigned
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("connect", "0002_questtrack"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="HudBar",
+            fields=[
+                (
+                    "id",
+                    apps.core.models.unsigned.UnsignedAutoField(
+                        primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "player_id",
+                    models.IntegerField(
+                        help_text="players.id of the character the bar belongs to.",
+                        unique=True,
+                        verbose_name="Player ID",
+                    ),
+                ),
+                (
+                    "account_id",
+                    models.IntegerField(
+                        db_index=True,
+                        help_text="Owning account id (denormalized for ownership scoping).",
+                        verbose_name="Account ID",
+                    ),
+                ),
+                (
+                    "slots",
+                    models.JSONField(
+                        default=list,
+                        help_text=(
+                            "Ordered action-bar slots: skill keys (strings), "
+                            "pinned-item objects, or null for an empty slot. "
+                            "Sanitized server-side."
+                        ),
+                        verbose_name="Slots",
+                    ),
+                ),
+                (
+                    "updated_at",
+                    models.DateTimeField(
+                        auto_now=True,
+                        help_text="When the bar was last saved.",
+                        verbose_name="Updated At",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "HUD Bar",
+                "verbose_name_plural": "HUD Bars",
+                "db_table": "web_hud_bar",
+                "managed": True,
+            },
+        ),
+    ]

--- a/apps/connect/models/__init__.py
+++ b/apps/connect/models/__init__.py
@@ -1,3 +1,4 @@
+from .bar import HudBar
 from .map import RoomDiscovery, RoomNote
 from .quest import QuestTrack
 from .token import WebLoginToken

--- a/apps/connect/models/bar.py
+++ b/apps/connect/models/bar.py
@@ -1,0 +1,57 @@
+"""Site-owned per-character action-bar settings for the web HUD
+(isharmud/ishar-web#167).
+
+The HUD's action bar — a player's favorite skills and pinned consumables,
+in ordered numbered slots — used to live only in browser localStorage. That
+made it a property of the *device*: shared across every character played on
+it, and awkward to switch between. This table moves the bar server-side,
+one row per character, so it follows the character across devices instead.
+
+Same shared-database pattern as the map state and quest tracking
+(``models/map.py``, ``models/quest.py``): the table is **owned by the
+site** (``managed = True`` — migrations live here, the game never touches
+it). It keys on the game's ``players.id`` (resolved server-side from the
+connected character's GMCP name, scoped to the owning account) with
+``account_id`` denormalized for ownership scoping and admin filtering.
+"""
+from django.db import models
+
+from apps.core.models.unsigned import UnsignedAutoField
+
+
+class HudBar(models.Model):
+    """One character's action-bar slot assignments."""
+
+    id = UnsignedAutoField(primary_key=True)
+    player_id = models.IntegerField(
+        unique=True,
+        help_text="players.id of the character the bar belongs to.",
+        verbose_name="Player ID",
+    )
+    account_id = models.IntegerField(
+        db_index=True,
+        help_text="Owning account id (denormalized for ownership scoping).",
+        verbose_name="Account ID",
+    )
+    slots = models.JSONField(
+        default=list,
+        help_text=(
+            "Ordered action-bar slots: skill keys (strings), pinned-item "
+            "objects, or null for an empty slot. Sanitized server-side."
+        ),
+        verbose_name="Slots",
+    )
+    updated_at = models.DateTimeField(
+        auto_now=True,
+        help_text="When the bar was last saved.",
+        verbose_name="Updated At",
+    )
+
+    class Meta:
+        managed = True
+        db_table = "web_hud_bar"
+        verbose_name = "HUD Bar"
+        verbose_name_plural = "HUD Bars"
+
+    def __str__(self) -> str:
+        return f"Action bar for player {self.player_id}"

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -65,6 +65,15 @@
     // be dragged; unlocked is edit mode — taps rearrange instead of firing.
     var barLocked = localStorage.getItem("ishar.barUnlocked") !== "1";
     var pickedSlot = null;                     // tap-to-swap source (edit mode)
+    // Per-character bar sync (isharmud/ishar-web#167). Signed in, the action
+    // bar lives server-side keyed on the connected character; localStorage is
+    // a write-through cache and the guest fallback. barChar is the character
+    // whose bar is currently live (set from Char.Status).
+    var barCfg = { url: "", csrf: "", authed: false };
+    var barChar = null;
+    var barSeq = 0;            // fetch generation, guards a stale async load
+    var barSaveTimer = null;   // debounce handle for the save POST
+    var barPending = null;     // {name, slots} snapshot awaiting the debounce
     var spriteUrl = "";                        // game-icons sprite URL (set in init)
     var biUrl = "";                            // Bootstrap Icons sprite URL (set in init)
     var collapsed = loadSet("ishar.collapsed");
@@ -323,9 +332,13 @@
         } catch (e) {}
         return [];
     }
-    function saveSlots() {
-        try { localStorage.setItem("ishar.slots", JSON.stringify(slots.map(function (x) { return x || null; }))); } catch (e) {}
+    function slotsArray() { return slots.map(function (x) { return x || null; }); }
+    function writeSlotsCache() {
+        try { localStorage.setItem("ishar.slots", JSON.stringify(slotsArray())); } catch (e) {}
     }
+    // A slot edit: cache locally (the guest fallback + a fast reconnect paint)
+    // and, when signed in, mirror the active character's bar to the server.
+    function saveSlots() { writeSlotsCache(); pushBar(); }
     function slotKeyOf(s) { return nameOf(s && s.name).toLowerCase(); }
     function slotIndexOf(key) { for (var i = 0; i < slots.length; i++) if (slots[i] === key) return i; return -1; }
     function onBar(key) { return slotIndexOf(key) !== -1; }
@@ -414,6 +427,78 @@
     // Repaint after any slot mutation: the bar, and the surfaces that show
     // pin state (the Abilities ★, the Bags/Gear pin chips).
     function afterSlotChange() { renderHotbar(); renderAbilities(); renderInventory(); renderEquipment(); }
+
+    // ------------------------------------------------------------------
+    // Per-character bar sync (isharmud/ishar-web#167)
+    // ------------------------------------------------------------------
+    // One-time migration guard: the character in play when this shipped keeps
+    // the browser's existing bar; every other character starts from its own
+    // server bar (empty until customized), instead of inheriting this one.
+    function barMigrated() {
+        try { return localStorage.getItem("ishar.barMigrated") === "1"; } catch (e) { return false; }
+    }
+    function markBarMigrated() {
+        try { localStorage.setItem("ishar.barMigrated", "1"); } catch (e) {}
+    }
+
+    // keepalive lets an in-flight save outlive the page (a pin made moments
+    // before the tab closes still lands), so the server never ends up behind
+    // the localStorage cache the next load reads from.
+    function postBar(name, arr) {
+        fetch(barCfg.url, {
+            method: "POST", credentials: "same-origin", keepalive: true,
+            headers: { "Content-Type": "application/json", "X-CSRFToken": barCfg.csrf },
+            body: JSON.stringify({ character: name, slots: arr })
+        }).catch(function () {});
+    }
+    // Send any debounced save now — before switching characters (so it saves
+    // under the right name) and on page hide (so a last edit isn't lost).
+    function flushBar() {
+        if (barSaveTimer) { clearTimeout(barSaveTimer); barSaveTimer = null; }
+        if (barPending) { postBar(barPending.name, barPending.slots); barPending = null; }
+    }
+    // Debounced mirror of the active character's bar to the server. A no-op
+    // for guests and before Char.Status names the character. The pending
+    // snapshot is captured now, so a save can't pick up a later character's
+    // slots when it fires.
+    function pushBar() {
+        if (!barCfg.authed || !barCfg.url || !barChar) return;
+        barPending = { name: barChar, slots: slotsArray() };
+        if (barSaveTimer) clearTimeout(barSaveTimer);
+        barSaveTimer = setTimeout(flushBar, 600);
+    }
+
+    // Char.Status named the character in play. On a change, load that
+    // character's server bar in place of the last one's. A character with no
+    // server bar yet inherits the browser's pre-migration bar exactly once
+    // (see barMigrated), then starts empty.
+    function onCharacter(name) {
+        name = String(name || "").trim();
+        if (!name || !barCfg.authed || !barCfg.url || name === barChar) return;
+        flushBar();   // persist the previous character's pending edit first
+        barChar = name;
+        var seq = ++barSeq;
+        fetch(barCfg.url + "?character=" + encodeURIComponent(name), { credentials: "same-origin" })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (seq !== barSeq || !data) return;   // a newer character superseded this load
+                if (data.found && Array.isArray(data.slots)) {
+                    slots = data.slots.map(normalizeSlot);
+                    markBarMigrated();
+                    writeSlotsCache();
+                    afterSlotChange();
+                } else if (!barMigrated() && anyAssigned()) {
+                    markBarMigrated();
+                    postBar(name, slotsArray());   // one-time seed from the browser's bar
+                } else {
+                    markBarMigrated();
+                    slots = [];
+                    writeSlotsCache();
+                    afterSlotChange();
+                }
+            })
+            .catch(function () {});
+    }
 
     // ------------------------------------------------------------------
     // Skill icons (game-icons.net, CC BY 3.0, self-hosted sprite)
@@ -751,7 +836,9 @@
                 if (abilitiesVisible()) renderAbilities();
                 break;
             case "Char.Status":
-                S.status = data; renderVitals(); renderTrain(); renderXp();
+                S.status = data;
+                if (data && data.name) onCharacter(String(data.name));
+                renderVitals(); renderTrain(); renderXp();
                 // Self-name may have just landed; re-run the group leak guard if
                 // an earlier Group.Update couldn't verify us (issue #162).
                 if (groupPendingSelf) applyGroup(); else renderGroup();
@@ -5090,6 +5177,9 @@
         S.quests = []; S.questMarkers = null;
         S.season = null; S.achievements = null;
         S.tgtHostile = null; S.tgtFriendly = null;
+        // A reconnect may land as a different character; re-sync the bar on the
+        // next Char.Status. The cached slots stay up meanwhile (no empty flash).
+        barChar = null;
         lastVitalsBody = null;
         lastProfessionsBody = null;
         lastQuestsBody = null;
@@ -5114,6 +5204,11 @@
             questCfg.urls = opts.quests.urls || null;
             questCfg.csrf = String(opts.quests.csrf || "");
             questCfg.authed = !!opts.quests.authed;
+        }
+        if (opts.bar && typeof opts.bar === "object") {
+            barCfg.url = String(opts.bar.url || "");
+            barCfg.csrf = String(opts.bar.csrf || "");
+            barCfg.authed = !!opts.bar.authed;
         }
 
         dom.app = document.getElementById("connect-app");
@@ -5164,6 +5259,14 @@
         wireHotkeys();
         wireTooltips();
         loadQuestTracked();
+
+        // A bar edit debounces its save; flush it when the tab is backgrounded
+        // or closed so a last-moment pin still reaches the server (keepalive on
+        // the POST lets it finish after the page goes away).
+        document.addEventListener("visibilitychange", function () {
+            if (document.visibilityState === "hidden") flushBar();
+        });
+        window.addEventListener("pagehide", flushBar);
 
         var toggle = document.getElementById("ui-toggle");
         if (toggle) toggle.addEventListener("click", function () {

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -1083,6 +1083,13 @@
                     tracked: "{% url 'quest_tracked' %}",
                     track: "{% url 'quest_track' %}"
                 }
+            },
+            // Per-character action bar: server-persisted for signed-in players,
+            // keyed on the connected character (same CSRF source as the map).
+            bar: {
+                authed: {{ user.is_authenticated|yesno:"true,false" }},
+                csrf: (document.querySelector("#command-form [name=csrfmiddlewaretoken]") || {}).value || "",
+                url: "{% url 'hud_bar' %}"
             }
         });
     }

--- a/apps/connect/urls.py
+++ b/apps/connect/urls.py
@@ -2,8 +2,9 @@
 from django.urls import path
 
 from .views import (
-    ConnectView, MapDiscoverView, MapNoteView, MapStateView, MapZonesView,
-    QuestCatalogView, QuestTrackedView, QuestTrackView, ZoneGraphView,
+    ConnectView, HudBarView, MapDiscoverView, MapNoteView, MapStateView,
+    MapZonesView, QuestCatalogView, QuestTrackedView, QuestTrackView,
+    ZoneGraphView,
 )
 
 
@@ -17,4 +18,5 @@ urlpatterns = [
     path("quests/catalog/", QuestCatalogView.as_view(), name="quest_catalog"),
     path("quests/tracked/", QuestTrackedView.as_view(), name="quest_tracked"),
     path("quests/track/", QuestTrackView.as_view(), name="quest_track"),
+    path("hud/bar/", HudBarView.as_view(), name="hud_bar"),
 ]

--- a/apps/connect/views/__init__.py
+++ b/apps/connect/views/__init__.py
@@ -1,3 +1,4 @@
+from .bar import HudBarView
 from .connect import ConnectView
 from .map import (
     MapDiscoverView, MapNoteView, MapStateView, MapZonesView, ZoneGraphView,

--- a/apps/connect/views/bar.py
+++ b/apps/connect/views/bar.py
@@ -1,0 +1,125 @@
+"""JSON endpoint for the HUD action bar (isharmud/ishar-web#167).
+
+The action bar — favorite skills + pinned consumables in numbered slots —
+is per-character HUD state, so it keys on the connected character rather
+than the account (a player's mage and warrior want different bars). The
+client knows only the character's GMCP name; this view resolves it to a
+``players`` row **owned by the requesting account**, which both authorizes
+the request and yields the stable ``player_id`` the bar keys on.
+
+``GET  ?character=<name>`` → the saved slots (``found: false`` when the
+character has no server bar yet — the client's cue to seed the row from the
+browser's pre-migration localStorage). ``POST {character, slots}`` upserts,
+with the slot list re-sanitized here: the stored blob is never trusted from
+the client (mirrors ``hud.js`` ``normalizeSlot``).
+"""
+import json
+
+from django.http import JsonResponse
+from django.views.generic.base import View
+
+from apps.core.views.mixins import NeverCacheMixin
+from apps.players.models import Player
+
+from ..models import HudBar
+from .map import MapJSONMixin
+
+
+# Mirrors hud.js SLOT_MAX (two pages of ten). A longer list is truncated.
+SLOT_MAX = 20
+
+# Per-field caps for a pinned-item slot object (mirrors hud.js normalizeSlot).
+_KEY_MAX = 64
+_CMD_MAX = 64
+_NAME_MAX = 64
+_OTYPE_MAX = 32
+_ICON_MAX = 64
+
+
+def _str_field(value, cap):
+    return value[:cap] if isinstance(value, str) else ""
+
+
+def _sanitize_slot(x):
+    """One slot -> a stored skill key (str), item object (dict), or None.
+
+    The client blob is untrusted: skill keys are capped, item objects are
+    rebuilt field-by-field, and anything else collapses to an empty slot.
+    """
+    if isinstance(x, str):
+        x = x.strip()
+        return x[:_KEY_MAX] if x else None
+    if isinstance(x, dict) and x.get("item") is True:
+        cmd = x.get("cmd")
+        if not isinstance(cmd, str) or not cmd.strip():
+            return None
+        vnum = x.get("vnum")
+        if isinstance(vnum, bool) or not isinstance(vnum, int):
+            vnum = None
+        return {
+            "item": True,
+            "cmd": cmd.strip()[:_CMD_MAX],
+            "vnum": vnum,
+            "otype": _str_field(x.get("otype"), _OTYPE_MAX),
+            "name": _str_field(x.get("name"), _NAME_MAX),
+            "icon": _str_field(x.get("icon"), _ICON_MAX),
+        }
+    return None
+
+
+def _sanitize_slots(raw):
+    if not isinstance(raw, list):
+        return []
+    return [_sanitize_slot(x) for x in raw[:SLOT_MAX]]
+
+
+class HudBarView(MapJSONMixin, NeverCacheMixin, View):
+    """Per-character action-bar load (GET) and save (POST)."""
+
+    http_method_names = ("get", "post")
+
+    def _player_id(self, request, name):
+        """``players.id`` for a character name owned by the request's
+        account, or None. The account scope is the authorization boundary —
+        an account may only read/write bars for its own characters."""
+        if not isinstance(name, str) or not name.strip():
+            return None
+        return (
+            Player.objects.filter(
+                account_id=request.user.account_id,
+                name__iexact=name.strip(),
+                is_deleted=False,
+            ).values_list("id", flat=True).first()
+        )
+
+    def get(self, request, *args, **kwargs):
+        player_id = self._player_id(request, request.GET.get("character"))
+        if player_id is None:
+            return JsonResponse({"error": "unknown character"}, status=404)
+        slots = HudBar.objects.filter(player_id=player_id).values_list(
+            "slots", flat=True,
+        ).first()
+        if slots is None:
+            return JsonResponse({"found": False, "slots": [], "max": SLOT_MAX})
+        return JsonResponse({"found": True, "slots": slots, "max": SLOT_MAX})
+
+    def post(self, request, *args, **kwargs):
+        try:
+            data = json.loads(request.body)
+            name = data["character"]
+            slots = data["slots"]
+        except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError):
+            return JsonResponse({"error": "bad request"}, status=400)
+
+        player_id = self._player_id(request, name)
+        if player_id is None:
+            return JsonResponse({"error": "unknown character"}, status=404)
+
+        HudBar.objects.update_or_create(
+            player_id=player_id,
+            defaults={
+                "account_id": request.user.account_id,
+                "slots": _sanitize_slots(slots),
+            },
+        )
+        return JsonResponse({"ok": True, "max": SLOT_MAX})

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,48 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-21 — HUD action bar is per-character server state, not per-device
+
+**Problem.** The action bar (favorite skills + pinned consumables in numbered
+slots) lived only in `localStorage` (`ishar.slots`). That made it a property of
+the *browser*: every character on a device shared one bar, and it never followed
+a player between phone and desktop. Switching characters meant re-pinning.
+
+**Decision.** The bar is **per-character** state, stored server-side and keyed on
+the connected character — a mage and a warrior want different bars. A new
+site-owned table `web_hud_bar` (`managed = True`, same shared-DB pattern as the
+map fog-of-war and quest tracking) holds one JSON slot list per character.
+
+- **Keyed on `players.id`, not the account.** The client knows only the
+  character's GMCP name (`Char.Status.name`); the view resolves it to a
+  `players` row **owned by the requesting account** (`HudBarView._player_id`).
+  That resolution is the authorization boundary — an account can only read/write
+  bars for its own characters — and yields the stable id the row keys on.
+  `account_id` is denormalized for ownership scoping, mirroring the map/quest
+  tables.
+- **`localStorage` demotes to a write-through cache** (fast reconnect paint) and
+  the **guest fallback** (unauthenticated players keep pure-local bars,
+  unchanged). The server is the source of truth once signed in.
+- **The stored blob is never trusted.** Slots are re-sanitized server-side on
+  every save (`_sanitize_slots`, mirroring the client's `normalizeSlot`): skill
+  keys capped, item objects rebuilt field-by-field, everything else → empty
+  slot, list capped at `SLOT_MAX`.
+
+**Migration (no one loses their bar).** The character in play when this ships
+keeps the browser's existing bar: the first time a signed-in player loads a
+character with no server row yet, the client seeds that row from `ishar.slots`
+(guarded by a one-time `ishar.barMigrated` flag). Every *other* character starts
+from its own (empty) server bar rather than inheriting this one — the flag stops
+one character's bar from spraying onto all of them.
+
+**Notes.** Saves debounce (600 ms) but flush on character switch (so an edit
+saves under the right name) and on page hide, with `keepalive` on the POST so a
+last-moment pin outlives the tab — the server can't fall behind the cache the
+next load reads. Bar *edit-mode* state (`ishar.barUnlocked`, page) and icon
+overrides stay device-local: they're UI/session state, not per-character prefs.
+Endpoint `GET/POST /connect/hud/bar/` follows the map/quest `MapJSONMixin`
+(login-gated JSON, 403 not redirect) + `X-CSRFToken` conventions.
+
 ## 2026-07-19 — "Play Now" is the site's first-class action (nav CTA + home flagship)
 
 **Decision.** The web client is the best way to play Ishar, so playing is treated


### PR DESCRIPTION
Closes #167

### Problem

The `/connect` HUD's action bar — favorite skills and pinned consumables in numbered slots — was saved only in browser `localStorage` (`ishar.slots`), so it belonged to the *device*, not the character. Every character played on a browser shared one bar, and it never followed a player between phone and desktop. For a playerbase that mostly drives the game from phones and runs several characters, switching characters meant the bar was wrong until re-pinned by hand. The map fog-of-war and quest tracking already sync server-side; the bar was the odd one out.

### Solution

The bar moves server-side, one row per character, following the same shared-DB pattern as the map/quest state:

- **`web_hud_bar`** (`managed = True`) holds one JSON slot list per character, keyed on **`players.id`** with `account_id` denormalized for scoping.
- **`HudBarView`** (`GET`/`POST /connect/hud/bar/`) resolves the connected character's GMCP name (`Char.Status.name`) to a `players` row **owned by the requesting account**. That resolution is the whole authorization story — an account can only read/write bars for its own characters — and it yields the stable id the row keys on. The client never sends an id, only the name it already has.
- The stored slot blob is **re-sanitized server-side** on every save (mirroring the client's `normalizeSlot`): skill keys capped, item objects rebuilt field-by-field, anything else → empty slot, list capped at 20. The client is never trusted as the source of the persisted shape.
- In `hud.js`, `Char.Status` drives the swap; `localStorage` demotes to a write-through cache and the **guest fallback** (unauthenticated players are unchanged).

The one non-obvious mechanism is the **save timing**. Saves debounce (600 ms), but a debounce that simply reads `slots` when it fires would save the *wrong* character's bar the instant you switch characters, and would drop a pin made just before the tab closes. So the pending save captures a `{name, slots}` snapshot at schedule time and is force-flushed both on character switch (persist the old character first) and on page hide, with `keepalive` on the POST so it outlives the page. That keeps the server from ever falling behind the cache the next load reads from.

**Lossless migration** (the reason no one loses their current setup): the character in play when this ships keeps the browser's existing bar. The first time a signed-in player loads a character with no server row, the client seeds that row from `localStorage` once, guarded by an `ishar.barMigrated` flag; every other character starts from its own (empty) server bar rather than inheriting this one.

Design decision recorded in `docs/design/decisions.md`.

### Verification

Environment can't reach the shared MariaDB or the live game, so this is verified as far as static tooling allows, with the end-to-end path left to an on-prod test:

- **Proven here:** `node --check` (hud.js); `py_compile` (model, view, migration); migration graph consistent and model↔migration match via `makemigrations --check` (no drift); a row round-trips through a throwaway sqlite build; `connect.html` parse-compiles and `{% url 'hud_bar' %}` resolves. The server sanitizer was unit-tested against adversarial input (wrong types, oversize strings, forged/empty item dicts, >20 overflow, non-list) — all collapse to safe values.
- **No screenshots:** there is no visual change — the bar renders identically; only the source of its data changed. There is no new UI state to capture.
- **Left to on-prod test:** the actual DB `GET`/`POST`, the GMCP-name→player resolution, and the in-browser character-switch + first-run migration flow. Worth a specific check: confirm `Char.Status.name` equals the `players.name` column exactly (the resolver matches case-insensitively on the trimmed name) — if the game ever decorates that name, the lookup 404s and the bar silently stays device-local.

### Deploy notes

- New `managed = True` table: the migration (`connect/0003_hudbar.py`) must run on deploy. It's site-owned (the game never touches `web_hud_bar`), same as the map/quest tables.
- `hud.js` and `connect.html` were already tracked (git shows them modified, not untracked), so no force-add was needed despite the gitignored `static/` target; `collectstatic` on container start ships the JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U19uZ2neGBSyyeZFD6azyK)_