### PR TITLE
connect: order-followers hotkey + skills that inherit the target

### DIFF
--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -1121,6 +1121,12 @@ button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 .skill--attack .skill-icon { color: var(--ac-text); }
 .skill--attack.armed { border-bottom-color: var(--ac-danger); }
 .skill--attack.armed .skill-icon { color: var(--hud-hostile); }
+/* Order-followers tile: accent (not danger) to read apart from the attack
+   tile it sits beside; armed once a ⚔ target gives the order a subject. */
+.skill--order[hidden] { display: none; }
+.skill--order .skill-icon { color: var(--ac-dim); }
+.skill--order.armed { border-bottom-color: var(--ac-accent); }
+.skill--order.armed .skill-icon { color: var(--ac-accent); }
 .atk-chip { display: flex; align-items: stretch; min-width: 0; }
 .atk-tgt {
     min-width: 0; max-width: 9rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;

--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -51,7 +51,7 @@
         professions: [], recipes: [], craft: null,
         chat: [], connected: false,
         // Default targets (from Room.Occupants) that make the hotbar
-        // target-aware: offensive spells → hostile, defensive → beneficial.
+        // target-aware: offensive abilities → hostile, defensive → beneficial.
         tgtHostile: null, tgtFriendly: null
     };
 
@@ -1105,8 +1105,8 @@
         // Active default targets, so target-aware casting is legible at a glance.
         if (S.tgtHostile || S.tgtFriendly) {
             var tk = [];
-            if (S.tgtHostile) tk.push(el("button", { type: "button", class: "v-tgt hostile", "data-act": "cycle-target", title: "Offensive spells + Attack target this — tap to cycle (Alt+T)", text: "⚔ " + S.tgtHostile.desc }));
-            if (S.tgtFriendly) tk.push(el("span", { class: "v-tgt friendly", title: "Beneficial spells target this", text: "✚ " + S.tgtFriendly.desc }));
+            if (S.tgtHostile) tk.push(el("button", { type: "button", class: "v-tgt hostile", "data-act": "cycle-target", title: "Offensive abilities + Attack target this — tap to cycle (Alt+T)", text: "⚔ " + S.tgtHostile.desc }));
+            if (S.tgtFriendly) tk.push(el("span", { class: "v-tgt friendly", title: "Beneficial abilities target this", text: "✚ " + S.tgtFriendly.desc }));
             groups.push(el("div", { class: "v-group v-targets" }, tk));
         }
         var world = el("div", { class: "v-group v-world" });
@@ -1384,6 +1384,20 @@
         if (dom.attackBtn) flashSlot(dom.attackBtn);
         return true;
     }
+    // Sic your loyal followers on the ⚔ target — the summoner reflex (pets open
+    // the fight). Needs a target and a follower that can hear the order; a
+    // no-op (returns false, so the hotkey combo isn't swallowed) otherwise.
+    // Bare keyword, never the handle: each follower resolves ordinals from its
+    // own spot in the room, so a viewer-relative "2.thug" could aim the wrong
+    // way for them (mirrors the occupant menu's "Order attack", line ~4560).
+    function orderFollowersAttack() {
+        if (!S.connected || !S.tgtHostile || !anyLoyalFollowerHere()) return false;
+        var o = occByHandle(S.tgtHostile.handle);
+        if (!o) return false;
+        sendCmd("order followers kill " + firstWord(o.keyword));
+        if (dom.orderBtn) flashSlot(dom.orderBtn);
+        return true;
+    }
 
     function occHostileClass(o) {
         if (o.is_dead) return "dead";
@@ -1452,8 +1466,8 @@
                 // Target chips (current defaults) so they're visible at a glance.
                 if (S.tgtHostile || S.tgtFriendly) {
                     var chips = [];
-                    if (S.tgtHostile) chips.push(el("span", { class: "tgt-chip hostile", title: "Offensive spells target this", text: "⚔ " + S.tgtHostile.desc }));
-                    if (S.tgtFriendly) chips.push(el("span", { class: "tgt-chip friendly", title: "Beneficial spells target this", text: "✚ " + S.tgtFriendly.desc }));
+                    if (S.tgtHostile) chips.push(el("span", { class: "tgt-chip hostile", title: "Offensive abilities target this", text: "⚔ " + S.tgtHostile.desc }));
+                    if (S.tgtFriendly) chips.push(el("span", { class: "tgt-chip friendly", title: "Beneficial abilities target this", text: "✚ " + S.tgtFriendly.desc }));
                     kids.push(el("div", { class: "tgt-chips" }, chips));
                 }
                 var list = el("ul", { class: "occ-list" });
@@ -2503,10 +2517,16 @@
             if (s.target_type === "defensive" && S.tgtFriendly) return base + " " + S.tgtFriendly.handle;
             return base;
         }
