### PR TITLE
Deploy Console: offer only prod, not the unreachable test env

### DIFF
--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -187,16 +187,11 @@
     background: var(--ac-elev);
     border-color: var(--ac-border-2);
 }
-/* Environment intent tints when selected. */
+/* Prod's intent tint when selected (red — it's the dangerous env). */
 .btn-check:checked + .ac-seg__item--prod {
     color: #ffb3b3;
     background: var(--ac-danger-wash);
     border-color: rgba(214,75,75,.5);
-}
-.btn-check:checked + .ac-seg__item--test {
-    color: #bcd8ff;
-    background: var(--ac-info-wash);
-    border-color: rgba(74,134,207,.5);
 }
 .btn-check:focus-visible + .ac-seg__item {
     outline: 2px solid var(--ac-accent);

--- a/settings.py
+++ b/settings.py
@@ -284,8 +284,10 @@ DEPLOY_AGENT_SOCKET = getenv("DEPLOY_AGENT_SOCKET", "/run/ishar-deploy/deploy-ag
 DEPLOY_AGENT_SECRET = getenv("DEPLOY_AGENT_SECRET", "")
 # Allowlist surfaced in the UI. The agent re-validates authoritatively; ishar-db
 # is intentionally absent (a phone-button DB rebuild under a live game is a
-# footgun).
-DEPLOY_AGENT_ENVS = ("test", "prod")
+# footgun). Prod only: staging.isharmud.com is a separate Lightsail box, and this
+# agent reaches the local (prod) Docker host only — offering "test" here would be
+# a control that runs deploy.sh against the wrong box and can never touch staging.
+DEPLOY_AGENT_ENVS = ("prod",)
 DEPLOY_AGENT_SERVICES = ("ishar-app", "ishar-web", "ishar-feedback-bridge")
 
 # Staff log viewer (/portal/logs/, ishar-web#104). Reuses the same host agent,


### PR DESCRIPTION
Closes #171

### Problem

The Deploy Console offered a **test** environment toggle that can never deploy staging. The console, its host deploy agent, and the unix socket all live on the prod box, where the agent has local Docker access only; `staging.isharmud.com` is a separate Lightsail instance it can't reach. Picking "test" ran `deploy.sh test` against the *prod* host — a control that lies. A God deploying from a phone shouldn't be shown an option that silently can't work.

### Solution

Restrict `DEPLOY_AGENT_ENVS` to `("prod",)`, and remove the now-dead `.ac-seg__item--test` tint from `admin-console.css` (and fix a stale "2 short envs" comment on `.ac-seg--wrap`). The template's env loop already handles a single item, so no markup change is needed. Making the console deploy staging cross-box (an agent on the staging box reached over an authenticated channel) is a separate, larger piece being scoped — this just stops the console from advertising what it can't do.

### Verification

- `python3 -m py_compile settings.py` passes.
- Grepped the console template + CSS: no `test` references remain except the explanatory comment on the setting.
- **Visual proof**: rendered the env panel at phone width (390px) with headless Chromium, using the real `.ac-seg`/`.ac-panel` rules and `--ac-*` tokens. The single `prod` pill sits correctly in the segmented track (red danger tint, unchanged) — a one-item control does not look broken. Shared with the owner for review.
- **Not** run against the live Daphne/DB. Left to the owner: confirm on prod that the console shows only `prod` and a deploy still fires.

### Deploy notes

Changes `settings.py` (an allowlist tuple) and `apps/core/static/css/admin-console.css` (already git-tracked; edited in place — no new file to force-add). `collectstatic` runs on container start, so the CSS lands on the next `ishar-web` deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HxSEpTrsRw5Ft6SAWBJTq)_