### PR TITLE
Gate the Deploy Console at Forger, not God

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ repo is **not** the game; the game engine (C + a growing Rust layer) lives in
 2. **The web telnet client** (`/connect`) — a browser terminal that speaks to
    the live game over a Channels/Daphne websocket bridge (the "HUD").
 3. **Staff / admin tooling** — the account portal (`/portal`), feedback triage,
-   the **Deploy Console** (`/portal/deploy`, God-gated, drives blue-green
+   the **Deploy Console** (`/portal/deploy`, Forger-gated, drives blue-green
    deploys of the game from a phone), and process/admin views.
 
 The site **shares the game's MariaDB**. Most models are `managed = False` — they
@@ -187,6 +187,8 @@ New views are class-based. Staff gating uses the mixins in
 for them):
 
 - `GodRequiredMixin` — `account.is_god()` (`immortal_level >= 5`).
+- `ForgerRequiredMixin` — `account.is_forger()` (`immortal_level >= 4`); gates
+  the Deploy Console.
 - `EternalRequiredMixin` — `account.is_eternal()` (`immortal_level >= 3`;
   equivalent to `is_staff`).
 - `NeverCacheMixin` — for sensitive/live pages.

--- a/apps/accounts/templates/deploy.html
+++ b/apps/accounts/templates/deploy.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% load static %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Deploy Console{% endblock meta_title %}
-{% block meta_description %}God-only deploy console for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
+{% block meta_description %}Forger-only deploy console for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
 {% block meta_url %}{% url 'deploy' %}#deploy{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Deploy Console{% endblock title %}
 {% block scripts %}let focusTo = 'deploy'{% endblock scripts %}

--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -46,7 +46,7 @@
                     <span class="ac-link__note d-block">Django admin — models &amp; data</span>
                 </span>
             </a>
-    {% if user.is_god %}
+    {% if user.is_forger %}
             <a class="ac-link" href="{% url 'deploy' %}#deploy" title="Deploy Console">
                 <span class="ac-link__icon">{% bi "rocket-takeoff" %}</span>
                 <span class="ac-link__body">
@@ -54,6 +54,8 @@
                     <span class="ac-link__note d-block">Rebuild &amp; restart the stack</span>
                 </span>
             </a>
+    {% endif %}
+    {% if user.is_god %}
             <a class="ac-link" href="{% url 'season_console' %}#console" title="Season Console">
                 <span class="ac-link__icon">{% bi "hourglass-split" %}</span>
                 <span class="ac-link__body">

