### PR TITLE
Deploy Console + Log Viewer: staging via the forwarding agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ repo is **not** the game; the game engine (C + a growing Rust layer) lives in
 2. **The web telnet client** (`/connect`) — a browser terminal that speaks to
    the live game over a Channels/Daphne websocket bridge (the "HUD").
 3. **Staff / admin tooling** — the account portal (`/portal`), feedback triage,
-   the **Deploy Console** (`/portal/deploy`, Forger-gated, drives blue-green
-   deploys of the game from a phone), and process/admin views.
+   the **Deploy Console** (`/portal/deploy`, Eternal-gated page; a prod deploy
+   requires Forger, staging Eternal — it drives blue-green deploys of the game
+   and staging from a phone), and process/admin views.
 
 The site **shares the game's MariaDB**. Most models are `managed = False` — they
 map onto tables the C game engine owns; Django reads and occasionally writes
@@ -187,10 +188,12 @@ New views are class-based. Staff gating uses the mixins in
 for them):
 
 - `GodRequiredMixin` — `account.is_god()` (`immortal_level >= 5`).
-- `ForgerRequiredMixin` — `account.is_forger()` (`immortal_level >= 4`); gates
-  the Deploy Console.
 - `EternalRequiredMixin` — `account.is_eternal()` (`immortal_level >= 3`;
   equivalent to `is_staff`).
+
+Finer, per-env gates are enforced in the view rather than by a blanket mixin —
+e.g. the Deploy Console page is Eternal, but a *prod* deploy checks
+`account.is_forger()` inline (`apps/accounts/views/deploy.py`).
 - `NeverCacheMixin` — for sensitive/live pages.
 
 **Immortal levels** live on `accounts.Account.immortal_level`

--- a/apps/accounts/templates/deploy.html
+++ b/apps/accounts/templates/deploy.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% load static %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Deploy Console{% endblock meta_title %}
-{% block meta_description %}Forger-only deploy console for {{ WEBSITE_TITLE }}.{% endblock meta_description %}
+{% block meta_description %}Deploy console for {{ WEBSITE_TITLE }} staff.{% endblock meta_description %}
 {% block meta_url %}{% url 'deploy' %}#deploy{% endblock meta_url %}
 {% block title %}{{ WEBSITE_TITLE }} Deploy Console{% endblock title %}
 {% block scripts %}let focusTo = 'deploy'{% endblock scripts %}
@@ -72,13 +72,20 @@
             </div>
             <div class="ac-seg" role="radiogroup" aria-label="Environment">
     {% for env in deploy_envs %}
-                <input class="btn-check" type="radio" name="env" id="env-{{ env }}" value="{{ env }}" autocomplete="off"{% if env == "prod" %} checked{% endif %}>
-                <label class="ac-seg__item ac-seg__item--{{ env }}" for="env-{{ env }}">
-                    <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{% if env == 'prod' %}hdd-stack{% else %}cone-striped{% endif %}"></use></svg>
-                    {{ env }}
+                <input class="btn-check" type="radio" name="env" id="env-{{ env.key }}" value="{{ env.key }}" autocomplete="off"{% if env.checked %} checked{% endif %}{% if not env.allowed %} disabled{% endif %}>
+                <label class="ac-seg__item ac-seg__item--{{ env.key }}" for="env-{{ env.key }}"{% if not env.allowed %} title="Deploying {{ env.key }} requires {{ env.gate }} or higher."{% endif %}>
+                    <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{{ env.icon }}"></use></svg>
+                    {{ env.key }}
+        {% if not env.allowed %}<svg class="bi ac-seg__lock" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#lock-fill"></use></svg>{% endif %}
                 </label>
     {% endfor %}
             </div>
+    {% for env in deploy_locked %}
+            <p class="ac-panel__hint mt-2" role="note">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#lock-fill"></use></svg>
+                Deploying <code>{{ env.key }}</code> is <strong>{{ env.gate }}+</strong>. Ask a Forger or God if you need a <code>{{ env.key }}</code> re-release.
+            </p>
+    {% endfor %}
         </div>
 
         <!-- Services -->
@@ -93,14 +100,14 @@
             </p>
             <div class="ac-grid">
     {% for service in deploy_services %}
-                <input class="btn-check service-check" type="checkbox" name="services" id="svc-{{ service }}" value="{{ service }}" autocomplete="off"{% if service == "ishar-app" %} checked{% endif %}>
-                <label class="ac-toggle" for="svc-{{ service }}">
+                <input class="btn-check service-check" type="checkbox" name="services" id="svc-{{ service.name }}" value="{{ service.name }}" data-envs="{{ service.envs }}" autocomplete="off"{% if service.checked %} checked{% endif %}>
+                <label class="ac-toggle" for="svc-{{ service.name }}">
                     <span class="ac-toggle__icon">
-                        <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{% if service == 'ishar-app' %}controller{% elif service == 'ishar-web' %}globe2{% elif service == 'ishar-feedback-bridge' %}chat-left-dots{% else %}box{% endif %}"></use></svg>
+                        <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{% if service.name == 'ishar-app' %}controller{% elif service.name == 'ishar-web' %}globe2{% elif service.name == 'ishar-feedback-bridge' %}chat-left-dots{% else %}box{% endif %}"></use></svg>
                     </span>
                     <span class="ac-toggle__body">