-        // Multi-word skills ("Shield Slam") must go through the "action" parser
-        // (the one spells use) or they're misread as command "shield" + arg
-        // "slam"; single-word skills work as a bare verb.
-        return /\s/.test(nm) ? "action " + nm : nm;
+        // Every skill invokes through the "action" parser (the one spells use),
+        // not a bare verb: uniform so a multi-word name isn't misread as
+        // command+arg ("Shield Slam" → "shield" + "slam") and a single-word
+        // skill can't be shadowed by a same-named command. Offensive/defensive
+        // skills inherit the ⚔/✚ target exactly like spells, so a hotkeyed
+        // backstab lands on the set foe instead of firing bare.
+        var cmd = "action " + nm;
+        if (s.target_type === "offensive" && S.tgtHostile) return cmd + " " + S.tgtHostile.handle;
+        if (s.target_type === "defensive" && S.tgtFriendly) return cmd + " " + S.tgtFriendly.handle;
+        return cmd;
     }
     function abilityUsable(s) { return abilityCommand(s) != null; }
     // Why a skill is unusable right now (or null). cd in seconds.
@@ -2805,8 +2825,18 @@
             iconSvg("crossed-swords", "gi skill-icon"),
             el("span", { class: "skill-key", text: "A" })
         ]);
+        // Order-followers tile: sits between the attack tile and the target
+        // chip so both act-on-the-⚔-target controls share the one readout.
+        // Hidden until a loyal follower is present (nothing to command).
+        dom.orderBtn = el("button", {
+            type: "button", class: "skill skill--order", "data-act": "order-followers", hidden: true
+        }, [
+            iconSvg("wolf-howl", "gi skill-icon"),
+            el("span", { class: "skill-key", text: "O" })
+        ]);
         dom.attackChip = el("span", { class: "atk-chip" });
         dom.attack.appendChild(dom.attackBtn);
+        dom.attack.appendChild(dom.orderBtn);
         dom.attack.appendChild(dom.attackChip);
         updateAttack();
     }
@@ -2817,6 +2847,15 @@
         dom.attackBtn.classList.toggle("armed", !!t);
         dom.attackBtn.setAttribute("aria-label",
             (t ? "Attack " + t.desc : "Assist — join your group's fight") + " (Alt+A)");
+        if (dom.orderBtn) {
+            // Only when there's a follower to command; armed once a ⚔ target
+            // gives the order a subject.
+            var canOrder = S.connected && anyLoyalFollowerHere();
+            dom.orderBtn.hidden = !canOrder;
+            dom.orderBtn.classList.toggle("armed", canOrder && !!t);
+            dom.orderBtn.setAttribute("aria-label",
+                (t ? "Order followers to attack " + t.desc : "Order followers to attack (set a ⚔ target)") + " (Alt+O)");
+        }
         var kids = [el("button", {
             type: "button", class: "atk-tgt" + (t ? " hostile" : ""),
             "data-act": "cycle-target",
@@ -2844,6 +2883,12 @@
             return { name: t ? t.desc : "No ⚔ target", key: "Alt+T",
                      sub: n ? "cycle " + n + " target" + (n === 1 ? "" : "s") + " · Tab on empty input"
                             : "nothing attackable here" };
+        }
+        if (act === "order-followers") {
+            var o = t ? occByHandle(t.handle) : null;
+            return t ? { name: "Order followers → " + t.desc, key: "Alt+O",
+                         sub: o ? "order followers kill " + firstWord(o.keyword) : "order followers kill" }
+                     : { name: "Order followers attack", key: "Alt+O", sub: "set a ⚔ target first" };
         }
         return { name: "Clear target" };
     }
@@ -2982,7 +3027,8 @@
     }
 
     // Global hotkeys: Alt/Ctrl + 1..0 fire the visible bar's slots; Alt+` pages;