--- a/apps/accounts/utils/deploy_agent.py
+++ b/apps/accounts/utils/deploy_agent.py
@@ -1,6 +1,6 @@
 """Client for the host deploy agent (#1754).
 
-The God-gated deploy page (apps/accounts/views/deploy.py) uses this to talk to
+The Forger-gated deploy page (apps/accounts/views/deploy.py) uses this to talk to
 scripts/deploy-agent.py on the host over a bind-mounted unix socket. The agent —
 NOT this container — is the real security boundary: it enforces the env/service
 allowlist and argv-execs deploy.sh. This client only frames JSON requests and

--- a/apps/accounts/views/deploy.py
+++ b/apps/accounts/views/deploy.py
@@ -1,6 +1,6 @@
-"""God-gated web deploy button (#1754).
+"""Forger-gated web deploy button (#1754).
 
-A phone-friendly page (NOT Django admin) where a God picks an environment and
+A phone-friendly page (NOT Django admin) where a Forger picks an environment and
 services and triggers scripts/deploy.sh on the host via the deploy agent. The
 deploy POST requires password re-entry (re-auth), so a driven/XSS'd session
 cannot fire a deploy on its own — see docs/infrastructure/reboot_process.md §4.
@@ -17,7 +17,7 @@ from apps.connect import tracker as connect_tracker
 from apps.core.models.webadmin import WebAdminCommand
 from apps.core.utils import webadmin
 from apps.core.utils.staff import staff_name
-from apps.core.views.mixins import GodRequiredMixin, NeverCacheMixin
+from apps.core.views.mixins import ForgerRequiredMixin, NeverCacheMixin
 
 from ..utils.deploy_agent import (
     DeployAgentError,
@@ -33,8 +33,8 @@ SCHEDULE_DELAY_MIN = 60
 SCHEDULE_DELAY_MAX = 3600
 
 
-class DeployView(GodRequiredMixin, NeverCacheMixin, TemplateView):
-    """Render the deploy control page. God-only (GodRequiredMixin -> 404)."""
+class DeployView(ForgerRequiredMixin, NeverCacheMixin, TemplateView):
+    """Render the deploy control page. Forger-only (ForgerRequiredMixin -> 404)."""
 
     template_name = "deploy.html"
 
@@ -46,10 +46,10 @@ class DeployView(GodRequiredMixin, NeverCacheMixin, TemplateView):
         return context
 
 
-class DeployActionView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployActionView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only endpoint that starts a deploy. CSRF-protected (no exemption).
 
-    Requires re-authentication: the God must re-enter their account password on
+    Requires re-authentication: the Forger must re-enter their account password on
     this request. The heavy validation (env/service allowlist, injection
     inertness) lives in the host agent; we surface its verdict.
     """
@@ -86,9 +86,9 @@ class DeployActionView(GodRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(result, status=status)
 
 
-class DeployPingView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployPingView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only liveness probe for the host agent. Powers the console's live
-    agent-health pill. Read-only (no re-auth); God gate + CSRF still apply."""
+    agent-health pill. Read-only (no re-auth); Forger gate + CSRF still apply."""
 
     http_method_names = ("post",)
 
@@ -107,14 +107,14 @@ class DeployPingView(GodRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(result)
 
 
-class DeployWebClientsView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployWebClientsView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only count of live web-client (/connect) game sessions.
 
     Deploying ishar-web restarts Daphne, which severs every browser player's
     telnet proxy mid-game — the console polls this to warn before that happens.
     Reads an in-process registry (Daphne is a single process; see
     apps.connect.tracker), so it costs nothing and needs no agent or DB.
-    Read-only (no re-auth); God gate + CSRF still apply.
+    Read-only (no re-auth); Forger gate + CSRF still apply.
     """
 
     http_method_names = ("post",)
@@ -123,7 +123,7 @@ class DeployWebClientsView(GodRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(connect_tracker.snapshot())
 
 
-class DeployScheduleView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployScheduleView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only: schedule a deploy after a delay, warning players first.
 
     One action, two effects, in this order:
@@ -189,13 +189,13 @@ class DeployScheduleView(GodRequiredMixin, NeverCacheMixin, View):
         return JsonResponse({**result, "notice_task_id": task.id}, status=200)
 
 
-class DeployCancelScheduledView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployCancelScheduledView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only: cancel a still-scheduled deploy and tell players it's off.
 
     Cancels the host agent's pending deploy (a no-op once it has started
     running), then — if the cancel landed — enqueues a `reboot_cancel` so the
     game announces the stand-down. No re-auth: cancelling is the safe direction.
-    God gate + CSRF still apply.
+    Forger gate + CSRF still apply.
     """
 
     http_method_names = ("post",)
@@ -224,7 +224,7 @@ class DeployCancelScheduledView(GodRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(result, status=status)
 
 
-class DeployGameStatusView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployGameStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only read of the game's presence heartbeat (Contract 2, #1771).
 
     Powers the console's live "Game" pill and the pre-deploy warning when
@@ -233,7 +233,7 @@ class DeployGameStatusView(GodRequiredMixin, NeverCacheMixin, View):
     game_presence (one row per in-game character); we report whether the game
     is up (heartbeat within the staleness window), the live player count, and
     the heartbeat age. Degrades gracefully before the game ships the heartbeat
-    (tables absent / no row). Read-only (no re-auth); God gate + CSRF apply.
+    (tables absent / no row). Read-only (no re-auth); Forger gate + CSRF apply.
     """
 
     http_method_names = ("post",)
@@ -280,9 +280,9 @@ class DeployGameStatusView(GodRequiredMixin, NeverCacheMixin, View):
         )
 
 
-class DeployStatusView(GodRequiredMixin, NeverCacheMixin, View):
+class DeployStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
     """POST-only status poll for a running/finished deploy. No re-auth (read
-    only); God gate + CSRF still apply."""
+    only); Forger gate + CSRF still apply."""
 
     http_method_names = ("post",)
 

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -198,7 +198,7 @@
     outline-offset: 2px;
 }
 /* Wrapping variant: for a control with more/longer items than fit one phone row
-   (the deploy console's 2 short envs never need it; the log viewer's 3 sources
+   (the deploy console's single env never needs it; the log viewer's 3 sources
    do). Block-level (`display:flex`) so it's constrained to its container width —
    base .ac-seg is inline-flex and sizes to content, so flex-wrap alone would
    never trigger. Items grow to fill and wrap to the next line on overflow. */

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -240,13 +240,15 @@
                                         {% bi "box-arrow-up-right" label="Open Administration in a new window." %}
                                     </a>
                                 </li>
-        {% if user.is_god %}
+        {% if user.is_forger %}
                                 <li class="nav-item" title="Deploy">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'deploy' %}#deploy">
                                         {% bi "rocket-takeoff" %}
                                         Deploy
                                     </a>
                                 </li>
+        {% endif %}
+        {% if user.is_god %}
                                 <li class="nav-item" title="Season Console">
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'season_console' %}#console">
                                         {% bi "hourglass-split" %}

--- a/apps/core/views/mixins.py
+++ b/apps/core/views/mixins.py
@@ -26,6 +26,22 @@ class GodRequiredMixin(View):
         return super().dispatch(request, *args, **kwargs)
 
 
+class ForgerRequiredMixin(View):
+    """Restrict a view to Forger-level accounts (immortal_level >= FORGER).
+
+    Same 404-for-everyone-else convention as GodRequiredMixin. Gates the Deploy
+    Console: firing a prod deploy sits one rung below God but above the Eternal
+    staff floor. game-DB immortal_level is the sole source of truth (see
+    apps/accounts/models/account.py: is_forger()).
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        user = getattr(request, "user", None)
+        if not (user and user.is_authenticated and user.is_forger()):
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+
 class EternalRequiredMixin(View):
     """Restrict a view to Eternal-level accounts (immortal_level >= ETERNAL).
 

--- a/apps/processes/admin/process.py
+++ b/apps/processes/admin/process.py
@@ -14,7 +14,7 @@ class MUDProcessAdmin(ModelAdmin):
     # The old "Restart" button here shelled out to `sudo systemctl restart` on
     # the host (apps/processes/utils/service.py) — a bare-metal relic that is
     # broken in the container model and was security-sensitive. It is retired in
-    # favour of the God-gated web deploy page (portal:deploy, #1754). The
+    # favour of the Forger-gated web deploy page (portal:deploy, #1754). The
     # terminate/kill signal actions remain but only see this container's process
     # table; the game runs in a separate container, so they are largely inert in
     # prod too (tracked as follow-up cleanup, out of scope for #1754).

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -374,7 +374,7 @@ Status: **formalized** (see decisions.md 2026-07-19).
 
 ### Global nav "Portal" dropdown
 `apps/core/templates/layout.html` — the staff/admin menu (Administration,
-Deploy, Feedback Triage, …), gated by `is_staff`/`is_god`/`is_eternal`. The
+Deploy, Feedback Triage, …), gated by `is_staff`/`is_forger`/`is_god`/`is_eternal`. The
 canonical place to surface a new staff tool (mirror the existing items).
 Count badges in the nav are plain `.ac-pill`s.
 