-                        <span class="ac-toggle__name">{{ service }}</span>
-                        <span class="ac-toggle__note">{% if service == 'ishar-app' %}Game server · blue-green, no player drop{% elif service == 'ishar-web' %}Website · restarts this page{% elif service == 'ishar-feedback-bridge' %}Discord → feedback bridge{% else %}Service{% endif %}</span>
+                        <span class="ac-toggle__name">{{ service.name }}</span>
+                        <span class="ac-toggle__note">{% if service.name == 'ishar-app' %}Game server · blue-green, no player drop{% elif service.name == 'ishar-web' %}Website · restarts this page{% elif service.name == 'ishar-feedback-bridge' %}Discord → feedback bridge{% else %}Service{% endif %}</span>
                     </span>
                     <span class="ac-toggle__check">
                         <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#check-circle-fill"></use></svg>
@@ -157,6 +164,7 @@
             </div>
             <p class="ac-panel__hint mt-2 mb-0">Re-authentication is required on every deploy.</p>
 
+            <div id="scheduleSection">
             <label class="ac-panel__h" style="margin-top:1.25rem; margin-bottom:.35rem;">
                 <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#clock-history"></use></svg>
                 Or schedule &amp; warn players
@@ -164,6 +172,7 @@
             <p class="ac-panel__hint mt-0">
                 Announce a reboot in-game, count it down, then deploy after the delay.
                 The game does the countdown — you don't need to keep this page open.
+                Prod only.
             </p>
             <div class="ac-seg" role="radiogroup" aria-label="Reboot delay">
                 <input class="btn-check" type="radio" name="delay_min" id="delay-2" value="2" autocomplete="off">
@@ -179,6 +188,7 @@
                 <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#alarm"></use></svg>
                 Schedule &amp; warn players
             </button>
+            </div>
         </div>
 
         <!-- CTA -->
@@ -237,6 +247,11 @@
     const cancelScheduledBtn = document.getElementById("cancelScheduledBtn");
     const csrftoken = "{{ csrf_token }}";
     const deployConfigured = {% if deploy_configured %}true{% else %}false{% endif %};
+    // Per-env agent routing / services / scheduling, from DEPLOY_ENVIRONMENTS.
+    const ENV_META = {{ deploy_env_meta|safe }};
+    // Env of the in-flight/last deploy — status + cancel polls must reach the
+    // same agent it started on (a forwarded staging deploy's state lives there).
+    let currentDeployEnv = "";
     let polling = null;
     let timer = null;
     let startedAt = 0;
@@ -288,7 +303,21 @@
     // ---- self-deploy caveat + live web-client count ----------------------
     // "Nothing selected = all services" includes ishar-web, so an empty
     // selection gets the same warnings as an explicit ishar-web check.
+    function currentEnv() {
+        const el = form.querySelector("input[name=env]:checked");
+        return el ? el.value : "";
+    }
+    function currentEnvMeta() { return ENV_META[currentEnv()] || null; }
+    function envIsLocal() {
+        const m = currentEnvMeta();
+        return m ? m.target === "local" : true;
+    }
+
+    // ishar-web only exists in envs whose service set includes it (prod). For a
+    // staging deploy it's never in the set, so this is always false there.
     function deployIncludesWeb() {
+        const meta = currentEnvMeta();
+        if (!meta || meta.services.indexOf("ishar-web") === -1) { return false; }
         const web = document.getElementById("svc-ishar-web");
         const anyChecked = form.querySelector(".service-check:checked") !== null;
         return (web && web.checked) || !anyChecked;
@@ -320,18 +349,44 @@
         return Math.floor(s / 3600) + "h " + (Math.floor(s / 60) % 60) + "m";
     }
 
+    // The web/game warnings are about the PROD game (its /connect sessions and
+    // presence), so they only apply to a local (prod) deploy — a staging deploy
+    // touches neither.
     function refreshWarning() {
+        const local = envIsLocal();
         const includesWeb = deployIncludesWeb();
         warning.classList.toggle("d-none", !includesWeb);
         webClientsWarning.classList.toggle(
             "d-none", !(includesWeb && webClientCount > 0)
         );
         gamePlayersWarning.classList.toggle(
-            "d-none", !(deployIncludesApp() && gamePlayerCount > 0)
+            "d-none", !(local && deployIncludesApp() && gamePlayerCount > 0)
         );
+    }
+
+    // React to an env switch: show only that env's services (unchecking any that
+    // vanished), and hide the prod-only "schedule & warn players" block.
+    const scheduleSection = document.getElementById("scheduleSection");
+    function applyEnv() {
+        const meta = currentEnvMeta();
+        const svcs = meta ? meta.services : [];
+        document.querySelectorAll(".service-check").forEach(function (input) {
+            const ok = svcs.indexOf(input.value) !== -1;
+            const label = document.querySelector('label[for="' + input.id + '"]');
+            input.classList.toggle("d-none", !ok);
+            if (label) { label.classList.toggle("d-none", !ok); }
+            if (!ok && input.checked) { input.checked = false; }
+        });
+        if (scheduleSection) {
+            scheduleSection.classList.toggle("d-none", !(meta && meta.schedulable));
+        }
+        refreshWarning();
     }
     document.querySelectorAll(".service-check").forEach(function (el) {
         el.addEventListener("change", refreshWarning);
+    });
+    form.querySelectorAll("input[name=env]").forEach(function (el) {
+        el.addEventListener("change", applyEnv);
     });
 
     function pollWebClients() {
@@ -352,7 +407,7 @@
             })
             .catch(function () { /* keep last known count */ });
     }
