### PR TITLE
Player profile: add public kit paperdoll, inspect-gated standing & ledger

### DIFF
--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -1169,6 +1169,90 @@ a.ac-link--featured:visited .ac-link__name { color: var(--ac-accent); }
     white-space: normal;
 }
 
+/* -------------------------------------------------------- kit doll --- */
+/* Profile equipment paperdoll (player.html): slot tiles in wear order —
+   head to feet, held items in their worn position. Tapping a filled slot
+   pins its item card below the grid (hover isn't real on phones, so the
+   title-attribute hover text is desktop sugar, never the only affordance). */
+.ac-doll {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+    gap: .5rem;
+}
+.ac-doll__slot {
+    display: flex;
+    align-items: center;
+    gap: .55rem;
+    padding: .45rem .6rem;
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border);
+    border-radius: var(--ac-radius-sm);
+    color: var(--ac-text);
+    text-align: left;
+    min-width: 0;
+}
+button.ac-doll__slot {
+    cursor: pointer;
+    transition: border-color .15s ease, background .15s ease;
+}
+button.ac-doll__slot:hover {
+    border-color: var(--ac-border-2);
+    background: var(--ac-elev);
+}
+button.ac-doll__slot:focus-visible {
+    outline: 2px solid var(--ac-accent);
+    outline-offset: 1px;
+}
+.ac-doll__slot--active,
+button.ac-doll__slot.ac-doll__slot--active:hover {
+    border-color: rgba(255, 170, 119, .45);
+    background: var(--ac-wash);
+}
+.ac-doll__slot--empty { border-style: dashed; color: var(--ac-dim); }
+.ac-doll__icon { flex: 0 0 auto; display: inline-flex; color: var(--ac-accent); }
+.ac-doll__icon .bi { width: 1.05rem; height: 1.05rem; }
+.ac-doll__slot--empty .ac-doll__icon { color: var(--ac-dim); opacity: .55; }
+.ac-doll__body { min-width: 0; display: flex; flex-direction: column; }
+.ac-doll__label {
+    font-size: .62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--ac-dim);
+}
+.ac-doll__name {
+    font-size: .8rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ac-doll__ench { margin-left: auto; flex: 0 0 auto; color: var(--ac-accent); }
+.ac-doll__card {
+    margin-top: .65rem;
+    padding: .75rem .85rem;
+    background: var(--ac-bg);
+    border: 1px solid var(--ac-border-2);
+    border-left: 3px solid var(--ac-accent);
+    border-radius: var(--ac-radius-sm);
+}
+.ac-doll__card[hidden] { display: none; }
+.ac-doll__cardhead {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .4rem;
+    margin-bottom: .55rem;
+    font-weight: 600;
+}
+.ac-doll__mods {
+    list-style: none;
+    margin: .55rem 0 0;
+    padding: 0;
+    font-size: .82rem;
+}
+.ac-doll__mods li { color: var(--ac-ok); font-variant-numeric: tabular-nums; }
+.ac-doll__flavor { margin: .55rem 0 0; font-size: .8rem; font-style: italic; color: var(--ac-dim); }
+
 /* ---------------------------------------------------------- motion --- */
 @keyframes ac-pulse {
     0%, 100% { opacity: 1;   transform: scale(1); }
@@ -1226,4 +1310,8 @@ a.ac-link--featured:visited .ac-link__name { color: var(--ac-accent); }
     .ac-toggle:hover { transform: none; }
     .ac-row:hover { background: transparent; }
     .ac-table tbody tr:hover { background: transparent; }
+    button.ac-doll__slot:not(.ac-doll__slot--active):hover {
+        border-color: var(--ac-border);
+        background: var(--ac-bg);
+    }
 }

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -1170,14 +1170,40 @@ a.ac-link--featured:visited .ac-link__name { color: var(--ac-accent); }
 }
 
 /* -------------------------------------------------------- kit doll --- */