### PR DESCRIPTION
Closes #173

### Problem

Firing a game deploy is God-only (immortal_level 5), so the Forgers (level 4) who actually ship can't deploy from the console without a God present. The destructive prod button should sit one rung below God but above the general Eternal staff floor — and staff should be able to read logs without being able to deploy.

### Solution

New `ForgerRequiredMixin` (`is_forger()`, level ≥ 4) in `apps/core/views/mixins.py`, mirroring the existing God/Eternal mixins and their 404-for-everyone-else convention. All Deploy Console views move to it; the nav dropdown and portal card move the Deploy entry from the `is_god` group to `is_forger`, while Season Console stays God-gated. The log viewer is already `EternalRequiredMixin`, so "logs = Eternal" needed no change.

Per-env gating (prod = Forger, test/staging = Eternal) is deferred to the cross-server staging-deploy work — the console offers only prod today, so a blanket Forger gate is correct now. When staging returns, the page drops to an Eternal floor with a per-env check enforcing Forger for prod.

Also carries a one-line CSS comment fix (`.ac-seg--wrap`: "2 short envs" → "single env") that was orphaned from #172 — unrelated to gating, but it belongs in `main` and was already in the working tree.

### Verification

- `python3 -m py_compile` on every changed Python file (mixins, deploy views, deploy_agent, process admin) — passes.
- Confirmed the swap: the import + all 8 Deploy views use `ForgerRequiredMixin`; no `GodRequiredMixin` remains in `deploy.py`; Season/surveys/feedback God gates untouched.
- `{% if %}`/`{% endif %}` balance verified in both edited nav surfaces (12/12 and 21/21).
- **No visual delta to screenshot** — this is an authz change, not a rendering one. The Deploy entry's markup is unchanged; only which accounts see it differs (a Forger now sees it; a God sees exactly what they saw before).
- Not run against the live DB. Left to the owner: confirm a Forger account reaches `/portal/deploy` and its POST actions, and an Eternal account gets a 404.

### Deploy notes

Templates + view gating + docstring/comment updates; `admin-console.css` edited in place (already tracked). `collectstatic` on container start picks up the CSS comment. No new tracked files to force-add.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HxSEpTrsRw5Ft6SAWBJTq)_