-    refreshWarning();
+    applyEnv();
     pollWebClients();
     setInterval(pollWebClients, 10000);
 
@@ -461,7 +516,7 @@
 
     // ---- poll ------------------------------------------------------------
     function poll(deployId) {
-        post("{% url 'deploy_status' %}", { deploy_id: deployId })
+        post("{% url 'deploy_status' %}", { deploy_id: deployId, env: currentDeployEnv })
             .then(function (r) {
                 if (r.status !== 200) {
                     setBadge("lost", "danger", false);
@@ -502,6 +557,7 @@
     // ---- submit ----------------------------------------------------------
     form.addEventListener("submit", function () {
         const env = (form.querySelector("input[name=env]:checked") || {}).value;
+        currentDeployEnv = env;
         const services = Array.from(
             form.querySelectorAll("input[name=services]:checked")
         ).map(function (el) { return el.value; });
@@ -519,7 +575,7 @@
                 " player session" + (webClientCount === 1 ? "" : "s") +
                 " on the web client will be disconnected mid-game.";
         }
-        if (deployIncludesApp() && gamePlayerCount > 0) {
+        if (envIsLocal() && deployIncludesApp() && gamePlayerCount > 0) {
             prompt += "\n\nNote: " + gamePlayerCount + " player" +
                 (gamePlayerCount === 1 ? " is" : "s are") +
                 " in the game. ishar-app is blue-green (no drop), but the game" +
@@ -603,6 +659,7 @@
 
     scheduleBtn.addEventListener("click", function () {
         const env = (form.querySelector("input[name=env]:checked") || {}).value;
+        currentDeployEnv = env;
         const services = Array.from(
             form.querySelectorAll("input[name=services]:checked")
         ).map(function (el) { return el.value; });
@@ -686,7 +743,7 @@
             return;
         }
         const id = scheduledDeployId;
-        post("{% url 'deploy_cancel_scheduled' %}", { deploy_id: id }).then(function (r) {
+        post("{% url 'deploy_cancel_scheduled' %}", { deploy_id: id, env: currentDeployEnv }).then(function (r) {
             if (r.status === 200 && r.data.ok) {
                 clearInterval(polling);
                 endScheduleUI();

--- a/apps/accounts/templates/logs.html
+++ b/apps/accounts/templates/logs.html
@@ -70,6 +70,23 @@
         <span id="agentDiagText"></span>
     </div>
 
+    <!-- Environment -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">
+            <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#hdd-network"></use></svg>
+            Environment
+        </div>
+        <div class="ac-seg ac-seg--wrap" role="radiogroup" aria-label="Environment" id="envSeg">
+    {% for env in log_envs %}
+            <input class="btn-check" type="radio" name="logenv" id="logenv-{{ env.key }}" value="{{ env.key }}" autocomplete="off"{% if env.checked %} checked{% endif %}>
+            <label class="ac-seg__item ac-seg__item--{{ env.key }}" for="logenv-{{ env.key }}">
+                <svg class="bi" aria-hidden="true"><use xlink:href="{% static 'bootstrap-icons/bootstrap-icons.svg' %}#{{ env.icon }}"></use></svg>
+                {{ env.key }}
+            </label>
+    {% endfor %}
+        </div>
+    </div>
+
     <!-- Source + color + size -->
     <div class="ac-panel">
         <div class="ac-panel__h">
@@ -219,6 +236,10 @@
         const el = document.querySelector('input[name="color"]:checked');
         return el ? el.value : "live";
     }
+    function currentLogEnv() {
+        const el = document.querySelector('input[name="logenv"]:checked');
+        return el ? el.value : "";
+    }
 
     function post(url, params) {
         const body = new URLSearchParams(params);
@@ -257,7 +278,7 @@
 
     function loadStatus() {
         if (!configured) { return; }
-        post("{% url 'logs_status' %}", {}).then(function (r) {
+        post("{% url 'logs_status' %}", { env: currentLogEnv() }).then(function (r) {
             if (r.status === 200 && r.data && r.data.ok) {
                 const live = r.data.live_color;
                 if (live) {
@@ -405,6 +426,7 @@
         refreshBtn.disabled = true;
         outTitle.textContent = SOURCE_LABEL[source] || source;
         post("{% url 'logs_fetch' %}", {
+            env: currentLogEnv(),
             source: source,
             color: currentColor(),
             lines: linesSel.value,
@@ -452,6 +474,9 @@
 
     document.querySelectorAll('input[name="source"]').forEach(function (el) {
         el.addEventListener("change", function () { syncColorVisibility(); fetchLogs(); });
+    });
+    document.querySelectorAll('input[name="logenv"]').forEach(function (el) {
+        el.addEventListener("change", function () { loadStatus(); fetchLogs(); });
     });
     document.querySelectorAll('input[name="color"]').forEach(function (el) {
         el.addEventListener("change", fetchLogs);

--- a/apps/accounts/utils/deploy_agent.py
+++ b/apps/accounts/utils/deploy_agent.py
@@ -47,12 +47,23 @@ def _call(payload, timeout=15):
         raise DeployAgentError("invalid response from deploy agent") from exc
 
 
-def ping():
+def _with_target(payload, target):
+    """Tag a request for a remote agent so the local (prod) agent forwards it
+    (#1868). "local"/None means handle it here — no target field, wire-identical
+    to the pre-forwarding protocol. A forwarded action's state (e.g. a deploy_id)
+    lives in the remote agent, so status/cancel for it must carry the same
+    target."""
+    if target and target != "local":
+        payload["target"] = target
+    return payload
+
+
+def ping(target=None):
     """Liveness + allowlist discovery."""
-    return _call({"action": "ping"})
+    return _call(_with_target({"action": "ping"}, target))
 
 
-def start_deploy(actor, env, services, no_pull=False, delay_seconds=0):
+def start_deploy(actor, env, services, no_pull=False, delay_seconds=0, target=None):
     """Ask the agent to start a deploy. Returns the agent's JSON (deploy_id on
     success, or a rejection with an `error` key).
 
@@ -60,25 +71,25 @@ def start_deploy(actor, env, services, no_pull=False, delay_seconds=0):
     single-flight slot immediately (status "scheduled") and fires deploy.sh
     itself after the delay — surviving this container restarting. Cancel a
     scheduled deploy with cancel_deploy()."""
-    return _call({
+    return _call(_with_target({
         "action": "deploy",
         "actor": actor,
         "env": env,
         "services": services,
         "no_pull": no_pull,
         "delay_seconds": int(delay_seconds),
-    })
+    }, target))
 
 
-def cancel_deploy(deploy_id):
+def cancel_deploy(deploy_id, target=None):
     """Cancel a still-scheduled deploy before it fires. No-op (409) once it has
     started running. Returns the agent's JSON."""
-    return _call({"action": "cancel", "deploy_id": deploy_id})
+    return _call(_with_target({"action": "cancel", "deploy_id": deploy_id}, target))
 
 
-def deploy_status(deploy_id):
+def deploy_status(deploy_id, target=None):
     """Poll a running/finished/scheduled deploy by id."""
-    return _call({"action": "status", "deploy_id": deploy_id})
+    return _call(_with_target({"action": "status", "deploy_id": deploy_id}, target))
 
 
 # ── Read-only log access (ishar-web#104) ─────────────────────────────────────
@@ -87,25 +98,28 @@ def deploy_status(deploy_id):
 # source / color and argv-execs docker with no shell.
 
 
-def log_status(env):
+def log_status(env, target=None):
     """Live-color + which colors/web containers are up, plus the source/color
     allowlists. Powers the viewer's LIVE badge and control state."""
-    return _call({"action": "log-status", "env": env})
+    return _call(_with_target({"action": "log-status", "env": env}, target))
 
 
-def fetch_log(actor, env, source, color="live", lines=500, timeout=25):
+def fetch_log(actor, env, source, color="live", lines=500, timeout=25, target=None):
     """Return a byte-capped tail of one log source. `source` is runlog|stderr|web;
     `color` is live|blue|green (ignored for web). The agent re-validates all of
     it. A slightly longer timeout than deploy calls: reading an idle color's
     runlog spins up a throwaway container host-side."""
     return _call(
-        {
-            "action": "log-tail",
-            "actor": actor,
-            "env": env,
-            "source": source,
-            "color": color,
-            "lines": int(lines),
-        },
+        _with_target(
+            {
+                "action": "log-tail",
+                "actor": actor,
+                "env": env,
+                "source": source,
+                "color": color,
+                "lines": int(lines),
+            },
+            target,
+        ),
         timeout=timeout,
     )

--- a/apps/accounts/views/deploy.py
+++ b/apps/accounts/views/deploy.py
@@ -1,10 +1,14 @@
-"""Forger-gated web deploy button (#1754).
+"""Web deploy console (#1754, #1868).
 
-A phone-friendly page (NOT Django admin) where a Forger picks an environment and
-services and triggers scripts/deploy.sh on the host via the deploy agent. The
-deploy POST requires password re-entry (re-auth), so a driven/XSS'd session
-cannot fire a deploy on its own — see docs/infrastructure/reboot_process.md §4.
+A phone-friendly page (NOT Django admin) where staff pick an environment and
+services and trigger scripts/deploy.sh on the host via the deploy agent. Prod
+runs on the local host agent; staging is a separate box the agent forwards to
+(#1868). The page floor is Eternal, but a *prod* deploy requires Forger — the
+per-env gate is enforced here, not just disabled in the UI. The deploy POST
+requires password re-entry (re-auth), so a driven/XSS'd session cannot fire a
+deploy on its own — see docs/infrastructure/reboot_process.md §4.
 """
+import json
 from datetime import timedelta
 
 from django.conf import settings
@@ -17,7 +21,7 @@ from apps.connect import tracker as connect_tracker
 from apps.core.models.webadmin import WebAdminCommand
 from apps.core.utils import webadmin
 from apps.core.utils.staff import staff_name
-from apps.core.views.mixins import ForgerRequiredMixin, NeverCacheMixin
+from apps.core.views.mixins import EternalRequiredMixin, NeverCacheMixin
 
 from ..utils.deploy_agent import (
     DeployAgentError,
@@ -32,26 +36,94 @@ from ..utils.deploy_agent import (
 SCHEDULE_DELAY_MIN = 60
 SCHEDULE_DELAY_MAX = 3600
 
+# DEPLOY_ENVIRONMENTS[env]["gate"] -> the Account predicate that gates deploying
+# that env. immortal_level is the sole source of truth (game-owned column).
+GATE_METHODS = {"eternal": "is_eternal", "forger": "is_forger", "god": "is_god"}
 
-class DeployView(ForgerRequiredMixin, NeverCacheMixin, TemplateView):
-    """Render the deploy control page. Forger-only (ForgerRequiredMixin -> 404)."""
+
+def _resolve_deploy_env(request):
+    """Resolve the POSTed console env for a *mutating* deploy and enforce its
+    gate (prod → Forger, staging → Eternal). Returns (spec, error_response) with
+    exactly one non-None. This is the real authorization boundary; the UI only
+    disables the control an account can't use."""
+    key = request.POST.get("env", "")
+    spec = settings.DEPLOY_ENVIRONMENTS.get(key)
+    if spec is None:
+        return None, JsonResponse({"message": "Unknown environment."}, status=400)
+    if not getattr(request.user, GATE_METHODS[spec["gate"]])():
+        return None, JsonResponse(
+            {"message": f"Deploying {key} requires {spec['gate'].title()} or higher."},
+            status=403,
+        )
+    return spec, None
+
+
+def _poll_target(request):
+    """Forward target for a status/cancel poll. A forwarded deploy's state lives
+    in the remote agent, so the poll must reach the same agent the deploy ran on.
+    Read-only, so no gate; an absent/unknown env falls back to the local agent."""
+    spec = settings.DEPLOY_ENVIRONMENTS.get(request.POST.get("env", ""))
+    return spec["target"] if spec else "local"
+
+
+class DeployView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
+    """Render the deploy control page. Eternal floor (EternalRequiredMixin ->
+    404); a prod deploy additionally requires Forger (enforced in the actions)."""
 
     template_name = "deploy.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["deploy_envs"] = settings.DEPLOY_AGENT_ENVS
-        context["deploy_services"] = settings.DEPLOY_AGENT_SERVICES
+        user = self.request.user
+
+        # Show every env, but mark which ones this account may actually deploy
+        # (a disabled control + note beats hiding it). The default selection is
+        # the first env the account can deploy — prod for a Forger, staging for
+        # an Eternal. Services are the union across envs, each tagged with the
+        # envs it belongs to so the UI can show only the relevant ones.
+        envs = []
+        service_order = []
+        service_envs = {}
+        default_taken = False
+        for key, spec in settings.DEPLOY_ENVIRONMENTS.items():
+            allowed = getattr(user, GATE_METHODS[spec["gate"]])()
+            checked = allowed and not default_taken
+            default_taken = default_taken or checked
+            envs.append({
+                "key": key,
+                "icon": spec["icon"],
+                "gate": spec["gate"].title(),
+                "allowed": allowed,
+                "checked": checked,
+            })
+            for svc in spec["services"]:
+                if svc not in service_envs:
+                    service_envs[svc] = []
+                    service_order.append(svc)
+                service_envs[svc].append(key)
+
+        context["deploy_envs"] = envs
+        context["deploy_locked"] = [e for e in envs if not e["allowed"]]
+        context["deploy_services"] = [
+            {"name": s, "envs": " ".join(service_envs[s]), "checked": s == "ishar-app"}
+            for s in service_order
+        ]
+        context["deploy_env_meta"] = json.dumps({
+            key: {"target": spec["target"], "services": list(spec["services"]),
+                  "schedulable": spec["target"] == "local"}
+            for key, spec in settings.DEPLOY_ENVIRONMENTS.items()
+        })
         context["deploy_configured"] = bool(settings.DEPLOY_AGENT_SECRET)
         return context
 
 
-class DeployActionView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployActionView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only endpoint that starts a deploy. CSRF-protected (no exemption).
 
-    Requires re-authentication: the Forger must re-enter their account password on
-    this request. The heavy validation (env/service allowlist, injection
-    inertness) lives in the host agent; we surface its verdict.
+    Requires re-authentication (password) AND the target env's gate (Forger for
+    prod). Env/service validation and injection inertness live in the host agent
+    — the local one for prod, the forwarded remote for staging; we surface its
+    verdict.
     """
 
     http_method_names = ("post",)
@@ -64,16 +136,26 @@ class DeployActionView(ForgerRequiredMixin, NeverCacheMixin, View):
                 {"message": "Re-authentication failed."}, status=403
             )
 
-        env = request.POST.get("env", "")
+        spec, err = _resolve_deploy_env(request)
+        if err:
+            return err
+
         services = request.POST.getlist("services")
+        bad = [s for s in services if s not in spec["services"]]
+        if bad:
+            return JsonResponse(
+                {"message": f"Service(s) not available on this env: {', '.join(bad)}"},
+                status=400,
+            )
         no_pull = request.POST.get("no_pull") in ("1", "true", "on")
 
         try:
             result = start_deploy(
                 actor=request.user.get_username(),
-                env=env,
+                env=spec["env"],
                 services=services,
                 no_pull=no_pull,
+                target=spec["target"],
             )
         except DeployAgentError as exc:
             return JsonResponse(
@@ -86,9 +168,9 @@ class DeployActionView(ForgerRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(result, status=status)
 
 
-class DeployPingView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployPingView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only liveness probe for the host agent. Powers the console's live
-    agent-health pill. Read-only (no re-auth); Forger gate + CSRF still apply."""
+    agent-health pill. Read-only (no re-auth); Eternal gate + CSRF still apply."""
 
     http_method_names = ("post",)
 
@@ -107,14 +189,14 @@ class DeployPingView(ForgerRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(result)
 
 
-class DeployWebClientsView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployWebClientsView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only count of live web-client (/connect) game sessions.
 
     Deploying ishar-web restarts Daphne, which severs every browser player's
     telnet proxy mid-game — the console polls this to warn before that happens.
     Reads an in-process registry (Daphne is a single process; see
     apps.connect.tracker), so it costs nothing and needs no agent or DB.
-    Read-only (no re-auth); Forger gate + CSRF still apply.
+    Read-only (no re-auth); Eternal gate + CSRF still apply.
     """
 
     http_method_names = ("post",)
@@ -123,10 +205,12 @@ class DeployWebClientsView(ForgerRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(connect_tracker.snapshot())
 
 
-class DeployScheduleView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployScheduleView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only: schedule a deploy after a delay, warning players first.
 
-    One action, two effects, in this order:
+    Prod-only: the countdown is announced to the live game, which is meaningless
+    for staging (a separate box with no prod players), so a non-local target is
+    rejected. One action, two effects, in this order:
       1. Ask the host agent to schedule the deploy (it holds the timer and fires
          deploy.sh itself after the delay — surviving this container restarting).
       2. Only if that was accepted, enqueue a `reboot_notice` so the game counts
@@ -147,6 +231,15 @@ class DeployScheduleView(ForgerRequiredMixin, NeverCacheMixin, View):
                 {"message": "Re-authentication failed."}, status=403
             )
 
+        spec, err = _resolve_deploy_env(request)
+        if err:
+            return err
+        if spec["target"] != "local":
+            return JsonResponse(
+                {"message": "Scheduling with a player warning is prod-only."},
+                status=400,
+            )
+
         delay_raw = request.POST.get("delay_seconds", "")
         if not delay_raw.isdigit():
             return JsonResponse({"message": "Invalid delay."}, status=400)
@@ -156,18 +249,24 @@ class DeployScheduleView(ForgerRequiredMixin, NeverCacheMixin, View):
                 {"message": "Delay must be between 1 and 60 minutes."}, status=400
             )
 
-        env = request.POST.get("env", "")
         services = request.POST.getlist("services")
+        bad = [s for s in services if s not in spec["services"]]
+        if bad:
+            return JsonResponse(
+                {"message": f"Service(s) not available on this env: {', '.join(bad)}"},
+                status=400,
+            )
         no_pull = request.POST.get("no_pull") in ("1", "true", "on")
 
         # 1. Schedule the deploy on the host agent (the part that can be refused).
         try:
             result = start_deploy(
                 actor=request.user.get_username(),
-                env=env,
+                env=spec["env"],
                 services=services,
                 no_pull=no_pull,
                 delay_seconds=delay_seconds,
+                target=spec["target"],
             )
         except DeployAgentError as exc:
             return JsonResponse(
@@ -189,13 +288,13 @@ class DeployScheduleView(ForgerRequiredMixin, NeverCacheMixin, View):
         return JsonResponse({**result, "notice_task_id": task.id}, status=200)
 
 
-class DeployCancelScheduledView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployCancelScheduledView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only: cancel a still-scheduled deploy and tell players it's off.
 
     Cancels the host agent's pending deploy (a no-op once it has started
-    running), then — if the cancel landed — enqueues a `reboot_cancel` so the
-    game announces the stand-down. No re-auth: cancelling is the safe direction.
-    Forger gate + CSRF still apply.
+    running), then — if the cancel landed on a prod (local) deploy — enqueues a
+    `reboot_cancel` so the game announces the stand-down. No re-auth: cancelling
+    is the safe direction. Eternal gate + CSRF still apply.
     """
 
     http_method_names = ("post",)
@@ -205,14 +304,17 @@ class DeployCancelScheduledView(ForgerRequiredMixin, NeverCacheMixin, View):
         if not deploy_id:
             return JsonResponse({"message": "Missing deploy_id."}, status=400)
 
+        target = _poll_target(request)
         try:
-            result = cancel_deploy(deploy_id)
+            result = cancel_deploy(deploy_id, target=target)
         except DeployAgentError as exc:
             return JsonResponse(
                 {"message": f"Deploy agent unavailable: {exc}"}, status=503
             )
 
-        if result.get("ok"):
+        # Only prod deploys are scheduled (and thus announced), so only they get
+        # a stand-down announcement.
+        if result.get("ok") and target == "local":
             webadmin.enqueue(
                 command=WebAdminCommand.REBOOT_CANCEL,
                 payload={},
@@ -224,7 +326,7 @@ class DeployCancelScheduledView(ForgerRequiredMixin, NeverCacheMixin, View):
         return JsonResponse(result, status=status)
 
 
-class DeployGameStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployGameStatusView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only read of the game's presence heartbeat (Contract 2, #1771).
 
     Powers the console's live "Game" pill and the pre-deploy warning when
@@ -233,7 +335,7 @@ class DeployGameStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
     game_presence (one row per in-game character); we report whether the game
     is up (heartbeat within the staleness window), the live player count, and
     the heartbeat age. Degrades gracefully before the game ships the heartbeat
-    (tables absent / no row). Read-only (no re-auth); Forger gate + CSRF apply.
+    (tables absent / no row). Read-only (no re-auth); Eternal gate + CSRF apply.
     """
 
     http_method_names = ("post",)
@@ -280,9 +382,10 @@ class DeployGameStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
         )
 
 
-class DeployStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
+class DeployStatusView(EternalRequiredMixin, NeverCacheMixin, View):
     """POST-only status poll for a running/finished deploy. No re-auth (read
-    only); Forger gate + CSRF still apply."""
+    only); Eternal gate + CSRF still apply. Carries the deploy's env so a
+    forwarded (staging) deploy is polled on the agent that holds its state."""
 
     http_method_names = ("post",)
 
@@ -291,7 +394,7 @@ class DeployStatusView(ForgerRequiredMixin, NeverCacheMixin, View):
         if not deploy_id:
             return JsonResponse({"message": "Missing deploy_id."}, status=400)
         try:
-            result = deploy_status(deploy_id)
+            result = deploy_status(deploy_id, target=_poll_target(request))
         except DeployAgentError as exc:
             return JsonResponse(
                 {"message": f"Deploy agent unavailable: {exc}"}, status=503

--- a/apps/accounts/views/logs.py
+++ b/apps/accounts/views/logs.py
@@ -44,6 +44,20 @@ def _agent_version_hint(payload):
     return None
 
 
+def _log_env(request):
+    """(deploy_env, target) for the requested console env. Logs are Eternal for
+    every env, so there's no gate — just map the selection to a box: the
+    deploy.sh env (for container names) and the forward target (#1868). An
+    absent/unknown env falls back to LOG_VIEWER_ENV / the local agent."""
+    key = request.POST.get("env") or settings.LOG_VIEWER_ENV
+    spec = settings.DEPLOY_ENVIRONMENTS.get(key) or settings.DEPLOY_ENVIRONMENTS.get(
+        settings.LOG_VIEWER_ENV
+    )
+    if spec is None:
+        return settings.LOG_VIEWER_ENV, None
+    return spec["env"], spec["target"]
+
+
 class LogViewerView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
     """Render the log viewer. Eternal-gated (staff); unauthorized -> 404."""
 
@@ -56,6 +70,12 @@ class LogViewerView(EternalRequiredMixin, NeverCacheMixin, TemplateView):
         context["log_default_lines"] = DEFAULT_LINES
         context["log_levels"] = LEVELS
         context["log_configured"] = bool(settings.DEPLOY_AGENT_SECRET)
+        # Env selector: every deploy env is viewable at Eternal; default to
+        # LOG_VIEWER_ENV. A single env renders as one (still-labelled) chip.
+        context["log_envs"] = [
+            {"key": key, "icon": spec["icon"], "checked": key == settings.LOG_VIEWER_ENV}
+            for key, spec in settings.DEPLOY_ENVIRONMENTS.items()
+        ]
         return context
 
 
@@ -66,8 +86,9 @@ class LogStatusView(EternalRequiredMixin, NeverCacheMixin, View):
     http_method_names = ("post",)
 
     def post(self, request, *args, **kwargs):
+        env, target = _log_env(request)
         try:
-            result = log_status(settings.LOG_VIEWER_ENV)
+            result = log_status(env, target=target)
         except DeployAgentError as exc:
             return JsonResponse(
                 {"ok": False, "message": f"Log agent unavailable: {exc}"},
@@ -100,13 +121,15 @@ class LogFetchView(EternalRequiredMixin, NeverCacheMixin, View):
         except (TypeError, ValueError):
             lines = DEFAULT_LINES
 
+        env, target = _log_env(request)
         try:
             data = fetch_log(
                 actor=request.user.get_username(),
-                env=settings.LOG_VIEWER_ENV,
+                env=env,
                 source=source,
                 color=color,
                 lines=lines,
+                target=target,
             )
         except DeployAgentError as exc:
             return JsonResponse(

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -193,6 +193,18 @@
     background: var(--ac-danger-wash);
     border-color: rgba(214,75,75,.5);
 }
+/* Staging's intent tint (blue — the safe, non-prod box). */
+.btn-check:checked + .ac-seg__item--staging {
+    color: #bcd8ff;
+    background: var(--ac-info-wash);
+    border-color: rgba(74,134,207,.5);
+}
+/* An env above the viewer's level: dimmed and not selectable. */
+.btn-check:disabled + .ac-seg__item {
+    opacity: .55;
+    cursor: not-allowed;
+}
+.ac-seg__lock { width: .8rem; height: .8rem; opacity: .7; }
 .btn-check:focus-visible + .ac-seg__item {
     outline: 2px solid var(--ac-accent);
     outline-offset: 2px;

--- a/apps/core/views/mixins.py
+++ b/apps/core/views/mixins.py
@@ -26,22 +26,6 @@ class GodRequiredMixin(View):
         return super().dispatch(request, *args, **kwargs)
 
 
-class ForgerRequiredMixin(View):
-    """Restrict a view to Forger-level accounts (immortal_level >= FORGER).
-
-    Same 404-for-everyone-else convention as GodRequiredMixin. Gates the Deploy
-    Console: firing a prod deploy sits one rung below God but above the Eternal
-    staff floor. game-DB immortal_level is the sole source of truth (see
-    apps/accounts/models/account.py: is_forger()).
-    """
-
-    def dispatch(self, request, *args, **kwargs):
-        user = getattr(request, "user", None)
-        if not (user and user.is_authenticated and user.is_forger()):
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
-
-
 class EternalRequiredMixin(View):
     """Restrict a view to Eternal-level accounts (immortal_level >= ETERNAL).
 

--- a/settings.py
+++ b/settings.py
@@ -282,18 +282,35 @@ MUD_PORT = int(getenv("MUD_PORT", 23))
 # the agent's allowlist is. See docs/infrastructure/reboot_process.md §4.
 DEPLOY_AGENT_SOCKET = getenv("DEPLOY_AGENT_SOCKET", "/run/ishar-deploy/deploy-agent.sock")
 DEPLOY_AGENT_SECRET = getenv("DEPLOY_AGENT_SECRET", "")
-# Allowlist surfaced in the UI. The agent re-validates authoritatively; ishar-db
-# is intentionally absent (a phone-button DB rebuild under a live game is a
-# footgun). Prod only: staging.isharmud.com is a separate Lightsail box, and this
-# agent reaches the local (prod) Docker host only — offering "test" here would be
-# a control that runs deploy.sh against the wrong box and can never touch staging.
-DEPLOY_AGENT_ENVS = ("prod",)
-DEPLOY_AGENT_SERVICES = ("ishar-app", "ishar-web", "ishar-feedback-bridge")
+# Deploy Console + Log Viewer environments (#1868). Each console env maps to how
+# the host agent runs it: `target` selects the agent — "local" is the prod host
+# agent; any other name is FORWARDED to that remote (the agent's
+# ISHAR_DEPLOY_REMOTES). `env` is the deploy.sh env on that box. `services` is the
+# per-env deploy allowlist (staging is game-only — it has no website). `gate` is
+# the minimum immortal level to DEPLOY it (logs are Eternal for every env). The
+# agent re-validates target/env/services authoritatively; ishar-db is never
+# offered — a phone-button DB rebuild under a live game is a footgun.
+DEPLOY_ENVIRONMENTS = {
+    "prod": {
+        "target": "local",
+        "env": "prod",
+        "services": ("ishar-app", "ishar-web", "ishar-feedback-bridge"),
+        "gate": "forger",
+        "icon": "hdd-stack",
+    },
+    "staging": {
+        "target": "staging",
+        "env": "test",
+        "services": ("ishar-app", "ishar-feedback-bridge"),
+        "gate": "eternal",
+        "icon": "cone-striped",
+    },
+}
 
 # Staff log viewer (/portal/logs/, ishar-web#104). Reuses the same host agent,
-# socket, and secret as the deploy button — the log actions are read-only
-# additions to that agent. LOG_VIEWER_ENV is which deploy env the viewer reads
-# (prod in production); the agent still re-validates it against its own allowlist.
+# socket, and secret as the deploy console, and the DEPLOY_ENVIRONMENTS map above
+# (logs are Eternal for every env; a non-local env is forwarded like a deploy).
+# LOG_VIEWER_ENV is the viewer's default env selection.
 LOG_VIEWER_ENV = getenv("LOG_VIEWER_ENV", "prod")
 LOG_VIEWER_SOURCES = ("runlog", "stderr", "web")
 


### PR DESCRIPTION
Relates to isharmud/ishar-mud#1868 — this is Phase 3 (the ishar-web console/log wiring + per-env authz) on top of the merged transport (isharmud/ishar-mud#1869). It doesn't close #1868: the docs pass and the optional TLS fast-follow remain.

### Problem

Staging (`staging.isharmud.com`, a separate box) could be deployed and tailed only over SSH. Now that the host agent can forward to a peer (isharmud/ishar-mud#1869), the console can drive staging too — but only if the UI can target it and the gate splits correctly: a prod deploy should stay Forger, while staging (and log-reading) is fine at Eternal.

### Solution

- **Env model** (`settings.DEPLOY_ENVIRONMENTS`): each console env → `{target, deploy.sh env, services, gate}`. `prod` = local agent / all services / Forger; `staging` = forwarded agent / game-only / Eternal. The browser sends only the env name; the view resolves the rest and the agent client tags the request with `target` so the prod agent forwards it — deploy, status, cancel, and logs all ride the one transport.
- **Authz**: the page and read endpoints drop to an **Eternal** floor; the deploy/schedule actions enforce the env's gate **server-side** (`is_forger()` for prod) — the disabled control + note is only UX, not the boundary. An Eternal POSTing `env=prod` gets 403. "Schedule & warn players" stays prod-only (it announces to the live game).
- **UX**: the staging toggle appears for everyone; prod is shown **disabled with a lock + an "ask a Forger/God" note** for Eternals (discoverable over hidden). Switching to staging shows only its game-only services (`ishar-web` disappears) and drops the prod-specific player/web-client warnings. The log viewer gains an env selector.
- **Cleanup**: removed the now-unused `ForgerRequiredMixin` (the per-env gate uses `is_forger()` inline); re-added a blue `--staging` seg tint.

### Verification

- `py_compile` on all changed Python; `node --check` on both templates' extracted JS; **Django template compile** of both templates (catches `{% %}`/block errors).
- Phone-width (390px) headless render of the Environment panel in both the Forger view (prod + staging enabled) and the Eternal view (prod locked + note, staging selected) — shared with the owner.
- **Not** run against the live DB/agent. Left to you on prod: a Forger deploying prod, an Eternal deploying staging (and being refused prod), and tailing staging logs end to end through the now-live transport.

### Deploy notes

`settings.py` (env model) + views + templates + `admin-console.css` (edited in place, already tracked). `collectstatic` on container start picks up the CSS. The console offers staging regardless of transport state; if the agent's `staging` remote isn't configured, a staging deploy returns a clear `forward-unavailable` rather than failing silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HxSEpTrsRw5Ft6SAWBJTq)_