### PR TITLE
connect: gate edge-cost skills on live edge in the HUD action bar

### DIFF
--- a/apps/connect/static/js/hud.js
+++ b/apps/connect/static/js/hud.js
@@ -827,12 +827,13 @@
                 // Let the page decide on HP-based notifications (damage taken /
                 // low-health) — it owns the tab-visibility + settings state.
                 api.onVitals(data);
-                tickHotbar();          // mana gate re-evaluates each pulse
-                // The Abilities browser bakes the mana/position block state into
-                // each row, so it must rebuild when mana changes (combat regen)
-                // or a spell stays greyed after you can afford it (issue #1801).
-                // Only when it's actually on screen — same guard the cooldown
-                // path uses to avoid rebuilding a ~400-row list off-screen.
+                tickHotbar();          // mana/edge gates re-evaluate each pulse
+                // The Abilities browser bakes the resource/position block state
+                // into each row, so it must rebuild when mana or edge changes
+                // (combat regen) or a skill stays greyed after you can afford it
+                // (mana #1801, edge isharmud/ishar-mud#1857). Only when it's
+                // actually on screen — same guard the cooldown path uses to
+                // avoid rebuilding a ~400-row list off-screen.
                 if (abilitiesVisible()) renderAbilities();
                 break;
             case "Char.Status":
@@ -2531,6 +2532,14 @@
                 if (s.mana_pct > manaPct) return { cd: 0, reason: "low mana" };
             }
         }
+        // Edge is a combat-built pool near zero out of combat; gate on the live
+        // value so a skill greyed while it's empty frees the moment enough edge
+        // is earned. The game omits edge affordability from `usable` for exactly
+        // this reason (isharmud/ishar-mud#1857), so this is the sole authority.
+        if (v && v.edge != null && s.edge != null && Number(s.edge) > 0
+            && Number(s.edge) > Number(v.edge)) {
+            return { cd: 0, reason: "low edge" };
+        }
         if (v && v.position && s.min_position && posRank(v.position) < posRank(s.min_position)) {
             return { cd: 0, reason: s.min_position };
         }
@@ -2713,10 +2722,12 @@
             if (!s) return;
             var blk = abilityBlock(s);
             var cd = blk ? blk.cd : 0;
-            // A non-cooldown block (mana / min-position) shows its reason instead
-            // of a timer, so a blocked slot isn't a silent dead tap.
+            // A non-cooldown block (mana / edge / min-position) shows its reason
+            // instead of a timer, so a blocked slot isn't a silent dead tap.
             var reason = (blk && cd === 0)
-                ? (blk.reason === "low mana" ? "mana" : blk.reason === "unavailable" ? "" : blk.reason)
+                ? (blk.reason === "low mana" ? "mana"
+                    : blk.reason === "low edge" ? "edge"
+                    : blk.reason === "unavailable" ? "" : blk.reason)
                 : "";
             n.btn.classList.toggle("off", !!blk);
             n.btn.classList.toggle("cooling", cd > 0);


### PR DESCRIPTION
Relates to IsharMud/ishar-mud#1857 (closed by the game-side companion PR IsharMud/ishar-mud#1858)

### Problem

Edge-cost skills stayed greyed as "unavailable" in the HUD action bar and never re-enabled, even once the edge meter filled — so players who drive the game from a phone couldn't use the whole edge toolkit. Edge is a combat-built pool that sits near zero out of combat, exactly when the game sends the `Char.Skills` feed. The game's `usable` flag baked in that near-zero edge, the feed rarely resends, and the HUD had no edge gate of its own — so the stale flag never recovered.

### Solution

With the game now emitting each skill's `edge` cost and excluding edge/mana affordability from `usable` (IsharMud/ishar-mud#1858), `abilityBlock` gains a live edge gate mirroring the existing mana gate: it blocks with reason `low edge` when the cost exceeds current edge, and the compact slot label reads `edge` (matching `mana`).

Why this works dynamically: edge rides the `Char.Vitals` payload, which already drives `tickHotbar()` and `renderAbilities()` on every pulse. So the gate re-evaluates continuously and a skill frees the instant enough edge is earned — no new plumbing, same path the mana gate uses.

### Verification

`node --check` clean on `hud.js`. A focused 10-case logic test of the exact `abilityBlock` branch passes, covering the reported case (edge reaches cost → un-greys) plus the guards: position still gates, a genuine non-resource `usable: false` is still respected (not overridden by affordable edge), cooldown takes precedence, spell mana is unaffected, and a missing vitals `edge` field is graceful. Not run end-to-end against the live game/DB. The greyed-slot rendering reuses the existing mana-block treatment (already eyeballed for the #1801 mana gate), so there's no new visual to screenshot — the only change is the `edge` reason label reusing the same path. Left to on-prod test: log in as a rogue/edge-Fated, build edge in combat, confirm the slot frees at cost and re-greys with an `edge` hint when spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE96czz3cJeTPgNrXwPWv4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GE96czz3cJeTPgNrXwPWv4)_