-/* Profile equipment paperdoll (player.html): slot tiles in wear order —
-   head to feet, held items in their worn position. Tapping a filled slot
-   pins its item card below the grid (hover isn't real on phones, so the
-   title-attribute hover text is desktop sugar, never the only affordance). */
+/* Profile equipment paperdoll (player.html): slot columns flank a drawn
+   silhouette — head/neck/back zone left, torso/arms right — with held items
+   and the lower body in a strip beneath. Tapping a filled slot pins its item
+   card below the doll (hover isn't real on phones, so the title-attribute
+   hover text is desktop sugar, never the only affordance). On phones the
+   figure steps aside and the columns sit side by side. */
 .ac-doll {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(6rem, 8rem) minmax(0, 1fr);
+    gap: .5rem .8rem;
+    align-items: start;
+}
+.ac-doll__col {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    min-width: 0;
+}
+.ac-doll__figure {
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: .4rem 0;
+    color: var(--ac-elev);
+}
+.ac-doll__figure svg { width: 100%; max-width: 7.5rem; height: auto; }
+.ac-doll__strip {
+    grid-column: 1 / -1;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
     gap: .5rem;
+    border-top: 1px dashed var(--ac-border);
+    padding-top: .6rem;
 }
 .ac-doll__slot {
     display: flex;
@@ -1275,6 +1301,8 @@ button.ac-doll__slot.ac-doll__slot--active:hover {
 
 /* ----------------------------------------------------- responsive --- */
 @media (max-width: 575.98px) {
+    .ac-doll { grid-template-columns: 1fr 1fr; gap: .5rem; }
+    .ac-doll__figure { display: none; }
     .ac-hero { flex-wrap: wrap; padding: .9rem 1rem; }
     .ac-hero__status { align-self: stretch; min-width: 0; }
     /* A hero's primary CTA fills the width once the hero wraps, so the flagship

--- a/apps/objects/models/enchantment.py
+++ b/apps/objects/models/enchantment.py
@@ -1,0 +1,63 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class Enchantment(models.Model):
+    """Ishar enchantment definition ("enchantments" game table)."""
+
+    id = models.AutoField(
+        primary_key=True,
+        help_text=_("Primary key identification number of the enchantment."),
+        verbose_name=_("Enchantment ID"),
+    )
+    enum_symbol = models.CharField(
+        max_length=64,
+        unique=True,
+        help_text=_("Game code enumeration symbol of the enchantment."),
+        verbose_name=_("Enum Symbol"),
+    )
+    name = models.CharField(
+        max_length=128,
+        help_text=_("Name of the enchantment."),
+        verbose_name=_("Name"),
+    )
+    description = models.TextField(
+        blank=True,
+        null=True,
+        help_text=_("Description of the enchantment."),
+        verbose_name=_("Description"),
+    )
+    obj_display = models.CharField(
+        max_length=256,
+        blank=True,
+        null=True,
+        help_text=_("String displayed on objects carrying the enchantment."),
+        verbose_name=_("Object Display"),
+    )
+    gear_type = models.IntegerField(
+        blank=True,
+        null=True,
+        help_text=_("Target gear type of the enchantment."),
+        verbose_name=_("Gear Type"),
+    )
+    is_exotic = models.BooleanField(
+        default=False,
+        help_text=_(
+            "Has special combat handling beyond stat modifiers."
+        ),
+        verbose_name=_("Is Exotic?"),
+    )
+
+    class Meta:
+        managed = False
+        db_table = "enchantments"
+        default_related_name = "enchantment"
+        ordering = ("name",)
+        verbose_name = _("Enchantment")
+        verbose_name_plural = _("Enchantments")
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {self.__str__()} ({self.pk})"
+
+    def __str__(self) -> str:
+        return self.name

--- a/apps/players/kit.py
+++ b/apps/players/kit.py
@@ -3,9 +3,11 @@ from apps.objects.models.object_mod import ObjectObjectMod
 from .models.object import PlayerObject, PositionType, PositionValue
 
 
-# Head-to-feet paperdoll order, held items in their worn position — the same
-# presentation order the HUD uses for recipe categories (docs/design ADR).
-KIT_SLOTS = (
+# Paperdoll layout: head/neck/back zone flanks the figure's left, torso/arms
+# its right, held items and lower body run in a strip beneath — the same
+# head-to-feet presentation order the HUD uses for recipe categories
+# (docs/design ADR). Each entry: (position, label, sprite icon).
+KIT_LEFT = (
     (PositionValue.EQUIPPED_ON_FOREHEAD, "Forehead", "gem"),
     (PositionValue.EQUIPPED_ON_HEAD, "Head", "record-circle"),
     (PositionValue.EQUIPPED_ON_FACE, "Face", "sunglasses"),
@@ -15,15 +17,19 @@ KIT_SLOTS = (
     (PositionValue.EQUIPPED_ABOUT, "About", "layers"),
     (PositionValue.EQUIPPED_ON_BACK, "Back", "backpack2"),
     (PositionValue.EQUIPPED_ON_BACK_ALT, "Back ②", "backpack2"),
+)
+KIT_RIGHT = (
     (PositionValue.EQUIPPED_ON_BODY, "Body", "person-standing"),
     (PositionValue.EQUIPPED_ON_UPPER_BODY, "Upper Body", "person-arms-up"),
     (PositionValue.EQUIPPED_ON_CHEST, "Chest", "shield-shaded"),
     (PositionValue.EQUIPPED_ON_ARMS, "Arms", "grip-vertical"),
-    (PositionValue.EQUIPPED_ON_HANDS, "Hands", "hand-index-thumb"),
     (PositionValue.EQUIPPED_ON_LEFT_WRIST, "Left Wrist", "watch"),
     (PositionValue.EQUIPPED_ON_RIGHT_WRIST, "Right Wrist", "watch"),
+    (PositionValue.EQUIPPED_ON_HANDS, "Hands", "hand-index-thumb"),
     (PositionValue.EQUIPPED_ON_LEFT_FINGER, "Left Finger", "suit-diamond"),
     (PositionValue.EQUIPPED_ON_RIGHT_FINGER, "Right Finger", "suit-diamond"),
+)
+KIT_STRIP = (
     (PositionValue.WIELDING, "Wielded", "lightning-charge"),
     (PositionValue.WIELDING_IN_TWO, "Two-Handed", "lightning"),
     (PositionValue.HELD_IN_LEFT_HAND, "Left Hand", "hand-index"),
@@ -34,8 +40,8 @@ KIT_SLOTS = (
 )
 
 
-def build_kit(player) -> list:
-    """Slot dicts for every wear position, worn item and its mods attached."""
+def build_kit(player) -> dict:
+    """Slot groups for the paperdoll, worn items and their mods attached."""
     worn = {}
     for player_object in PlayerObject.objects.filter(
         player=player,
@@ -54,14 +60,25 @@ def build_kit(player) -> list:
         ).select_related("object_mod").order_by("mod_slot"):
             mods.setdefault(object_mod.object_id, []).append(object_mod)
 
-    kit = []
-    for position, label, icon in KIT_SLOTS:
-        item = worn.get(int(position))
-        kit.append({
-            "position": int(position),
-            "label": label,
-            "icon": icon,
-            "item": item,
-            "mods": mods.get(item.object_id, ()) if item else (),
-        })
-    return kit
+    def build_group(specs):
+        group = []
+        for position, label, icon in specs:
+            item = worn.get(int(position))
+            group.append({
+                "position": int(position),
+                "label": label,
+                "icon": icon,
+                "item": item,
+                "mods": mods.get(item.object_id, ()) if item else (),
+            })
+        return group
+
+    left = build_group(KIT_LEFT)
+    right = build_group(KIT_RIGHT)
+    strip = build_group(KIT_STRIP)
+    return {
+        "left": left,
+        "right": right,
+        "strip": strip,
+        "filled": [s for s in left + right + strip if s["item"]],
+    }

--- a/apps/players/kit.py
+++ b/apps/players/kit.py
@@ -1,0 +1,67 @@
+from apps.objects.models.object_mod import ObjectObjectMod
+
+from .models.object import PlayerObject, PositionType, PositionValue
+
+
+# Head-to-feet paperdoll order, held items in their worn position — the same
+# presentation order the HUD uses for recipe categories (docs/design ADR).
+KIT_SLOTS = (
+    (PositionValue.EQUIPPED_ON_FOREHEAD, "Forehead", "gem"),
+    (PositionValue.EQUIPPED_ON_HEAD, "Head", "record-circle"),
+    (PositionValue.EQUIPPED_ON_FACE, "Face", "sunglasses"),
+    (PositionValue.EQUIPPED_IN_MOUTH, "Mouth", "emoji-smile"),
+    (PositionValue.EQUIPPED_ON_NECK, "Neck", "link-45deg"),
+    (PositionValue.EQUIPPED_ON_NECK_ALT, "Neck ②", "link-45deg"),
+    (PositionValue.EQUIPPED_ABOUT, "About", "layers"),
+    (PositionValue.EQUIPPED_ON_BACK, "Back", "backpack2"),
+    (PositionValue.EQUIPPED_ON_BACK_ALT, "Back ②", "backpack2"),
+    (PositionValue.EQUIPPED_ON_BODY, "Body", "person-standing"),
+    (PositionValue.EQUIPPED_ON_UPPER_BODY, "Upper Body", "person-arms-up"),
+    (PositionValue.EQUIPPED_ON_CHEST, "Chest", "shield-shaded"),
+    (PositionValue.EQUIPPED_ON_ARMS, "Arms", "grip-vertical"),
+    (PositionValue.EQUIPPED_ON_HANDS, "Hands", "hand-index-thumb"),
+    (PositionValue.EQUIPPED_ON_LEFT_WRIST, "Left Wrist", "watch"),
+    (PositionValue.EQUIPPED_ON_RIGHT_WRIST, "Right Wrist", "watch"),
+    (PositionValue.EQUIPPED_ON_LEFT_FINGER, "Left Finger", "suit-diamond"),
+    (PositionValue.EQUIPPED_ON_RIGHT_FINGER, "Right Finger", "suit-diamond"),
+    (PositionValue.WIELDING, "Wielded", "lightning-charge"),
+    (PositionValue.WIELDING_IN_TWO, "Two-Handed", "lightning"),
+    (PositionValue.HELD_IN_LEFT_HAND, "Left Hand", "hand-index"),
+    (PositionValue.HELD_IN_RIGHT_HAND, "Right Hand", "hand-index"),
+    (PositionValue.EQUIPPED_ON_WAIST, "Waist", "dash-circle"),
+    (PositionValue.EQUIPPED_ON_LEGS, "Legs", "person-walking"),
+    (PositionValue.EQUIPPED_ON_FEET, "Feet", "person-walking"),
+)
+
+
+def build_kit(player) -> list:
+    """Slot dicts for every wear position, worn item and its mods attached."""
+    worn = {}
+    for player_object in PlayerObject.objects.filter(
+        player=player,
+        position_type=PositionType.EQUIPMENT,
+    ).select_related("object", "object__flag", "enchant"):
+        worn.setdefault(player_object.position_val, player_object)
+
+    # ObjectObjectMod's "object" relation is a OneToOne onto a composite-key
+    #   table (multiple mod slots per vnum), so the reverse accessor lies —
+    #   query the through table directly and group by vnum.
+    mods = {}
+    vnums = {po.object_id for po in worn.values()}
+    if vnums:
+        for object_mod in ObjectObjectMod.objects.filter(
+            object_id__in=vnums,
+        ).select_related("object_mod").order_by("mod_slot"):
+            mods.setdefault(object_mod.object_id, []).append(object_mod)
+
+    kit = []
+    for position, label, icon in KIT_SLOTS:
+        item = worn.get(int(position))
+        kit.append({
+            "position": int(position),
+            "label": label,
+            "icon": icon,
+            "item": item,
+            "mods": mods.get(item.object_id, ()) if item else (),
+        })
+    return kit

--- a/apps/players/models/object.py
+++ b/apps/players/models/object.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from apps.objects.models.enchantment import Enchantment
 from apps.objects.models.object import Object
 from .player import PlayerBase
 
@@ -81,7 +82,10 @@ class PlayerObject(models.Model):
         to_field="vnum",
         verbose_name="Object",
     )
-    enchant = models.PositiveIntegerField(
+    enchant = models.ForeignKey(
+        to=Enchantment,
+        db_column="enchant",
+        on_delete=models.DO_NOTHING,
         blank=True,
         null=True,
         help_text="Enchantment of the player object.",

--- a/apps/players/templates/kit_slot.html
+++ b/apps/players/templates/kit_slot.html
@@ -1,0 +1,23 @@
+{% load ishar %}
+{% if slot.item %}
+<button class="ac-doll__slot" type="button" data-slot="{{ slot.position }}"
+        aria-expanded="false" aria-controls="kit-card-{{ slot.position }}"
+        title="{{ slot.item.object.longname }}{% if slot.item.enchant %} &middot; {{ slot.item.enchant.name }}{% endif %}">
+    <span class="ac-doll__icon">{% bi slot.icon %}</span>
+    <span class="ac-doll__body">
+        <span class="ac-doll__label">{{ slot.label }}</span>
+        <span class="ac-doll__name">{{ slot.item.object.longname }}</span>
+    </span>
+{% if slot.item.enchant %}
+    <span class="ac-doll__ench" title="Enchanted: {{ slot.item.enchant.name }}">&#10038;</span>
+{% endif %}
+</button>
+{% else %}
+<div class="ac-doll__slot ac-doll__slot--empty">
+    <span class="ac-doll__icon">{% bi slot.icon %}</span>
+    <span class="ac-doll__body">
+        <span class="ac-doll__label">{{ slot.label }}</span>
+        <span class="ac-doll__name">&mdash;</span>
+    </span>
+</div>
+{% endif %}

--- a/apps/players/templates/player.html
+++ b/apps/players/templates/player.html
@@ -170,6 +170,140 @@
     </div>
 {% endif %}
 
+{% if can_inspect %}
+    <div class="ac-panel">
+        <div class="ac-panel__h" id="kit">
+            {% bi "backpack2" %}
+            Kit
+            <a class="anchor-link" href="#kit" aria-label="Link to this section: Kit"></a>
+        </div>
+        <p class="ac-panel__hint">
+            Worn equipment as of the last autosave (within ~5 minutes).
+            Tap a slot for details &mdash; visible only to this character&#39;s
+            account and staff.
+        </p>
+        <div class="ac-doll" id="kit-doll">
+{% for slot in kit %}
+{% if slot.item %}
+            <button class="ac-doll__slot" type="button" data-slot="{{ slot.position }}"
+                    aria-expanded="false" aria-controls="kit-card-{{ slot.position }}"
+                    title="{{ slot.item.object.longname }}{% if slot.item.enchant %} &middot; {{ slot.item.enchant.name }}{% endif %}">
+                <span class="ac-doll__icon">{% bi slot.icon %}</span>
+                <span class="ac-doll__body">
+                    <span class="ac-doll__label">{{ slot.label }}</span>
+                    <span class="ac-doll__name">{{ slot.item.object.longname }}</span>
+                </span>
+{% if slot.item.enchant %}
+                <span class="ac-doll__ench" title="Enchanted: {{ slot.item.enchant.name }}">&#10038;</span>
+{% endif %}
+            </button>
+{% else %}
+            <div class="ac-doll__slot ac-doll__slot--empty">
+                <span class="ac-doll__icon">{% bi slot.icon %}</span>
+                <span class="ac-doll__body">
+                    <span class="ac-doll__label">{{ slot.label }}</span>
+                    <span class="ac-doll__name">&mdash;</span>
+                </span>
+            </div>
+{% endif %}
+{% endfor %}
+        </div>
+{% for slot in kit %}
+{% if slot.item %}
+        <div class="ac-doll__card" id="kit-card-{{ slot.position }}" hidden>
+            <div class="ac-doll__cardhead">
+                <span>{{ slot.item.object.longname }}</span>
+{% if slot.item.object.flag.artifact %}
+                <span class="ac-pill ac-pill--warn">artifact</span>
+{% endif %}
+{% if slot.item.object.flag.relic %}
+                <span class="ac-pill ac-pill--info">relic</span>
+{% endif %}
+{% if slot.item.enchant %}
+                <span class="ac-pill ac-pill--accent">{{ slot.item.enchant.name }}</span>
+{% endif %}
+            </div>
+            <dl class="ac-kv mb-0">
+                <dt>Slot</dt>
+                <dd>{{ slot.label }}</dd>
+                <dt>Type</dt>
+                <dd>{{ slot.item.object.get_item_type_display }}</dd>
+{% if slot.item.min_level %}
+                <dt>Min Level</dt>
+                <dd>{{ slot.item.min_level }}</dd>
+{% endif %}
+{% if slot.item.object.weight %}
+                <dt>Weight</dt>
+                <dd>{{ slot.item.object.weight }}</dd>
+{% endif %}
+            </dl>
+{% if slot.mods %}
+            <ul class="ac-doll__mods">
+{% for mod in slot.mods %}
+                <li>{{ mod.value|stringformat:"+d" }} {{ mod.object_mod }}</li>
+{% endfor %}
+            </ul>
+{% endif %}
+{% if slot.item.enchant.obj_display %}
+            <p class="ac-doll__flavor">{{ slot.item.enchant.obj_display }}</p>
+{% endif %}
+        </div>
+{% endif %}
+{% endfor %}
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h" id="standing">
+            {% bi "bar-chart" %}
+            Standing
+            <a class="anchor-link" href="#standing" aria-label="Link to this section: Standing"></a>
+        </div>
+        <p class="ac-panel__hint">
+            Lifetime totals compared against all {{ standing.peer_count }}
+            living mortal characters.
+        </p>
+        <div class="ac-bars">
+{% for row in standing.rows %}
+            <div class="ac-bar" title="{{ row.label }}: {{ row.display }} (#{{ row.rank }} of {{ standing.peer_count }})">
+                <span class="ac-bar__label">{{ row.label }}</span>
+                <span class="ac-bar__track"><span class="ac-bar__fill" style="width: {{ row.pct }}%;"></span></span>
+                <span class="ac-bar__n">{{ row.display }} &middot; #{{ row.rank }}</span>
+            </div>
+{% endfor %}
+        </div>
+{% if standing.tiles %}
+        <div class="ac-tiles mt-2">
+{% for tile in standing.tiles %}
+            <div class="ac-tile ac-tile--{{ tile.css }}">
+                <span class="ac-tile__n">{{ tile.value }}</span>
+                <span class="ac-tile__label">{{ tile.label }}</span>
+            </div>
+{% endfor %}
+        </div>
+{% endif %}
+    </div>
+
+    <div class="ac-panel">
+        <div class="ac-panel__h" id="ledger">
+            {% bi "coin" %}
+            Ledger
+            <a class="anchor-link" href="#ledger" aria-label="Link to this section: Ledger"></a>
+        </div>
+        <dl class="ac-kv mb-0">
+            <dt>Bank</dt>
+            <dd>{{ player.bankacc|intcomma }}</dd>
+            <dt>Gold Carried</dt>
+            <dd>{{ player.common.gold|intcomma }}</dd>
+            <dt>Unspent Renown</dt>
+            <dd>{{ player.renown|intcomma }}</dd>
+            <dt>Favors</dt>
+            <dd>{{ player.favors|intcomma }}</dd>
+            <dt>Karma</dt>
+            <dd>{{ player.common.karma|intcomma }}</dd>
+        </dl>
+    </div>
+{% endif %}
+
     <div class="ac-panel">
         <div class="ac-panel__h" id="time">
             {% bi "hourglass-split" %}
@@ -213,4 +347,35 @@
 {% endif %}
 
 </div>
+<script>
+    (function () {
+        "use strict";
+
+        const doll = document.getElementById("kit-doll");
+        if (!doll) { return; }
+
+        const slots = doll.querySelectorAll("button.ac-doll__slot");
+        const cards = document.querySelectorAll(".ac-doll__card");
+
+        const closeAll = function () {
+            slots.forEach(function (slot) {
+                slot.classList.remove("ac-doll__slot--active");
+                slot.setAttribute("aria-expanded", "false");
+            });
+            cards.forEach(function (card) { card.hidden = true; });
+        };
+
+        slots.forEach(function (slot) {
+            slot.addEventListener("click", function () {
+                const wasActive = slot.classList.contains("ac-doll__slot--active");
+                closeAll();
+                if (wasActive) { return; }
+                slot.classList.add("ac-doll__slot--active");
+                slot.setAttribute("aria-expanded", "true");
+                const card = document.getElementById("kit-card-" + slot.dataset.slot);
+                if (card) { card.hidden = false; }
+            });
+        });
+    })();
+</script>
 {% endblock content %}

--- a/apps/players/templates/player.html
+++ b/apps/players/templates/player.html
@@ -132,6 +132,89 @@
 {% endif %}
     </div>
 
+    <div class="ac-panel">
+        <div class="ac-panel__h" id="kit">
+            {% bi "backpack2" %}
+            Kit
+            <a class="anchor-link" href="#kit" aria-label="Link to this section: Kit"></a>
+        </div>
+        <p class="ac-panel__hint">
+            Worn equipment as of the last autosave (within ~5 minutes).
+            Tap a slot for details.
+        </p>
+        <div class="ac-doll" id="kit-doll">
+            <div class="ac-doll__col">
+{% for slot in kit.left %}
+{% include "kit_slot.html" %}
+{% endfor %}
+            </div>
+            <div class="ac-doll__figure" aria-hidden="true">
+                <svg viewBox="0 0 120 300" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="60" cy="30" r="17" fill="currentColor"/>
+                    <path d="M38 58 Q60 50 82 58 L76 130 Q60 138 44 130 Z" fill="currentColor"/>
+                    <g stroke="currentColor" stroke-linecap="round" fill="none">
+                        <path d="M41 64 L32 100 L30 128" stroke-width="11"/>
+                        <path d="M79 64 L88 100 L90 128" stroke-width="11"/>
+                        <path d="M51 136 L48 200 L46 258" stroke-width="13"/>
+                        <path d="M69 136 L72 200 L74 258" stroke-width="13"/>
+                        <path d="M46 262 L38 266" stroke-width="9"/>
+                        <path d="M74 262 L82 266" stroke-width="9"/>
+                    </g>
+                </svg>
+            </div>
+            <div class="ac-doll__col">
+{% for slot in kit.right %}
+{% include "kit_slot.html" %}
+{% endfor %}
+            </div>
+            <div class="ac-doll__strip">
+{% for slot in kit.strip %}
+{% include "kit_slot.html" %}
+{% endfor %}
+            </div>
+        </div>
+{% for slot in kit.filled %}
+        <div class="ac-doll__card" id="kit-card-{{ slot.position }}" hidden>
+            <div class="ac-doll__cardhead">
+                <span>{{ slot.item.object.longname }}</span>
+{% if slot.item.object.flag.artifact %}
+                <span class="ac-pill ac-pill--warn">artifact</span>
+{% endif %}
+{% if slot.item.object.flag.relic %}
+                <span class="ac-pill ac-pill--info">relic</span>
+{% endif %}
+{% if slot.item.enchant %}
+                <span class="ac-pill ac-pill--accent">{{ slot.item.enchant.name }}</span>
+{% endif %}
+            </div>
+            <dl class="ac-kv mb-0">
+                <dt>Slot</dt>
+                <dd>{{ slot.label }}</dd>
+                <dt>Type</dt>
+                <dd>{{ slot.item.object.get_item_type_display }}</dd>
+{% if slot.item.min_level %}
+                <dt>Min Level</dt>
+                <dd>{{ slot.item.min_level }}</dd>
+{% endif %}
+{% if slot.item.object.weight %}
+                <dt>Weight</dt>
+                <dd>{{ slot.item.object.weight }}</dd>
+{% endif %}
+            </dl>
+{% if slot.mods %}
+            <ul class="ac-doll__mods">
+{% for mod in slot.mods %}
+                <li>{{ mod.value|stringformat:"+d" }} {{ mod.object_mod }}</li>
+{% endfor %}
+            </ul>
+{% endif %}
+{% if slot.item.enchant.obj_display %}
+            <p class="ac-doll__flavor">{{ slot.item.enchant.obj_display }}</p>
+{% endif %}
+        </div>
+{% endfor %}
+    </div>
+
 {% if player.upgrades %}
     <div class="ac-panel">
         <div class="ac-panel__h" id="upgrades">
@@ -171,87 +254,6 @@
 {% endif %}
 
 {% if can_inspect %}
-    <div class="ac-panel">
-        <div class="ac-panel__h" id="kit">
-            {% bi "backpack2" %}
-            Kit
-            <a class="anchor-link" href="#kit" aria-label="Link to this section: Kit"></a>
-        </div>
-        <p class="ac-panel__hint">
-            Worn equipment as of the last autosave (within ~5 minutes).
-            Tap a slot for details &mdash; visible only to this character&#39;s
-            account and staff.
-        </p>
-        <div class="ac-doll" id="kit-doll">
-{% for slot in kit %}
-{% if slot.item %}
-            <button class="ac-doll__slot" type="button" data-slot="{{ slot.position }}"
-                    aria-expanded="false" aria-controls="kit-card-{{ slot.position }}"
-                    title="{{ slot.item.object.longname }}{% if slot.item.enchant %} &middot; {{ slot.item.enchant.name }}{% endif %}">
-                <span class="ac-doll__icon">{% bi slot.icon %}</span>
-                <span class="ac-doll__body">
-                    <span class="ac-doll__label">{{ slot.label }}</span>
-                    <span class="ac-doll__name">{{ slot.item.object.longname }}</span>
-                </span>
-{% if slot.item.enchant %}
-                <span class="ac-doll__ench" title="Enchanted: {{ slot.item.enchant.name }}">&#10038;</span>
-{% endif %}
-            </button>
-{% else %}
-            <div class="ac-doll__slot ac-doll__slot--empty">
-                <span class="ac-doll__icon">{% bi slot.icon %}</span>
-                <span class="ac-doll__body">
-                    <span class="ac-doll__label">{{ slot.label }}</span>
-                    <span class="ac-doll__name">&mdash;</span>
-                </span>
-            </div>
-{% endif %}
-{% endfor %}
-        </div>
-{% for slot in kit %}
-{% if slot.item %}
-        <div class="ac-doll__card" id="kit-card-{{ slot.position }}" hidden>
-            <div class="ac-doll__cardhead">
-                <span>{{ slot.item.object.longname }}</span>
-{% if slot.item.object.flag.artifact %}
-                <span class="ac-pill ac-pill--warn">artifact</span>
-{% endif %}
-{% if slot.item.object.flag.relic %}
-                <span class="ac-pill ac-pill--info">relic</span>
-{% endif %}
-{% if slot.item.enchant %}
-                <span class="ac-pill ac-pill--accent">{{ slot.item.enchant.name }}</span>
-{% endif %}
-            </div>
-            <dl class="ac-kv mb-0">
-                <dt>Slot</dt>
-                <dd>{{ slot.label }}</dd>
-                <dt>Type</dt>
-                <dd>{{ slot.item.object.get_item_type_display }}</dd>
-{% if slot.item.min_level %}
-                <dt>Min Level</dt>
-                <dd>{{ slot.item.min_level }}</dd>
-{% endif %}
-{% if slot.item.object.weight %}
-                <dt>Weight</dt>
-                <dd>{{ slot.item.object.weight }}</dd>
-{% endif %}
-            </dl>
-{% if slot.mods %}
-            <ul class="ac-doll__mods">
-{% for mod in slot.mods %}
-                <li>{{ mod.value|stringformat:"+d" }} {{ mod.object_mod }}</li>
-{% endfor %}
-            </ul>
-{% endif %}
-{% if slot.item.enchant.obj_display %}
-            <p class="ac-doll__flavor">{{ slot.item.enchant.obj_display }}</p>
-{% endif %}
-        </div>
-{% endif %}
-{% endfor %}
-    </div>
-
     <div class="ac-panel">
         <div class="ac-panel__h" id="standing">
             {% bi "bar-chart" %}

--- a/apps/players/views/player.py
+++ b/apps/players/views/player.py
@@ -6,7 +6,19 @@ from django.views.generic.detail import DetailView
 from apps.accounts.models import Account
 from apps.core.views.mixins import NeverCacheMixin
 
+from ..kit import build_kit
 from ..models.player import Player
+
+
+# Standing bars: label, player_stats column, per-day rate tile (or None)
+#   and the tile's semantic tint.
+STANDING_METRICS = (
+    ("Renown", "total_renown", "Renown / day", "accent"),
+    ("Hours Played", "total_play_time", None, None),
+    ("Quests", "total_quests", "Quests / day", "info"),
+    ("Challenges", "total_challenges", None, None),
+    ("Deaths", "total_deaths", "Deaths / day", "danger"),
+)
 
 
 class PlayerView(LoginRequiredMixin, NeverCacheMixin, DetailView):
@@ -40,3 +52,67 @@ class PlayerView(LoginRequiredMixin, NeverCacheMixin, DetailView):
                 message="This player has marked their profile private.",
             )
         return obj
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        player = context["player"]
+
+        # Kit / standing / ledger are the "inspect" layer: the owning account
+        #   and Eternal+ staff, until the feature is promoted to public
+        #   (isharmud/ishar-web#176).
+        user = self.request.user
+        can_inspect = user.pk == player.account_id or user.is_eternal()
+        context["can_inspect"] = can_inspect
+        if can_inspect:
+            context["kit"] = build_kit(player)
+            context["standing"] = self.build_standing(player)
+        return context
+
+    @staticmethod
+    def build_standing(player) -> dict:
+        # Lifetime totals compared against every living mortal character.
+        #   player_stats holds snapshot totals only (no history), so the
+        #   visuals are comparative, not time-series.
+        stat_fields = [field for _, field, _, _ in STANDING_METRICS]
+        peers = list(
+            Player.objects.filter(is_deleted=0).values(
+                "id", *[f"statistics__{field}" for field in stat_fields]
+            )
+        )
+
+        stats = getattr(player, "statistics", None)
+        mine = {
+            field: getattr(stats, field, 0) or 0 for field in stat_fields
+        }
+        days_played = mine["total_play_time"] / 86400
+
+        rows = []
+        tiles = []
+        for label, field, rate_label, rate_css in STANDING_METRICS:
+            values = [peer[f"statistics__{field}"] or 0 for peer in peers]
+            value = mine[field]
+            top = max(values, default=0)
+            if field == "total_play_time":
+                display = f"{value / 3600:,.0f}h"
+            else:
+                display = f"{value:,}"
+            rows.append({
+                "label": label,
+                "display": display,
+                # A dead character is outside the living-peer pool, so their
+                #   value can exceed the pool's max — clamp the fill.
+                "pct": min(100, round(100 * value / top)) if top else 0,
+                "rank": 1 + sum(1 for v in values if v > value),
+            })
+            if rate_label and days_played:
+                tiles.append({
+                    "label": rate_label,
+                    "value": f"{value / days_played:,.1f}",
+                    "css": rate_css,
+                })
+
+        return {
+            "rows": rows,
+            "tiles": tiles,
+            "peer_count": len(peers),
+        }

--- a/apps/players/views/player.py
+++ b/apps/players/views/player.py
@@ -43,8 +43,10 @@ class PlayerView(LoginRequiredMixin, NeverCacheMixin, DetailView):
         if is_private:
             # Same 404-for-everyone-else convention as GodRequiredMixin: a
             #   private profile does not disclose its own existence to
-            #   anyone below Artisan.
-            if not self.request.user.is_artisan():
+            #   anyone below Artisan — except its own account, who always
+            #   sees their own characters.
+            user = self.request.user
+            if not (user.pk == obj.account_id or user.is_artisan()):
                 raise Http404
             messages.add_message(
                 request=self.request,
@@ -57,14 +59,14 @@ class PlayerView(LoginRequiredMixin, NeverCacheMixin, DetailView):
         context = super().get_context_data(**kwargs)
         player = context["player"]
 
-        # Kit / standing / ledger are the "inspect" layer: the owning account
-        #   and Eternal+ staff, until the feature is promoted to public
-        #   (isharmud/ishar-web#176).
+        # The kit is public (isharmud/ishar-web#176: equipment surfaces like
+        #   remort upgrades do); standing/ledger stay the "inspect" layer —
+        #   the owning account and Eternal+ staff.
+        context["kit"] = build_kit(player)
         user = self.request.user
         can_inspect = user.pk == player.account_id or user.is_eternal()
         context["can_inspect"] = can_inspect
         if can_inspect:
-            context["kit"] = build_kit(player)
             context["standing"] = self.build_standing(player)
         return context
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -323,29 +323,28 @@ Used: leaders. Status: **formalized** (supersedes the DataTables treatment —
 see decisions.md).
 
 ### `.ac-doll` — equipment paperdoll
-The profile kit panel (player.html): wear slots as tiles in a responsive grid,
-head→feet with held items in their worn position (the HUD recipe-category
-order). Filled slots are `<button>`s that pin their server-rendered
-`.ac-doll__card` below the grid (class/`hidden` swap only — no data through
-JS); empty slots are dashed, dim, non-interactive `<div>`s. An amber
-`.ac-doll__ench` ✦ marks enchanted tiles; `title` gives desktop hover text
-(tap is the affordance of record). Card: `__cardhead` (name + `.ac-pill`s),
-an `.ac-kv`, an ok-green `__mods` list, a dim italic `__flavor` line.
+The profile kit panel (player.html): two anatomical slot columns flanking a
+drawn SVG silhouette (`__figure`, inline `currentColor` art on `--ac-elev`) —
+head/neck/back zone left, torso/arms right — with held items and the lower
+body in a full-width `__strip` beneath a dashed rule. Slot markup lives in
+the `kit_slot.html` partial; groups come from `apps/players/kit.py`. Filled
+slots are `<button>`s that pin their server-rendered `.ac-doll__card` below
+the doll (class/`hidden` swap only — no data through JS); empty slots are
+dashed, dim, non-interactive `<div>`s. An amber `.ac-doll__ench` ✦ marks
+enchanted tiles; `title` gives desktop hover text (tap is the affordance of
+record). Card: `__cardhead` (name + `.ac-pill`s), an `.ac-kv`, an ok-green
+`__mods` list, a dim italic `__flavor` line. On phones the figure hides and
+the two columns sit side by side.
 ```html
 <div class="ac-doll">
-  <button class="ac-doll__slot" type="button" data-slot="1" aria-expanded="false"
-          aria-controls="kit-card-1" title="the greatsword Duskrender">
-    <span class="ac-doll__icon">{% bi "lightning-charge" %}</span>
-    <span class="ac-doll__body">
-      <span class="ac-doll__label">Wielded</span>
-      <span class="ac-doll__name">the greatsword Duskrender</span>
-    </span>
-    <span class="ac-doll__ench" title="Enchanted">&#10038;</span>
-  </button>
+  <div class="ac-doll__col">{# head/neck/back slots via kit_slot.html #}</div>
+  <div class="ac-doll__figure" aria-hidden="true">{# inline silhouette svg #}</div>
+  <div class="ac-doll__col">{# torso/arm slots #}</div>
+  <div class="ac-doll__strip">{# held + lower-body slots #}</div>
 </div>
 <div class="ac-doll__card" id="kit-card-1" hidden>…</div>
 ```
-Used: player profile (inspect-gated — see decisions.md 2026-07-26).
+Used: player profile (public — see decisions.md 2026-07-27).
 Status: **formalized.**
 
 ### `.ac-row--done` / `.ac-row:target` — row states

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -322,6 +322,32 @@ dim second line inside a cell (class under player name).
 Used: leaders. Status: **formalized** (supersedes the DataTables treatment —
 see decisions.md).
 
+### `.ac-doll` — equipment paperdoll
+The profile kit panel (player.html): wear slots as tiles in a responsive grid,
+head→feet with held items in their worn position (the HUD recipe-category
+order). Filled slots are `<button>`s that pin their server-rendered
+`.ac-doll__card` below the grid (class/`hidden` swap only — no data through
+JS); empty slots are dashed, dim, non-interactive `<div>`s. An amber
+`.ac-doll__ench` ✦ marks enchanted tiles; `title` gives desktop hover text
+(tap is the affordance of record). Card: `__cardhead` (name + `.ac-pill`s),
+an `.ac-kv`, an ok-green `__mods` list, a dim italic `__flavor` line.
+```html
+<div class="ac-doll">
+  <button class="ac-doll__slot" type="button" data-slot="1" aria-expanded="false"
+          aria-controls="kit-card-1" title="the greatsword Duskrender">
+    <span class="ac-doll__icon">{% bi "lightning-charge" %}</span>
+    <span class="ac-doll__body">
+      <span class="ac-doll__label">Wielded</span>
+      <span class="ac-doll__name">the greatsword Duskrender</span>
+    </span>
+    <span class="ac-doll__ench" title="Enchanted">&#10038;</span>
+  </button>
+</div>
+<div class="ac-doll__card" id="kit-card-1" hidden>…</div>
+```
+Used: player profile (inspect-gated — see decisions.md 2026-07-26).
+Status: **formalized.**
+
 ### `.ac-row--done` / `.ac-row:target` — row states
 `--done` checks a record off: title struck through in ok-green, icon tile
 turns ok (challenges). `:target` washes a deep-linked row amber (row `id`s +

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -2188,3 +2188,37 @@ mapping can't represent multiple mod slots). Slot spec + assembly live in
 `node --check`, and Chromium screenshots of a simulated-data preview at
 1200px and a true 390px viewport (headless `--window-size` clamps at 500 —
 use Playwright device emulation for phone proof).
+
+## 2026-07-27 — Kit goes public; the paperdoll becomes an actual paper doll
+
+**Problem.** The first kit panel (2026-07-26) rendered as a flat auto-fill
+grid — organized, but it didn't read as a body — and the whole inspect layer
+(kit + standing + ledger) was gated to owner/Eternal while the page already
+surfaces remort upgrades publicly. Equipment isn't truly competitive
+information for this playerbase.
+
+**Decision.** Two-tier profile, deliberately:
+
+- **Public** (any logged-in viewer of a non-private profile): the prose
+  details, remort upgrades, trainable stats, times — and now the **kit**.
+  Owner-promoted from the inspect layer per #176.
+- **Inspect** (owning account + Eternal+): **standing** and **ledger** — the
+  comparative analytics and the money stay the private layer.
+
+The doll itself is now anatomical: two slot columns flank a drawn SVG
+silhouette (head/neck/back zone on its left, torso/arms on its right), with
+held items and the lower body in a strip beneath a dashed rule. The
+silhouette is inline `currentColor` art tinted `--ac-elev` — background, not
+foreground; the slots stay the interactive surface. On phones the figure
+hides and the columns sit side by side, so the anatomical grouping survives
+at 390px without the art. Slot markup consolidated into the `kit_slot.html`
+partial; groups defined in `apps/players/kit.py`.
+
+**Also.** A private profile no longer 404s its own account: the owner always
+sees their own characters (staff-gating for everyone else unchanged). The
+prior behavior meant marking yourself private removed your own profile page —
+indefensible once the profile carries a self-view layer.
+
+**Notes.** Verified as before — template compile + render smoke test,
+`manage.py check`, Playwright screenshots at 1200px and a true 390px
+viewport (scrollWidth 390, no overflow).

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -2146,3 +2146,45 @@ are conjunctive bundles one character must satisfy whole, never alternatives.
 Discipline unchanged: `el()`/`textContent`, tokens only, motion-free. Verified
 with the demo feed (done/undone/hidden-earned/grouped mix) at desktop and
 390px.
+
+## 2026-07-26 — Player profile inspect layer: kit paperdoll, standing bars, ledger
+
+**Problem.** The profile page stopped at prose details and six trainable
+stats while the shared DB already held the character's whole material life —
+worn equipment (`player_objects`, refreshed by the ~5-minute autosave),
+enchants, object mods, lifetime `player_stats` totals. Nothing on the web
+showed a character's kit or where they stand against the playerbase, for
+players or for staff triaging balance questions.
+
+**Decision.** Three new panels on `player.html`, gated to an "inspect layer":
+the profile's owning account and Eternal+ staff, until the feature is promoted
+to public (isharmud/ishar-web#176 tracks the promotion call). Within the gate:
+
+- **Kit** — a paperdoll as a slot-tile grid (`.ac-doll`), head→feet with held
+  items in their worn position (the same presentation order as the HUD's
+  recipe categories), *not* literal body art: Bootstrap Icons carry the slot
+  vocabulary and the console greys carry the look. Tapping a filled slot pins
+  its server-rendered item card below the grid — cards are plain Django
+  markup toggled by class/`hidden` swaps, so no data ever passes through JS.
+  The `title` attribute provides desktop hover text as sugar; tap is the
+  affordance of record (hover isn't real on phones).
+- **Standing** — `.ac-bars` comparing lifetime totals against all living
+  mortal characters plus per-day-rate `.ac-tiles`. `player_stats` is snapshot
+  totals with no history, so the visuals are comparative by design, never
+  time-series; a rank token (`#n`) rides each bar's value.
+- **Ledger** — an `.ac-kv` of bank / gold / unspent renown / favors / karma.
+  Money is inspect-gated with the rest; it's the most sensitive number here.
+
+**Data.** `player_objects.position_type/position_val` (26 wear slots) joined
+to `objects`, `object_flags`, and — via a new `managed = False` `Enchantment`
+model, upgrading `PlayerObject.enchant` from a bare int to the FK the DB
+already declares — `enchantments`. Object mods come from the
+`object_object_mods` through table queried directly (its OneToOne-to-Object
+mapping can't represent multiple mod slots). Slot spec + assembly live in
+`apps/players/kit.py`; standing math in the view.
+
+**Notes.** Empty slots render dashed/dim so gaps read at a glance; an amber
+✦ marks enchanted tiles. Verified: template compile, `manage.py check`,
+`node --check`, and Chromium screenshots of a simulated-data preview at
+1200px and a true 390px viewport (headless `--window-size` clamps at 500 —
+use Playwright device emulation for phone proof).


### PR DESCRIPTION
## Summary

Adds three new panels to the player profile page: a public equipment paperdoll (`kit`), and two inspect-gated panels (`standing` and `ledger`) visible only to the character's owning account and Eternal+ staff.

The kit displays worn equipment in an anatomical paperdoll layout — two slot columns flanking an SVG silhouette (head/neck/back left, torso/arms right), with held items and lower body in a strip beneath. Tapping a filled slot pins its server-rendered item card below the doll. Empty slots render dashed and dim. The standing panel compares lifetime totals against all living mortal characters with per-day-rate tiles. The ledger shows bank, gold, renown, favors, and karma.

## Key Changes

- **New `Enchantment` model** (`apps/objects/models/enchantment.py`): `managed = False` wrapper around the game's `enchantments` table, upgrading `PlayerObject.enchant` from a bare int to a proper FK.
- **Kit assembly** (`apps/players/kit.py`): `build_kit()` function groups 26 wear slots into anatomical zones (left/right/strip), joins to worn items and their object mods, and returns filled/empty slot specs for template rendering.
- **Kit slot partial** (`apps/players/templates/kit_slot.html`): Renders filled slots as `<button>`s (pinning their card on click) and empty slots as dashed `<div>`s. Enchanted items get an amber ✦ marker.
- **Player view updates** (`apps/players/views/player.py`): 
  - `get_context_data()` builds the kit (public) and standing/ledger (inspect-gated).
  - `build_standing()` compares lifetime stats against all living mortals, ranks each metric, and calculates per-day rates.
  - Private profiles now allow the owning account to view their own characters (previously 404'd).
- **Template** (`apps/players/templates/player.html`): Three new panels with the kit doll, standing bars, and ledger. Vanilla JS toggles item cards via class/`hidden` swaps (no data through JS).
- **Styling** (`apps/core/static/css/admin-console.css`): New `.ac-doll` component — grid layout with anatomical grouping, slot tiles, item cards, and responsive behavior (figure hides on phones, columns sit side by side).
- **Design docs** (`docs/design/decisions.md`, `docs/design/components.md`): Recorded the two-tier profile decision (public kit, inspect-gated standing/ledger) and formalized the `.ac-doll` component.

## Implementation Notes

- Slot specs and grouping live in `apps/players/kit.py` for reuse and clarity.
- Object mods are queried from the through table directly (the OneToOne-to-Object mapping can't represent multiple mod slots per vnum).
- Standing math is comparative by design — `player_stats` holds snapshot totals with no history, so visuals rank against the living-peer pool, never time-series.
- Empty slots render dashed/dim so gaps read at a glance; filled slots are interactive buttons.
- The `title` attribute provides desktop hover text as sugar; tap is the affordance of record (hover isn't real on phones).
- Verified: template compile, `manage.py check`, Playwright screenshots at 1200px and true 390px viewport.

https://claude.ai/code/session_01R4er5E13JJn7aizu3knbT6