-    // Alt+T cycles the ⚔ target (Shift reverses) and Alt+A attacks/assists.
+    // Alt+T cycles the ⚔ target (Shift reverses), Alt+A attacks/assists, and
+    // Alt+O orders loyal followers to attack the ⚔ target (summoner reflex).
     // Browsers reserve Ctrl+digit for tab-switching and web content usually can't
     // veto that, so Alt+digit is the reliable path (works in Chrome/Chromium/
     // Safari; Firefox reserves Alt+digit too). Ctrl is offered as a bonus that
@@ -3031,6 +3077,10 @@
             }
             if (altCombo && !e.shiftKey && e.code === "KeyA") {
                 if (fireAttack()) e.preventDefault();
+                return;
+            }
+            if (altCombo && !e.shiftKey && e.code === "KeyO") {
+                if (orderFollowersAttack()) e.preventDefault();
                 return;
             }
             if (e.key === "`" && e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
@@ -3152,8 +3202,8 @@
     function castHint(s) {
         var tt = s.type === "spell" ? "cast" : "use";
         var arrow = "";
-        if (s.type === "spell" && s.target_type === "offensive") arrow = S.tgtHostile ? " → " + S.tgtHostile.desc : " (set a ⚔ target)";
-        if (s.type === "spell" && s.target_type === "defensive") arrow = S.tgtFriendly ? " → " + S.tgtFriendly.desc : " (set a ✚ target)";
+        if (s.target_type === "offensive") arrow = S.tgtHostile ? " → " + S.tgtHostile.desc : " (set a ⚔ target)";
+        else if (s.target_type === "defensive") arrow = S.tgtFriendly ? " → " + S.tgtFriendly.desc : " (set a ✚ target)";
         return tt + " " + s.name + arrow;
     }
     function persistAbilityFilter() {
@@ -4874,6 +4924,7 @@
         if (act && dom.app.contains(act)) {
             var an = act.getAttribute("data-act");
             if (an === "attack") { fireAttack(); return; }
+            if (an === "order-followers") { orderFollowersAttack(); return; }
             if (an === "cycle-target") { cycleTarget(1); return; }
             if (an === "clear-target") { clearTarget(); return; }
         }
@@ -5409,7 +5460,8 @@
             { id: 91, name: "Metamagic: Clarity", type: "skill", percent: 100, usable: true, category: "misc", target_type: "none", min_position: "Standing" },
             { id: 92, name: "Shield Slam", type: "skill", percent: 72, usable: true, category: "damage", target_type: "none", min_position: "Fighting" },
             { id: 60, name: "translocate", type: "spell", percent: 84, usable: true, category: "misc", target_type: "defensive", mana_pct: 25, mana: 75, min_position: "Standing" },
-            { id: 61, name: "summon", type: "spell", percent: 79, usable: true, category: "misc", target_type: "defensive", mana_pct: 33, mana: 100, min_position: "Standing" }
+            { id: 61, name: "summon", type: "spell", percent: 79, usable: true, category: "misc", target_type: "defensive", mana_pct: 33, mana: 100, min_position: "Standing" },
+            { id: 62, name: "backstab", type: "skill", percent: 80, usable: true, category: "damage", target_type: "offensive", min_position: "Standing" }
         ];
         // Pad to demonstrate the immortal overflow the browser now bounds.
         for (var i = 11; i <= 90; i++) bigSkills.push({ id: i, name: "spell " + i, type: (i % 3 ? "spell" : "skill"), percent: 40 + (i % 60), usable: (i % 4 !== 0), category: ["damage", "heal", "misc"][i % 3], target_type: ["offensive", "defensive", "none"][i % 3], mana_pct: 20 + (i % 40), mana: (20 + (i % 40)) * 3, min_position: "Standing" });

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -190,8 +190,9 @@
            docs/design/decisions.md "The HUD extension model". Buttons are
            revealed by hud.js when the matching feed has data. -->
         <div id="hud-actionrow">
-            <!-- Attack cluster (attack/assist tile + ⚔ target chip); hud.js
-               builds and maintains it. Alt+A fires, Alt+T / chip-tap cycles. -->
+            <!-- Attack cluster (attack/assist + order-followers tiles + ⚔ target
+               chip); hud.js builds and maintains it. Alt+A attacks, Alt+O orders
+               followers, Alt+T / chip-tap cycles. -->
             <div id="hud-attack"></div>
             <div id="hud-hotbar" class="empty"></div>
             <nav id="hud-micro" aria-label="Overlay windows">
@@ -936,7 +937,9 @@
                 sysln("      the room's attackables; Shift reverses; the chip by the action bar");
                 sysln("      shows it (tap to cycle, ✕ to clear). Alt+A / the crossed-swords");
                 sysln("      tile attacks it — with no target it sends `assist` to join your");
-                sysln("      group's fight.");
+                sysln("      group's fight. Alt+O / the wolf tile (shown when a loyal follower");
+                sysln("      is here) orders your followers to attack the ⚔ target. Offensive");
+                sysln("      skills and spells (backstab, fireball) auto-aim at it too.");
                 sysln("Action bar: Alt+1..0 fire the bar's slots (Ctrl+1..0 too when the page");
                 sysln("      is installed/fullscreen — tabbed browsers reserve Ctrl+digit). Alt+`");
                 sysln("      switches bar pages. Pin skills from the Abilities panel and");

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -9,6 +9,53 @@ Format: `## YYYY-MM-DD — Title` · **Decision** · **Why** · (optional) **Not
 
 ---
 
+## 2026-07-21 — HUD combat layer III: order-followers hotkey + skills that inherit the target
+
+**Decision.** Two combat gaps in the `/connect` HUD close, and the "Alt = act"
+family gains a member (isharmud/ishar-web web-connector-hotkey-issues):
+
+- **Order followers → attack (`Alt+O`).** A summoner's reflex — pets open the
+  fight — had no fast path; the only door was a per-occupant context menu.
+  `Alt+O` (and a new **wolf-howl tile** in the `#hud-attack` cluster, between the
+  attack tile and the ⚔ chip) sends `order followers kill <keyword>` at the
+  current ⚔ target. The tile renders **only when a loyal follower is present**
+  (`anyLoyalFollowerHere()`) and arms (accent, not danger — it reads apart from
+  the attack tile beside it) once a ⚔ target gives the order a subject; with no
+  target it's a no-op. It sends the **bare keyword, never the handle**: each
+  follower resolves ordinals from its own spot in the room, so a viewer-relative
+  `2.thug` could aim the wrong way for them (same rule as the occupant menu's
+  "Order attack"). The tile is the phone path (Alt+O is desktop-only, and
+  summoners drive from phones).
+- **Skills inherit the ⚔/✚ target.** `abilityCommand` routed *spells* by
+  `target_type` (offensive → hostile handle, defensive → beneficial) but sent
+  skills bare, so a hotkeyed **backstab** fired at nothing. Skills now append the
+  same target the same way — offensive skills take the ⚔ target, defensive the ✚
+  — closing the gap the 2026-07-15 "route by target_type" decision named but only
+  wired for spells. The tile/browser tooltip (`castHint`) now shows the target
+  arrow for any offensive/defensive ability, not just spells.
+- **Every skill goes through `action`.** Previously only multi-word skills used
+  the `action` parser (a bare `shield slam` misparses as command+arg); single-
+  word skills fired as a bare verb, which a same-named command could shadow.
+  All skills now invoke as `action <name> [target]` — one uniform, unambiguous
+  form, and the single place the target is appended.
+
+**Why.** The data (`Room.Occupants`, `is_loyal_follower`, per-ability
+`target_type`, `S.tgtHostile`/`tgtFriendly`) and the input family (`Alt = act`)
+already existed; these are the missing wires, not new models. Consistency is the
+fix: skills and spells are both "abilities with a target_type", so they route
+identically, and ordering pets is an *act* on the ⚔ target, so it joins Alt+T/A.
+
+**Notes.** Hotkey families unchanged: `Ctrl+letter` opens overlays; `Alt+letter/
+digit` acts (bar slots, `Alt+``` paging, `T` cycle, `A` attack, now `O` order).
+`Alt+O` matches on `e.code === "KeyO"` like the other combat letters (macOS
+Alt+letter composes glyphs). **Verification:** `node --check` on `hud.js` and the
+inline `connect.html` script; a logic harness asserted the exact commands
+(`action backstab 1.thug`, `action backstab` with no target, `order followers
+kill thug`, spells unchanged, passives → null); a self-contained `preview.html`
+rendered the cluster's three states (order tile hidden / dim / armed) under
+headless Chromium. Not run end-to-end (needs the game's websocket + shared DB);
+the game's `action <skill> <target>` acceptance is the owner's on-prod check.
+
 ## 2026-07-21 — HUD action bar is per-character server state, not per-device
 
 **Problem.** The action bar (favorite skills + pinned consumables in numbered


### PR DESCRIPTION
## Problem

Three gaps in the `/connect` HUD combat layer:

1. **No hotkey to order followers to attack.** A summoner's reflex — sic your summons on the target so pets open the fight — had no fast path; the only door was a per-occupant context menu (Look → … → Order attack). Painful mid-fight, worse on a phone.
2. **Skills don't inherit the target.** `abilityCommand` routed *spells* by `target_type` (offensive → ⚔ handle, defensive → ✚ handle) but sent skills bare, so a hotkeyed **backstab** fired at nothing. You couldn't hotkey backstab-on-target at all.
3. **Skills didn't uniformly use the `action` parser.** Only multi-word skills went through `action`; single-word skills fired as a bare verb, which a same-named command could shadow — and there was no single place to append a target.

Also worth naming, since it prompted this: **why `Alt+A` for attack when the overlay hotkeys are all `Ctrl`?** It's not an inconsistency — the HUD has two hotkey families. `Ctrl+letter` **opens an overlay window** (Bags, Abilities, Map, …); `Alt+letter/digit` **acts** in the game (bar slots, `Alt+`` ` paging, `Alt+T` cycle, `Alt+A` attack). Attack is an act, so it's Alt. Browser reservations reinforce it (`Ctrl+A` = select-all, `Ctrl+T`/`Ctrl+digit` uninterceptable). This PR extends the act family rather than breaking the pattern.

## Solution

- **Order followers → attack (`Alt+O` + a wolf-howl tile).** Sends `order followers kill <keyword>` at the current ⚔ target. Uses the **bare keyword, never the handle** — each follower resolves ordinals from its own spot in the room, so a viewer-relative `2.thug` could aim the wrong way for them (same rule as the occupant menu's "Order attack"). Because summoners drive from phones and `Alt+O` is desktop-only, a **wolf-howl tile** joins the `#hud-attack` cluster (between the attack tile and the ⚔ chip); it renders only when a loyal follower is present and arms — accent, not danger, so it reads apart from the attack tile — once a target gives the order a subject. No target → no-op.
- **Skills inherit the ⚔/✚ target** like spells. Offensive skills append the ⚔ target, defensive the ✚ — closing the gap the 2026-07-15 "route by `target_type`" decision named but only wired for spells. The Abilities target-arrow (`castHint`) and the target-chip tooltips now cover any offensive/defensive ability, not just spells.
- **Every skill invokes as `action <name> [target]`** (was: only multi-word names), so a single-word skill can't be shadowed by a same-named command and there's one uniform place the target is appended.
- `/help` documents `Alt+O`; a new demo `backstab` (offensive skill) exercises the target-inheriting path; design decision recorded in `docs/design/decisions.md`.

## Verification

- `node --check` on `hud.js` and the inline `connect.html` script — pass.
- Logic harness asserting the exact commands built: `action backstab 1.thug`, `action backstab` (no target), `action Shield Slam`, `action bandage 1.Boric` (defensive), `metamagic clarity`, spells unchanged (`cast 'fireball' 1.thug`), passives → `null`, and `order followers kill thug` / no-op with no target — **all pass**.
- Self-contained `preview.html` rendered under headless Chromium showing the attack cluster's three states: order tile **hidden** (no follower) / **dim** (follower, no target) / **armed amber** (follower + target), plus the backstab row's target arrow.

**Not proven here** (Django + the game's websocket/shared DB aren't reachable in the build env): the end-to-end path, and specifically that the game accepts `action <skill> <target>` for every skill. That last one is the owner's on-prod check — if any skill rejects it, the carve-out is one line in `abilityCommand`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAstocZh48KLF88gYvDecb)_