### PR TITLE
Add Immortal Trial application system with staff review queue

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -25,4 +25,5 @@ from .rooms import RoomsConfig
 from .seasons import SeasonsConfig
 from .skills import SkillsConfig
 from .surveys import SurveysConfig
+from .trials import TrialsConfig
 from .connect import ConnectConfig

--- a/apps/accounts/templates/portal.html
+++ b/apps/accounts/templates/portal.html
@@ -107,6 +107,16 @@
                     <span class="ac-link__note d-block">Design tokens &amp; components, live</span>
                 </span>
             </a>
+            <a class="ac-link" href="{% url 'trial_review' %}#review" title="Trial Review">
+                <span class="ac-link__icon">{% bi "stars" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Trial Review</span>
+                    <span class="ac-link__note d-block">Immortal applications — review &amp; decide</span>
+                </span>
+{% if TRIALS_PENDING %}
+                <span class="ac-link__side ac-pill ac-pill--warn" title="{{ TRIALS_PENDING }} awaiting review">{{ TRIALS_PENDING }}</span>
+{% endif %}
+            </a>
     {% endif %}
         </div>
     </div>
@@ -141,6 +151,16 @@
                 </span>
 {% if SURVEYS_OPEN %}
                 <span class="ac-link__side ac-pill ac-pill--ok" title="{{ SURVEYS_OPEN }} awaiting your answers">{{ SURVEYS_OPEN }}</span>
+{% endif %}
+            </a>
+            <a class="ac-link" href="{% url 'trials' %}#trials" title="Immortal Trial">
+                <span class="ac-link__icon">{% bi "stars" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Immortal Trial</span>
+                    <span class="ac-link__note d-block">Apply to join the staff</span>
+                </span>
+{% if TRIAL_ATTENTION %}
+                <span class="ac-link__side ac-pill ac-pill--warn" title="Your application needs revision">!</span>
 {% endif %}
             </a>
             <a class="ac-link" href="{% url 'challenges' %}#challenges" title="Challenges">

--- a/apps/core/sitemaps.py
+++ b/apps/core/sitemaps.py
@@ -23,6 +23,7 @@ class StaticViewSitemap(Sitemap):
             "connect",
             "events",
             "news",
+            "trials",
         ]
 
     def location(self, item):
@@ -42,6 +43,7 @@ class StaticViewSitemap(Sitemap):
             "patches": 0.6,
             "history": 0.6,
             "support": 0.5,
+            "trials": 0.6,
         }
         return priorities.get(item, 0.5)
 
@@ -59,5 +61,6 @@ class StaticViewSitemap(Sitemap):
             "history": "yearly",
             "support": "yearly",
             "connect": "monthly",
+            "trials": "monthly",
         }
         return frequencies.get(item, "weekly")

--- a/apps/core/static/css/admin-console.css
+++ b/apps/core/static/css/admin-console.css
@@ -1022,6 +1022,9 @@ a.ac-link--featured:visited .ac-link__name { color: var(--ac-accent); }
 }
 .ac-tl--system { background: var(--ac-bg); border-style: dashed; }
 .ac-tl--system .ac-tl__text { color: var(--ac-dim); font-style: italic; font-size: .82rem; }
+/* Internal entries: staff-only in a mixed-audience timeline (pair with a
+   warn "internal" pill in the head so the marker isn't color-alone). */
+.ac-tl--internal { border-left: 3px solid var(--ac-warn); }
 
 /* ------------------------------------------------------- quote body --- */
 /* Verbatim player/machine text (report bodies, pasted output): monospace on

--- a/apps/core/templates/layout.html
+++ b/apps/core/templates/layout.html
@@ -294,6 +294,17 @@
                                         Style Guide
                                     </a>
                                 </li>
+                                <li class="nav-item" title="Trial Review">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'trial_review' %}#review">
+                                        {% bi "stars" %}
+                                        Trial Review
+{% if TRIALS_PENDING %}
+                                        <span class="ac-pill ac-pill--warn" title="{{ TRIALS_PENDING }} application{{ TRIALS_PENDING|pluralize }} awaiting review">
+                                            {{ TRIALS_PENDING }}
+                                        </span>
+{% endif %}
+                                    </a>
+                                </li>
                                 <li class="nav-item">
                                     <hr class="dropdown-divider">
                                 </li>
@@ -306,6 +317,16 @@
                                     <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'challenges' %}#challenges">
                                         {% bi "award" %}
                                         Challenges
+                                    </a>
+                                </li>
+
+                                <li class="nav-item" title="Immortal Trial">
+                                    <a class="nav-link dropdown-item icon-link icon-link-hover" href="{% url 'trials' %}#trials">
+                                        {% bi "stars" %}
+                                        Immortal Trial
+{% if TRIAL_ATTENTION %}
+                                        <span class="ac-pill ac-pill--warn" title="Your application needs revision">!</span>
+{% endif %}
                                     </a>
                                 </li>
 

--- a/apps/core/utils/text.py
+++ b/apps/core/utils/text.py
@@ -1,0 +1,21 @@
+"""Shared user-input text hygiene for site-owned submission surfaces."""
+
+# Bidirectional/direction-override codepoints that can spoof displayed order —
+# stripped to match the game's Rust `sanitize_text` (feedback.rs).
+_BIDI_OVERRIDES = frozenset(
+    chr(cp) for cp in list(range(0x202A, 0x202F)) + list(range(0x2066, 0x206A))
+)
+
+
+def clean_text(text, limit) -> str:
+    """Strip control + bidi-override characters and truncate — mirrors
+    `sanitize_text`."""
+    if not text:
+        return ""
+    cleaned = "".join(
+        ch for ch in str(text)
+        if (ch in ("\n", "\t") or ord(ch) >= 0x20) and ch not in _BIDI_OVERRIDES
+    ).strip()
+    if len(cleaned) > limit:
+        cleaned = cleaned[:limit].rstrip()
+    return cleaned

--- a/apps/feedback/services.py
+++ b/apps/feedback/services.py
@@ -22,6 +22,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from apps.core.utils.staff import staff_name  # noqa: F401 - shared, re-exported
+from apps.core.utils.text import clean_text as _clean
 
 from .models import (
     CommentSource,
@@ -44,27 +45,6 @@ INSTRUCTIONS_MAX = 2000
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
-
-# Bidirectional/direction-override codepoints that can spoof displayed order —
-# stripped to match the Rust `sanitize_text` (feedback.rs).
-_BIDI_OVERRIDES = frozenset(
-    chr(cp) for cp in list(range(0x202A, 0x202F)) + list(range(0x2066, 0x206A))
-)
-
-
-def _clean(text, limit) -> str:
-    """Strip control + bidi-override characters and truncate — mirrors
-    `sanitize_text`."""
-    if not text:
-        return ""
-    cleaned = "".join(
-        ch for ch in str(text)
-        if (ch in ("\n", "\t") or ord(ch) >= 0x20) and ch not in _BIDI_OVERRIDES
-    ).strip()
-    if len(cleaned) > limit:
-        cleaned = cleaned[:limit].rstrip()
-    return cleaned
-
 
 def _now():
     return timezone.now()

--- a/apps/trials/__init__.py
+++ b/apps/trials/__init__.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class TrialsConfig(AppConfig):
+    app_label = "trials"
+    name = "apps.trials"
+    verbose_name = "Immortal Trial"
+    verbose_name_plural = "Immortal Trials"

--- a/apps/trials/admin/__init__.py
+++ b/apps/trials/admin/__init__.py
@@ -1,0 +1,2 @@
+# Intentionally empty: trial applications are operated from the site
+# (/trials/review/), not Django admin — same split as feedback triage.

--- a/apps/trials/contexts.py
+++ b/apps/trials/contexts.py
@@ -1,0 +1,27 @@
+"""Context processor: trial-application badges for the nav/portal pills."""
+from django.db import DatabaseError
+
+
+def trials_badges(request):
+    """
+    `TRIALS_PENDING`: applications under review (Eternal+ only — the count
+    reveals staff-queue state). `TRIAL_ATTENTION`: the account has an
+    application sent back for revision. Defensively zero if the trial tables
+    aren't migrated yet.
+    """
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        return {"TRIALS_PENDING": 0, "TRIAL_ATTENTION": False}
+    try:
+        from .models import TrialApplication, TrialStatus
+        pending = 0
+        if user.is_eternal():
+            pending = TrialApplication.objects.filter(
+                status=TrialStatus.SUBMITTED,
+            ).count()
+        attention = TrialApplication.objects.filter(
+            account=user, status=TrialStatus.NEEDS_REVISION,
+        ).exists()
+        return {"TRIALS_PENDING": pending, "TRIAL_ATTENTION": attention}
+    except DatabaseError:
+        return {"TRIALS_PENDING": 0, "TRIAL_ATTENTION": False}

--- a/apps/trials/eligibility.py
+++ b/apps/trials/eligibility.py
@@ -1,0 +1,75 @@
+"""
+Soft eligibility check for the Immortal Trial: the policy asks for at least
+one full season played and two remorts. Displayed to the applicant and to
+reviewers as guidance — never enforced, so staff can waive edge cases.
+"""
+from dataclasses import dataclass
+
+from django.db import DatabaseError
+from django.db.models import Case, Count, F, IntegerField, Max, When
+from django.db.models.functions import Coalesce
+
+MIN_SEASONS = 1
+MIN_REMORTS = 2
+
+
+@dataclass(frozen=True)
+class Eligibility:
+    seasons_played: int
+    best_remorts: int
+
+    @property
+    def meets_seasons(self) -> bool:
+        return self.seasons_played >= MIN_SEASONS
+
+    @property
+    def meets_remorts(self) -> bool:
+        return self.best_remorts >= MIN_REMORTS
+
+    @property
+    def eligible(self) -> bool:
+        return self.meets_seasons and self.meets_remorts
+
+    def as_payload(self) -> dict:
+        """Numbers for the Discord outbox payload."""
+        return {
+            "eligible": self.eligible,
+            "seasons": self.seasons_played,
+            "remorts": self.best_remorts,
+        }
+
+
+def check(account) -> Eligibility:
+    """
+    Compute eligibility from mortal characters (current season) and
+    `historic_season_stat` snapshots (a row only exists once `cycle_season`
+    has archived a completed season, so distinct seasons there == full
+    seasons played).
+    """
+    from apps.players.models.game_type import GameType
+    from apps.players.models.player import Player
+    from apps.seasons.models.historic import HistoricSeasonStat
+
+    try:
+        # Rank hardcore characters by their permadeath-proof record — the
+        # same Coalesce the leaderboard uses (apps/leaders/views.py).
+        current = Player.objects.filter(account=account).aggregate(
+            best=Max(Case(
+                When(
+                    game_type=GameType.HARDCORE,
+                    then=Coalesce("statistics__hardcore_remorts", "remorts"),
+                ),
+                default=F("remorts"),
+                output_field=IntegerField(),
+            )),
+        )["best"] or 0
+        historic = HistoricSeasonStat.objects.filter(account=account).aggregate(
+            seasons=Count("season", distinct=True),
+            best=Max("remorts"),
+        )
+        return Eligibility(
+            seasons_played=historic["seasons"] or 0,
+            best_remorts=max(current, historic["best"] or 0),
+        )
+    except DatabaseError:
+        return Eligibility(seasons_played=0, best_remorts=0)

--- a/apps/trials/migrations/0001_initial.py
+++ b/apps/trials/migrations/0001_initial.py
@@ -1,0 +1,335 @@
+"""
+Immortal Trial application flow: three site-owned tables — applications,
+their comment/audit timeline, and the `trial_sync_queue` side-effect outbox
+the host daemon drains to Discord. The account FK is Django-level only
+(`db_constraint=False`): no DDL touches the game-owned `accounts` table.
+The unique constraint on `open_slot` is the MariaDB stand-in for a
+conditional "one open application per account" constraint (NULLs don't
+collide; the column is NULLed on terminal transitions).
+"""
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TrialApplication",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        primary_key=True, serialize=False, verbose_name="Application ID"
+                    ),
+                ),
+                (
+                    "character_name",
+                    models.CharField(
+                        help_text="The mortal character the applicant is known by.",
+                        max_length=64,
+                        verbose_name="Character Name",
+                    ),
+                ),
+                (
+                    "track",
+                    models.CharField(
+                        choices=[("zoner", "Zoner"), ("coder", "Coder")],
+                        max_length=8,
+                        verbose_name="Track",
+                    ),
+                ),
+                (
+                    "proposal",
+                    models.TextField(
+                        help_text="The trial project pitch: small, guided, ~4 weeks.",
+                        verbose_name="Project Proposal",
+                    ),
+                ),
+                (
+                    "experience",
+                    models.TextField(
+                        blank=True,
+                        default="",
+                        help_text="Relevant building / coding / writing experience.",
+                        verbose_name="Experience",
+                    ),
+                ),
+                (
+                    "ack_ai_policy",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Acknowledged: trial-phase creative writing must be original work.",
+                        verbose_name="AI Policy Acknowledged",
+                    ),
+                ),
+                (
+                    "ack_commitment",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Acknowledged: the time and communication commitment.",
+                        verbose_name="Commitment Acknowledged",
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("submitted", "Under Review"),
+                            ("needs_revision", "Needs Revision"),
+                            ("accepted", "Accepted"),
+                            ("rejected", "Rejected"),
+                            ("withdrawn", "Withdrawn"),
+                        ],
+                        default="submitted",
+                        max_length=16,
+                        verbose_name="Status",
+                    ),
+                ),
+                (
+                    "open_slot",
+                    models.PositiveIntegerField(
+                        blank=True, null=True, verbose_name="Open Slot"
+                    ),
+                ),
+                (
+                    "submitted_at",
+                    models.DateTimeField(
+                        help_text="Reset on resubmission; starts the review clock.",
+                        verbose_name="Submitted At",
+                    ),
+                ),
+                (
+                    "due_at",
+                    models.DateTimeField(
+                        help_text="submitted_at + 7 days. Display-only review deadline.",
+                        verbose_name="Review Due At",
+                    ),
+                ),
+                (
+                    "revision_count",
+                    models.PositiveSmallIntegerField(
+                        default=0, verbose_name="Revisions"
+                    ),
+                ),
+                (
+                    "decided_by",
+                    models.CharField(
+                        blank=True,
+                        help_text="Staff attribution for the decision.",
+                        max_length=64,
+                        null=True,
+                        verbose_name="Decided By",
+                    ),
+                ),
+                (
+                    "decided_at",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="Decided At"
+                    ),
+                ),
+                (
+                    "rejection_reason",
+                    models.CharField(
+                        blank=True,
+                        max_length=255,
+                        null=True,
+                        verbose_name="Rejection Reason",
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(auto_now_add=True, verbose_name="Created At"),
+                ),
+                (
+                    "account",
+                    models.ForeignKey(
+                        db_column="account_id",
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="trial_applications",
+                        related_query_name="trial_application",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Account",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Trial Application",
+                "verbose_name_plural": "Trial Applications",
+                "db_table": "trial_applications",
+                "ordering": ("due_at", "-id"),
+                "managed": True,
+            },
+        ),
+        migrations.CreateModel(
+            name="TrialComment",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        primary_key=True, serialize=False, verbose_name="Comment ID"
+                    ),
+                ),
+                (
+                    "kind",
+                    models.CharField(
+                        choices=[
+                            ("staff", "Staff"),
+                            ("applicant", "Applicant"),
+                            ("system", "System"),
+                        ],
+                        max_length=16,
+                        verbose_name="Kind",
+                    ),
+                ),
+                (
+                    "is_internal",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Staff-only: never shown to the applicant, never echoed to Discord.",
+                        verbose_name="Internal?",
+                    ),
+                ),
+                (
+                    "author",
+                    models.CharField(
+                        help_text="Staff name, or the applicant's character/account name.",
+                        max_length=64,
+                        verbose_name="Author",
+                    ),
+                ),
+                ("body", models.TextField(verbose_name="Body")),
+                ("created_at", models.DateTimeField(verbose_name="Created At")),
+                (
+                    "application",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="comments",
+                        related_query_name="comment",
+                        to="trials.trialapplication",
+                        verbose_name="Application",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Trial Comment",
+                "verbose_name_plural": "Trial Comments",
+                "db_table": "trial_comments",
+                "ordering": ("id",),
+                "managed": True,
+            },
+        ),
+        migrations.CreateModel(
+            name="TrialSyncTask",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        primary_key=True, serialize=False, verbose_name="Task ID"
+                    ),
+                ),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("submitted", "Submitted"),
+                            ("resubmitted", "Resubmitted"),
+                            ("comment", "Comment"),
+                            ("reply", "Reply"),
+                            ("needs_revision", "Needs Revision"),
+                            ("accepted", "Accepted"),
+                            ("rejected", "Rejected"),
+                            ("withdrawn", "Withdrawn"),
+                        ],
+                        help_text="Semantic verb whose side-effects the daemon must replay.",
+                        max_length=32,
+                        verbose_name="Action",
+                    ),
+                ),
+                (
+                    "actor",
+                    models.CharField(
+                        help_text="Attribution for the side-effect.",
+                        max_length=64,
+                        verbose_name="Actor",
+                    ),
+                ),
+                (
+                    "payload",
+                    models.JSONField(
+                        blank=True,
+                        help_text="Action parameters (see module docstring).",
+                        null=True,
+                        verbose_name="Payload",
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("done", "Done"),
+                            ("error", "Error"),
+                        ],
+                        default="pending",
+                        max_length=16,
+                        verbose_name="Status",
+                    ),
+                ),
+                (
+                    "attempts",
+                    models.PositiveIntegerField(default=0, verbose_name="Attempts"),
+                ),
+                (
+                    "last_error",
+                    models.CharField(
+                        blank=True, max_length=255, null=True, verbose_name="Last Error"
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="Created At"
+                    ),
+                ),
+                (
+                    "processed_at",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="Processed At"
+                    ),
+                ),
+                (
+                    "application",
+                    models.ForeignKey(
+                        db_column="application_id",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="sync_tasks",
+                        related_query_name="sync_task",
+                        to="trials.trialapplication",
+                        verbose_name="Application",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Trial Sync Task",
+                "verbose_name_plural": "Trial Sync Tasks",
+                "db_table": "trial_sync_queue",
+                "ordering": ("id",),
+                "managed": True,
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="trialapplication",
+            constraint=models.UniqueConstraint(
+                fields=("open_slot",), name="one_open_application_per_account"
+            ),
+        ),
+    ]

--- a/apps/trials/models/__init__.py
+++ b/apps/trials/models/__init__.py
@@ -1,0 +1,11 @@
+from .application import REVIEW_WINDOW, TrialApplication
+from .choices import (
+    OPEN_STATUSES,
+    TrialCommentKind,
+    TrialStatus,
+    TrialSyncAction,
+    TrialSyncStatus,
+    TrialTrack,
+)
+from .comment import TrialComment
+from .sync import TrialSyncTask

--- a/apps/trials/models/application.py
+++ b/apps/trials/models/application.py
@@ -1,0 +1,214 @@
+"""
+Immortal Trial applications — the site-owned intake for the trial process
+described at /trials/ (immortal_policy): a player pitches a small ~4-week
+project on one of two tracks, Eternal+ staff review inside a 7-day window,
+and acceptance grants Immortal (Trial) rank.
+"""
+from datetime import timedelta
+
+from django.db import models
+from django.utils import timezone
+
+from apps.accounts.models import Account
+
+from .choices import OPEN_STATUSES, TrialStatus, TrialTrack
+
+REVIEW_WINDOW = timedelta(days=7)
+
+
+class TrialApplication(models.Model):
+    """One application to the Immortal Trial."""
+
+    id = models.AutoField(
+        primary_key=True,
+        verbose_name="Application ID",
+    )
+    account = models.ForeignKey(
+        to=Account,
+        db_column="account_id",
+        to_field="account_id",
+        db_constraint=False,
+        on_delete=models.CASCADE,
+        related_name="trial_applications",
+        related_query_name="trial_application",
+        verbose_name="Account",
+    )
+    character_name = models.CharField(
+        max_length=64,
+        help_text="The mortal character the applicant is known by.",
+        verbose_name="Character Name",
+    )
+    track = models.CharField(
+        max_length=8,
+        choices=TrialTrack,
+        verbose_name="Track",
+    )
+    proposal = models.TextField(
+        help_text="The trial project pitch: small, guided, ~4 weeks.",
+        verbose_name="Project Proposal",
+    )
+    experience = models.TextField(
+        blank=True,
+        default="",
+        help_text="Relevant building / coding / writing experience.",
+        verbose_name="Experience",
+    )
+    ack_ai_policy = models.BooleanField(
+        default=False,
+        help_text="Acknowledged: trial-phase creative writing must be original work.",
+        verbose_name="AI Policy Acknowledged",
+    )
+    ack_commitment = models.BooleanField(
+        default=False,
+        help_text="Acknowledged: the time and communication commitment.",
+        verbose_name="Commitment Acknowledged",
+    )
+    status = models.CharField(
+        max_length=16,
+        choices=TrialStatus,
+        default=TrialStatus.SUBMITTED,
+        verbose_name="Status",
+    )
+    # MariaDB has no conditional unique constraints, so "one open application
+    # per account" is enforced by mirroring account_id here while the
+    # application is open and NULLing it on any terminal transition — NULLs
+    # never collide in a unique index.
+    open_slot = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        verbose_name="Open Slot",
+    )
+    submitted_at = models.DateTimeField(
+        help_text="Reset on resubmission; starts the review clock.",
+        verbose_name="Submitted At",
+    )
+    due_at = models.DateTimeField(
+        help_text="submitted_at + 7 days. Display-only review deadline.",
+        verbose_name="Review Due At",
+    )
+    revision_count = models.PositiveSmallIntegerField(
+        default=0,
+        verbose_name="Revisions",
+    )
+    decided_by = models.CharField(
+        max_length=64,
+        blank=True,
+        null=True,
+        help_text="Staff attribution for the decision.",
+        verbose_name="Decided By",
+    )
+    decided_at = models.DateTimeField(
+        blank=True,
+        null=True,
+        verbose_name="Decided At",
+    )
+    rejection_reason = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        verbose_name="Rejection Reason",
+    )
+    created_at = models.DateTimeField(
+        auto_now_add=True,
+        verbose_name="Created At",
+    )
+
+    class Meta:
+        managed = True
+        db_table = "trial_applications"
+        constraints = (
+            models.UniqueConstraint(
+                fields=("open_slot",),
+                name="one_open_application_per_account",
+            ),
+        )
+        ordering = ("due_at", "-id")
+        verbose_name = "Trial Application"
+        verbose_name_plural = "Trial Applications"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: #{self.pk} ({self.status})"
+
+    def __str__(self) -> str:
+        return f"#{self.pk} {self.character_name} [{self.get_track_display()}]"
+
+    # -- Predicates -------------------------------------------------------
+
+    def is_open(self) -> bool:
+        return self.status in OPEN_STATUSES
+
+    def is_submitted(self) -> bool:
+        return self.status == TrialStatus.SUBMITTED
+
+    def is_needs_revision(self) -> bool:
+        return self.status == TrialStatus.NEEDS_REVISION
+
+    def is_accepted(self) -> bool:
+        return self.status == TrialStatus.ACCEPTED
+
+    def is_rejected(self) -> bool:
+        return self.status == TrialStatus.REJECTED
+
+    def is_terminal(self) -> bool:
+        return not self.is_open()
+
+    def is_overdue(self) -> bool:
+        """Under review past the 7-day window — a promise staff missed."""
+        return self.is_submitted() and self.due_at < timezone.now()
+
+    # -- Presentation -----------------------------------------------------
+
+    @property
+    def days_left(self) -> int:
+        """Whole days until (positive) or past (negative) the review deadline."""
+        return (self.due_at - timezone.now()).days
+
+    @property
+    def due_label(self) -> str:
+        """Compact clock pill text — pills don't wrap, so keep it short."""
+        if self.is_overdue():
+            days = -self.days_left
+            return f"overdue {days}d" if days else "overdue"
+        days = self.days_left
+        return f"due in {days}d" if days > 0 else "due today"
+
+    def summary(self, length: int = 80) -> str:
+        line = (self.proposal or "").strip().splitlines()
+        line = line[0] if line else ""
+        if len(line) > length:
+            line = line[: length - 1].rstrip() + "…"
+        return line or "(no text)"
+
+    @property
+    def track_icon(self) -> str:
+        """Bootstrap-icons name for the track."""
+        return {
+            TrialTrack.ZONER: "map",
+            TrialTrack.CODER: "code-slash",
+        }.get(self.track, "stars")
+
+    @property
+    def status_label(self) -> str:
+        return self.get_status_display()
+
+    @property
+    def status_css(self) -> str:
+        """Bootstrap contextual class for the status."""
+        return {
+            TrialStatus.SUBMITTED: "info",
+            TrialStatus.NEEDS_REVISION: "warning",
+            TrialStatus.ACCEPTED: "success",
+            TrialStatus.REJECTED: "danger",
+            TrialStatus.WITHDRAWN: "secondary",
+        }.get(self.status, "secondary")
+
+    @property
+    def status_pill(self) -> str:
+        """Admin Console pill modifier (.ac-pill--*) for the status."""
+        return {
+            TrialStatus.SUBMITTED: "info",
+            TrialStatus.NEEDS_REVISION: "warn",
+            TrialStatus.ACCEPTED: "ok",
+            TrialStatus.REJECTED: "danger",
+            TrialStatus.WITHDRAWN: "muted",
+        }.get(self.status, "muted")

--- a/apps/trials/models/choices.py
+++ b/apps/trials/models/choices.py
@@ -1,0 +1,46 @@
+from django.db.models import TextChoices
+
+
+class TrialStatus(TextChoices):
+    """Application lifecycle. Open = SUBMITTED or NEEDS_REVISION; the rest are
+    terminal and free the account's one-open-application slot."""
+
+    SUBMITTED = "submitted", "Under Review"
+    NEEDS_REVISION = "needs_revision", "Needs Revision"
+    ACCEPTED = "accepted", "Accepted"
+    REJECTED = "rejected", "Rejected"
+    WITHDRAWN = "withdrawn", "Withdrawn"
+
+
+# The two open states, in query-ready form.
+OPEN_STATUSES = (TrialStatus.SUBMITTED, TrialStatus.NEEDS_REVISION)
+
+
+class TrialTrack(TextChoices):
+    ZONER = "zoner", "Zoner"
+    CODER = "coder", "Coder"
+
+
+class TrialCommentKind(TextChoices):
+    STAFF = "staff", "Staff"
+    APPLICANT = "applicant", "Applicant"
+    SYSTEM = "system", "System"
+
+
+class TrialSyncAction(TextChoices):
+    """Semantic verbs the host daemon turns into staff-Discord posts."""
+
+    SUBMITTED = "submitted"
+    RESUBMITTED = "resubmitted"
+    COMMENT = "comment"
+    REPLY = "reply"
+    NEEDS_REVISION = "needs_revision"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    WITHDRAWN = "withdrawn"
+
+
+class TrialSyncStatus(TextChoices):
+    PENDING = "pending"
+    DONE = "done"
+    ERROR = "error"

--- a/apps/trials/models/comment.py
+++ b/apps/trials/models/comment.py
@@ -1,0 +1,67 @@
+from django.db import models
+
+from .application import TrialApplication
+from .choices import TrialCommentKind
+
+
+class TrialComment(models.Model):
+    """One timeline entry on an application: staff comment, applicant reply,
+    or a system record of a state change (the audit trail)."""
+
+    id = models.AutoField(
+        primary_key=True,
+        verbose_name="Comment ID",
+    )
+    application = models.ForeignKey(
+        to=TrialApplication,
+        on_delete=models.CASCADE,
+        related_name="comments",
+        related_query_name="comment",
+        verbose_name="Application",
+    )
+    kind = models.CharField(
+        max_length=16,
+        choices=TrialCommentKind,
+        verbose_name="Kind",
+    )
+    is_internal = models.BooleanField(
+        default=False,
+        help_text="Staff-only: never shown to the applicant, never echoed to Discord.",
+        verbose_name="Internal?",
+    )
+    author = models.CharField(
+        max_length=64,
+        help_text="Staff name, or the applicant's character/account name.",
+        verbose_name="Author",
+    )
+    body = models.TextField(
+        verbose_name="Body",
+    )
+    created_at = models.DateTimeField(
+        verbose_name="Created At",
+    )
+
+    class Meta:
+        managed = True
+        db_table = "trial_comments"
+        ordering = ("id",)
+        verbose_name = "Trial Comment"
+        verbose_name_plural = "Trial Comments"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: #{self.pk} on #{self.application_id}"
+
+    def __str__(self) -> str:
+        return f"{self.author}: {self.body[:40]}"
+
+    def is_system(self) -> bool:
+        return self.kind == TrialCommentKind.SYSTEM
+
+    @property
+    def kind_icon(self) -> str:
+        """Bootstrap-icons name for the timeline tile."""
+        return {
+            TrialCommentKind.STAFF: "shield-check",
+            TrialCommentKind.APPLICANT: "person",
+            TrialCommentKind.SYSTEM: "gear",
+        }.get(self.kind, "chat")

--- a/apps/trials/models/sync.py
+++ b/apps/trials/models/sync.py
@@ -1,0 +1,102 @@
+"""
+Trial side-effect outbox (`trial_sync_queue` table).
+
+Same transactional-outbox split as feedback: the site owns authoritative state
+(application rows, comments), and each action enqueues one row here for the
+host daemon to replay as a staff-Discord post. Unlike `feedback_sync_queue`
+(game/daemon-owned, frozen contract), this table is **site-owned** — this
+docstring is the source of truth for its wire contract:
+
+The daemon polls `status='pending'` rows ordered by `id`, posts one staff
+Discord embed per row, then sets `done` (or `error` + `last_error`), stamping
+`processed_at` and bumping `attempts`. Link target for application rows:
+`/trials/review/<application_id>/`. Payloads by action:
+
+- submitted / resubmitted: {"track", "character_name", "eligible", "seasons", "remorts"}
+- comment (applicant-facing staff comment; internal comments are NEVER enqueued): {"text"}
+- reply (applicant reply): {"text"}
+- needs_revision: {"note"}
+- accepted: {"granted": bool}   # whether immortal_level was actually written
+- rejected: {"reason"}
+- withdrawn: {}
+
+Until the daemon-side worker ships (tracked in ishar-mud), rows accumulate
+harmlessly as `pending` — the same rollout property the feedback queue had.
+"""
+from django.db import models
+
+from .application import TrialApplication
+from .choices import TrialSyncAction, TrialSyncStatus
+
+
+class TrialSyncTask(models.Model):
+    """One queued side-effect intent for the host daemon to replay."""
+
+    id = models.AutoField(
+        primary_key=True,
+        verbose_name="Task ID",
+    )
+    application = models.ForeignKey(
+        to=TrialApplication,
+        db_column="application_id",
+        on_delete=models.CASCADE,
+        related_name="sync_tasks",
+        related_query_name="sync_task",
+        verbose_name="Application",
+    )
+    action = models.CharField(
+        max_length=32,
+        choices=TrialSyncAction,
+        help_text="Semantic verb whose side-effects the daemon must replay.",
+        verbose_name="Action",
+    )
+    actor = models.CharField(
+        max_length=64,
+        help_text="Attribution for the side-effect.",
+        verbose_name="Actor",
+    )
+    payload = models.JSONField(
+        blank=True,
+        null=True,
+        help_text="Action parameters (see module docstring).",
+        verbose_name="Payload",
+    )
+    status = models.CharField(
+        max_length=16,
+        choices=TrialSyncStatus,
+        default=TrialSyncStatus.PENDING,
+        verbose_name="Status",
+    )
+    attempts = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Attempts",
+    )
+    last_error = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        verbose_name="Last Error",
+    )
+    created_at = models.DateTimeField(
+        blank=True,
+        null=True,
+        verbose_name="Created At",
+    )
+    processed_at = models.DateTimeField(
+        blank=True,
+        null=True,
+        verbose_name="Processed At",
+    )
+
+    class Meta:
+        managed = True
+        db_table = "trial_sync_queue"
+        ordering = ("id",)
+        verbose_name = "Trial Sync Task"
+        verbose_name_plural = "Trial Sync Tasks"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {self.action} #{self.application_id}"
+
+    def __str__(self) -> str:
+        return f"{self.get_action_display()} on #{self.application_id} ({self.status})"

--- a/apps/trials/services.py
+++ b/apps/trials/services.py
@@ -1,0 +1,317 @@
+"""
+Immortal Trial state transitions — the only place application state mutates.
+
+Each verb performs the authoritative DB change (status, timestamps, timeline
+comment) and — in the SAME transaction — enqueues the Discord side-effect onto
+the `trial_sync_queue` outbox for the host daemon to replay (transactional
+outbox: the intent commits atomically with the state change). Internal staff
+comments never enqueue: the daemon posts to a channel applicants may read.
+
+Acceptance performs the site's first write to a game-owned `accounts` column:
+a guarded single-column UPDATE granting `immortal_level = IMMORTAL`, never a
+downgrade and never a full-row save.
+"""
+import logging
+
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from apps.accounts.models import Account, ImmortalLevel
+from apps.core.utils.staff import staff_name  # noqa: F401 - shared, re-exported
+from apps.core.utils.text import clean_text
+
+from . import eligibility
+from .models import (
+    OPEN_STATUSES,
+    REVIEW_WINDOW,
+    TrialApplication,
+    TrialComment,
+    TrialCommentKind,
+    TrialStatus,
+    TrialSyncAction,
+    TrialSyncTask,
+    TrialTrack,
+)
+
+log = logging.getLogger(__name__)
+
+CHARACTER_MAX = 64
+PROPOSAL_MAX = 4000
+EXPERIENCE_MAX = 4000
+COMMENT_MAX = 2000
+REASON_MAX = 255
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _now():
+    return timezone.now()
+
+
+def _add_comment(application, kind, author, body, is_internal=False) -> TrialComment:
+    return TrialComment.objects.create(
+        application=application,
+        kind=kind,
+        is_internal=is_internal,
+        author=author,
+        body=body,
+        created_at=_now(),
+    )
+
+
+def add_system_comment(application, actor, body) -> TrialComment:
+    """Record a state change on the timeline (the audit trail)."""
+    return _add_comment(application, TrialCommentKind.SYSTEM, actor, body)
+
+
+def enqueue(application, action, actor, payload=None) -> None:
+    """Append a Discord side-effect intent to the outbox, inside the action's
+    transaction, so delivery intent commits atomically with the state change."""
+    TrialSyncTask.objects.create(
+        application=application,
+        action=action,
+        actor=actor,
+        payload=payload or {},
+        created_at=_now(),
+    )
+
+
+def _validate_fields(data) -> dict:
+    """Validate and sanitize the application form fields (submit + resubmit)."""
+    character_name = clean_text(data.get("character_name"), CHARACTER_MAX)
+    track = data.get("track")
+    proposal = clean_text(data.get("proposal"), PROPOSAL_MAX)
+    experience = clean_text(data.get("experience"), EXPERIENCE_MAX)
+    if not character_name:
+        raise ValidationError("Which character are you known by?")
+    if track not in TrialTrack:
+        raise ValidationError("Pick a track: Zoner or Coder.")
+    if not proposal:
+        raise ValidationError("A project proposal is required.")
+    if not data.get("ack_ai_policy"):
+        raise ValidationError(
+            "You must acknowledge the original-work policy for trial writing."
+        )
+    if not data.get("ack_commitment"):
+        raise ValidationError(
+            "You must acknowledge the time and communication commitment."
+        )
+    return {
+        "character_name": character_name,
+        "track": track,
+        "proposal": proposal,
+        "experience": experience,
+        "ack_ai_policy": True,
+        "ack_commitment": True,
+    }
+
+
+def _applicant_name(account) -> str:
+    """Attribution for applicant-authored timeline entries."""
+    application = account.trial_applications.order_by("-id").first()
+    if application and application.character_name:
+        return application.character_name
+    return account.get_username()
+
+
+# --------------------------------------------------------------------------- #
+# Applicant actions
+# --------------------------------------------------------------------------- #
+
+def submit(account, data) -> TrialApplication:
+    """Create a new application and start the 7-day review clock."""
+    fields = _validate_fields(data)
+    if TrialApplication.objects.filter(
+        account=account, status__in=OPEN_STATUSES
+    ).exists():
+        raise ValidationError("You already have an open application.")
+    now = _now()
+    try:
+        with transaction.atomic():
+            application = TrialApplication.objects.create(
+                account=account,
+                status=TrialStatus.SUBMITTED,
+                open_slot=account.account_id,
+                submitted_at=now,
+                due_at=now + REVIEW_WINDOW,
+                **fields,
+            )
+            add_system_comment(
+                application, fields["character_name"], "Application submitted."
+            )
+            payload = {
+                "track": fields["track"],
+                "character_name": fields["character_name"],
+                **eligibility.check(account).as_payload(),
+            }
+            enqueue(
+                application,
+                TrialSyncAction.SUBMITTED,
+                fields["character_name"],
+                payload,
+            )
+    except IntegrityError:
+        # The open_slot unique constraint caught a double-submit race.
+        raise ValidationError("You already have an open application.")
+    return application
+
+
+def resubmit(application, account, data) -> TrialApplication:
+    """Revise a sent-back application; restarts the 7-day review clock."""
+    if application.account_id != account.account_id:
+        raise ValidationError("This is not your application.")
+    if application.status != TrialStatus.NEEDS_REVISION:
+        raise ValidationError("This application is not awaiting revision.")
+    fields = _validate_fields(data)
+    now = _now()
+    with transaction.atomic():
+        for name, value in fields.items():
+            setattr(application, name, value)
+        application.status = TrialStatus.SUBMITTED
+        application.submitted_at = now
+        application.due_at = now + REVIEW_WINDOW
+        application.revision_count += 1
+        application.save(update_fields=(
+            *fields, "status", "submitted_at", "due_at", "revision_count",
+        ))
+        add_system_comment(
+            application, fields["character_name"], "Revised and resubmitted."
+        )
+        payload = {
+            "track": fields["track"],
+            "character_name": fields["character_name"],
+            **eligibility.check(account).as_payload(),
+        }
+        enqueue(
+            application,
+            TrialSyncAction.RESUBMITTED,
+            fields["character_name"],
+            payload,
+        )
+    return application
+
+
+def applicant_reply(application, account, text) -> str:
+    """Applicant posts to the thread while the application is open."""
+    if application.account_id != account.account_id:
+        raise ValidationError("This is not your application.")
+    if not application.is_open():
+        raise ValidationError("This application is closed.")
+    text = clean_text(text, COMMENT_MAX)
+    if not text:
+        raise ValidationError("A reply cannot be empty.")
+    author = _applicant_name(account)
+    with transaction.atomic():
+        _add_comment(application, TrialCommentKind.APPLICANT, author, text)
+        enqueue(application, TrialSyncAction.REPLY, author, {"text": text})
+    return "Reply posted."
+
+
+def withdraw(application, account) -> str:
+    """Applicant withdraws an open application, freeing the open slot."""
+    if application.account_id != account.account_id:
+        raise ValidationError("This is not your application.")
+    if not application.is_open():
+        raise ValidationError("This application is already closed.")
+    author = _applicant_name(account)
+    with transaction.atomic():
+        application.status = TrialStatus.WITHDRAWN
+        application.open_slot = None
+        application.decided_at = _now()
+        application.save(update_fields=("status", "open_slot", "decided_at"))
+        add_system_comment(application, author, "Application withdrawn.")
+        enqueue(application, TrialSyncAction.WITHDRAWN, author)
+    return "Application withdrawn."
+
+
+# --------------------------------------------------------------------------- #
+# Staff actions
+# --------------------------------------------------------------------------- #
+
+def staff_comment(application, actor, text, internal=False) -> str:
+    """Staff comment — applicant-facing by default, or internal-only."""
+    text = clean_text(text, COMMENT_MAX)
+    if not text:
+        raise ValidationError("A comment cannot be empty.")
+    with transaction.atomic():
+        _add_comment(
+            application, TrialCommentKind.STAFF, actor, text, is_internal=internal
+        )
+        # Internal notes never reach the outbox: the daemon posts to Discord,
+        # where the applicant may be reading.
+        if not internal:
+            enqueue(application, TrialSyncAction.COMMENT, actor, {"text": text})
+    kind = "Internal note" if internal else "Comment"
+    return f"{kind} added to application #{application.pk}."
+
+
+def send_back(application, actor, note) -> str:
+    """Send back for revision — unlocks the form for the applicant."""
+    note = clean_text(note, COMMENT_MAX)
+    if not note:
+        raise ValidationError(
+            "A revision request needs a note telling the applicant what to fix."
+        )
+    if application.status == TrialStatus.NEEDS_REVISION:
+        return f"Application #{application.pk} is already awaiting revision."
+    if not application.is_open():
+        raise ValidationError("This application has already been decided.")
+    with transaction.atomic():
+        application.status = TrialStatus.NEEDS_REVISION
+        application.save(update_fields=("status",))
+        add_system_comment(application, actor, f"Needs revision: {note}")
+        enqueue(application, TrialSyncAction.NEEDS_REVISION, actor, {"note": note})
+    return f"Application #{application.pk} sent back for revision."
+
+
+def reject(application, actor, reason) -> str:
+    """Reject with a required reason (shown to the applicant)."""
+    reason = clean_text(reason, REASON_MAX)
+    if not reason:
+        raise ValidationError("A rejection requires a reason.")
+    if not application.is_open():
+        raise ValidationError("This application has already been decided.")
+    with transaction.atomic():
+        application.status = TrialStatus.REJECTED
+        application.rejection_reason = reason
+        application.decided_by = actor
+        application.decided_at = _now()
+        application.open_slot = None
+        application.save(update_fields=(
+            "status", "rejection_reason", "decided_by", "decided_at", "open_slot",
+        ))
+        add_system_comment(application, actor, f"Rejected: {reason}")
+        enqueue(application, TrialSyncAction.REJECTED, actor, {"reason": reason})
+    return f"Application #{application.pk} rejected."
+
+
+def accept(application, actor) -> str:
+    """Accept — and grant Immortal (Trial) rank if the account has none."""
+    if not application.is_open():
+        raise ValidationError("This application has already been decided.")
+    with transaction.atomic():
+        application.status = TrialStatus.ACCEPTED
+        application.decided_by = actor
+        application.decided_at = _now()
+        application.open_slot = None
+        application.save(update_fields=(
+            "status", "decided_by", "decided_at", "open_slot",
+        ))
+        # First site-side write to a game-owned accounts column (the table is
+        # managed = False). Guarded single-column queryset UPDATE only — never
+        # account.save(), which would rewrite every game-owned field — and
+        # never a downgrade: 0/None -> IMMORTAL only. An account already
+        # holding a rank is accepted without touching the column.
+        granted = bool(Account.objects.filter(
+            Q(immortal_level__isnull=True) | Q(immortal_level=ImmortalLevel.NONE),
+            pk=application.account_id,
+        ).update(immortal_level=ImmortalLevel.IMMORTAL))
+        add_system_comment(application, actor, "Accepted — welcome to the trial.")
+        if granted:
+            add_system_comment(application, actor, "Granted Immortal (Trial) rank.")
+        enqueue(application, TrialSyncAction.ACCEPTED, actor, {"granted": granted})
+    return f"Application #{application.pk} accepted."

--- a/apps/trials/templates/trial_application.html
+++ b/apps/trials/templates/trial_application.html
@@ -1,0 +1,185 @@
+{% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Trial Application{% endblock meta_title %}
+{% block meta_description %}Your {{ WEBSITE_TITLE }} Immortal Trial application.{% endblock meta_description %}
+{% block meta_url %}{% url 'trial_application' %}#application{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Trial Application{% endblock title %}
+{% block scripts %}let focusTo = 'application'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Immortal Trial" "stars" urlname="trials" anchor="trials" %}
+    {% crumb "Your Application" "envelope-paper" urlname="trial_application" anchor="application" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac ac--wide">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi application.track_icon %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title"><span id="application">Your Trial Application</span></h2>
+            <p class="ac-hero__sub">
+                {{ application.get_track_display }} track · submitted
+                {{ application.submitted_at|naturaltime }}
+                {% if application.revision_count %} · revision {{ application.revision_count }}{% endif %}
+            </p>
+        </div>
+        <div class="ac-hero__status d-flex flex-wrap gap-1 justify-content-end">
+            <span class="ac-pill ac-pill--status ac-pill--{{ application.status_pill }}" id="status-badge">{{ application.status_label }}</span>
+{% if application.is_submitted %}
+{% if application.is_overdue %}
+            <span class="ac-pill ac-pill--warn" title="Staff aim to review within seven days">review running long</span>
+{% else %}
+            <span class="ac-pill ac-pill--muted" title="{{ application.due_at }}">review {{ application.due_label }}</span>
+{% endif %}
+{% endif %}
+        </div>
+    </header>
+
+{% if application.is_accepted %}
+    <div class="ac-note ac-note--ok" role="status">
+        {% bi "stars" %}
+        <span><strong>Accepted — welcome to the trial.</strong> Senior staff will
+        reach out to scope your first project. Log in to the game to get started.</span>
+    </div>
+{% elif application.is_rejected %}
+    <div class="ac-note ac-note--danger" role="status">
+        {% bi "x-circle" %}
+        <span><strong>Not this time:</strong> {{ application.rejection_reason }}
+        You're welcome to apply again next season.</span>
+    </div>
+{% elif application.is_needs_revision %}
+    <div class="ac-note ac-note--warn" role="status">
+        {% bi "arrow-counterclockwise" %}
+        <span><strong>Revision requested</strong> — read the feedback below, then
+        revise and resubmit. The review clock restarts when you do.</span>
+    </div>
+{% endif %}
+
+    <div class="row g-3">
+
+        {# ---- Left: application + timeline -------------------------------- #}
+        <div class="col-lg-8 d-flex flex-column gap-3">
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "file-earmark-text" %} Application</div>
+                <dl class="ac-kv">
+                    <dt>Character</dt><dd>{{ application.character_name }}</dd>
+                    <dt>Track</dt><dd>{{ application.get_track_display }}</dd>
+                </dl>
+                <div class="ac-label mt-2">Project proposal</div>
+                <pre class="ac-quote">{{ application.proposal }}</pre>
+{% if application.experience %}
+                <div class="ac-label mt-2">Experience</div>
+                <pre class="ac-quote">{{ application.experience }}</pre>
+{% endif %}
+            </div>
+
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "chat-left-text" %} Timeline</div>
+                <div class="ac-timeline">
+{% for comment in timeline %}
+                    <div class="ac-tl{% if comment.is_system %} ac-tl--system{% endif %}">
+                        <span class="ac-tl__icon" title="{{ comment.get_kind_display }}">
+                            {% bi comment.kind_icon label=comment.get_kind_display %}
+                        </span>
+                        <div class="ac-tl__body">
+                            <div class="ac-tl__head">
+                                <span class="ac-tl__author{% if comment.kind == 'staff' %} ac-tl__author--staff{% endif %}">{{ comment.author }}</span>
+{% if comment.kind == 'staff' %}
+                                <span class="ac-pill ac-pill--info">staff</span>
+{% endif %}
+                                <span class="ac-tl__time" title="{{ comment.created_at }}">{{ comment.created_at|naturaltime }}</span>
+                            </div>
+                            <div class="ac-tl__text">{{ comment.body }}</div>
+                        </div>
+                    </div>
+{% empty %}
+                    <div class="ac-empty">
+                        {% bi "chat-left" %}
+                        <span>Nothing here yet.</span>
+                    </div>
+{% endfor %}
+                </div>
+            </div>
+        </div>
+
+        {# ---- Right: actions ----------------------------------------------- #}
+        <div class="col-lg-4 d-flex flex-column gap-3">
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "lightning-charge" %} Actions</div>
+                <div class="d-grid gap-2" id="action-panel">
+                    <div id="action-msg" class="d-none" role="status"></div>
+
+{% if application.is_needs_revision %}
+                    <a class="ac-btn ac-btn--accent" href="{% url 'trial_apply' %}">
+                        {% bi "pencil-square" %} Revise application
+                    </a>
+{% endif %}
+
+{% if application.is_open %}
+                    <div>
+                        <label class="ac-label" for="reply-text">Reply to staff</label>
+                        <textarea class="ac-field" id="reply-text" rows="3"
+                                  placeholder="Questions, updates, context…"></textarea>
+                    </div>
+                    <button class="ac-btn ac-btn--info" data-action="reply">
+                        {% bi "chat-left-text" %} Post reply
+                    </button>
+
+                    <hr class="border-secondary my-1">
+                    <button class="ac-btn ac-btn--danger" data-action="withdraw"
+                            data-confirm="Withdraw your application? This closes it — you'd start over with a fresh one.">
+                        {% bi "x-circle" %} Withdraw application
+                    </button>
+{% else %}
+                    <a class="ac-btn ac-btn--accent" href="{% url 'trials' %}">
+                        {% bi "stars" %} Back to the trial page
+                    </a>
+{% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+{% if application.is_open %}
+<script>
+    const msg = document.getElementById("action-msg")
+
+    function showMsg(text, ok) {
+        msg.textContent = text
+        msg.className = `ac-note ${ok ? "ac-note--ok" : "ac-note--danger"}`
+    }
+
+    async function postAction(action) {
+        const body = new URLSearchParams()
+        const replyText = document.getElementById("reply-text")
+        if (action === "reply" && replyText) body.append("text", replyText.value)
+
+        const resp = await fetch(`/trials/application/${action}/`, {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": "{{ csrf_token }}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: body.toString(),
+        })
+        const data = await resp.json().catch(() => ({ok: false, message: "Server error."}))
+        showMsg(data.message || (data.ok ? "Done." : "Failed."), data.ok)
+        if (data.ok) {
+            // Reload to reflect the new timeline entry and status.
+            setTimeout(() => window.location.reload(), 500)
+        }
+    }
+
+    document.querySelectorAll("#action-panel [data-action]").forEach((el) => {
+        el.addEventListener("click", () => {
+            el.blur()
+            if (el.dataset.confirm && !confirm(el.dataset.confirm)) return
+            postAction(el.dataset.action)
+        })
+    })
+</script>
+{% endif %}
+{% endblock content %}

--- a/apps/trials/templates/trial_application.html
+++ b/apps/trials/templates/trial_application.html
@@ -67,10 +67,10 @@
                     <dt>Track</dt><dd>{{ application.get_track_display }}</dd>
                 </dl>
                 <div class="ac-label mt-2">Project proposal</div>
-                <pre class="ac-quote">{{ application.proposal }}</pre>
+                <pre class="ac-quote">{{ application.proposal|urlize }}</pre>
 {% if application.experience %}
                 <div class="ac-label mt-2">Experience</div>
-                <pre class="ac-quote">{{ application.experience }}</pre>
+                <pre class="ac-quote">{{ application.experience|urlize }}</pre>
 {% endif %}
             </div>
 
@@ -90,7 +90,7 @@
 {% endif %}
                                 <span class="ac-tl__time" title="{{ comment.created_at }}">{{ comment.created_at|naturaltime }}</span>
                             </div>
-                            <div class="ac-tl__text">{{ comment.body }}</div>
+                            <div class="ac-tl__text">{{ comment.body|urlize }}</div>
                         </div>
                     </div>
 {% empty %}

--- a/apps/trials/templates/trial_apply.html
+++ b/apps/trials/templates/trial_apply.html
@@ -1,0 +1,177 @@
+{% extends "layout.html" %}
+{% load ishar %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Trial Application{% endblock meta_title %}
+{% block meta_description %}Apply for the {{ WEBSITE_TITLE }} Immortal Trial.{% endblock meta_description %}
+{% block meta_url %}{% url 'trial_apply' %}#apply{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Trial Application{% endblock title %}
+{% block scripts %}let focusTo = 'apply'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Immortal Trial" "stars" urlname="trials" anchor="trials" %}
+    {% crumb "Apply" "pencil-square" urlname="trial_apply" anchor="apply" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "pencil-square" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title"><span id="apply">{% if application %}Revise your application{% else %}Apply for the Immortal Trial{% endif %}</span></h2>
+            <p class="ac-hero__sub">
+                Pitch a small, guided project — about four weeks of your free
+                time. Staff aim to review within seven days.
+            </p>
+        </div>
+    </header>
+
+{% if application and revision_note %}
+    <div class="ac-note ac-note--warn" role="alert">
+        {% bi "arrow-counterclockwise" %}
+        <span>{{ revision_note }}</span>
+    </div>
+{% endif %}
+
+{% if eligibility and not eligibility.eligible %}
+    <div class="ac-note" role="note">
+        {% bi "person-check" %}
+        <span>The guideline is one full season played and two remorts — you're at
+        {{ eligibility.seasons_played }} season{{ eligibility.seasons_played|pluralize }}
+        and {{ eligibility.best_remorts }} remort{{ eligibility.best_remorts|pluralize }}.
+        You can still apply; use your proposal to make the case.</span>
+    </div>
+{% endif %}
+
+    <form id="trial-form" novalidate>
+        <div class="ac-panel">
+            <div class="ac-panel__h">{% bi "person" %} Who you are</div>
+            <label class="ac-label" for="character_name">Character name</label>
+            <input class="ac-field" id="character_name" name="character_name"
+                   maxlength="{{ caps.character }}" list="character-names" required
+                   value="{{ application.character_name|default:'' }}"
+                   placeholder="The mortal you're known by">
+            <datalist id="character-names">
+{% for name in character_names %}
+                <option value="{{ name }}"></option>
+{% endfor %}
+            </datalist>
+        </div>
+
+        <div class="ac-panel">
+            <div class="ac-panel__h">{% bi "signpost" %} Track</div>
+            <div class="ac-opts">
+                <input class="btn-check" type="radio" name="track" id="track-zoner"
+                       value="zoner" autocomplete="off"
+                       {% if application.track == "zoner" %}checked{% endif %}>
+                <label class="ac-opt" for="track-zoner">
+                    <span class="ac-opt__mark" aria-hidden="true"></span>
+                    {% bi "map" %} Zoner — zone design, quests, lore
+                </label>
+                <input class="btn-check" type="radio" name="track" id="track-coder"
+                       value="coder" autocomplete="off"
+                       {% if application.track == "coder" %}checked{% endif %}>
+                <label class="ac-opt" for="track-coder">
+                    <span class="ac-opt__mark" aria-hidden="true"></span>
+                    {% bi "code-slash" %} Coder — features, scripting, bug fixes
+                </label>
+            </div>
+        </div>
+
+        <div class="ac-panel">
+            <div class="ac-panel__h">{% bi "lightbulb" %} Your trial project</div>
+            <label class="ac-label" for="proposal">
+                What do you want to build? Keep it small — a 3–10 room
+                mini-zone with a quest line and a lore book, or a bug fix /
+                quality-of-life command.
+            </label>
+            <textarea class="ac-field" id="proposal" name="proposal" rows="8"
+                      maxlength="{{ caps.proposal }}" required
+                      placeholder="The project, why it fits the game, and roughly how you'd spend the four weeks…">{{ application.proposal|default:'' }}</textarea>
+            <label class="ac-label mt-3" for="experience">
+                Relevant experience <span class="text-secondary">(optional)</span>
+            </label>
+            <textarea class="ac-field" id="experience" name="experience" rows="4"
+                      maxlength="{{ caps.experience }}"
+                      placeholder="Building, writing, or coding you've done — here or elsewhere">{{ application.experience|default:'' }}</textarea>
+        </div>
+
+        <div class="ac-panel">
+            <div class="ac-panel__h">{% bi "check2-square" %} Acknowledgments</div>
+            <div class="d-flex flex-column gap-2">
+                <div class="ac-note" role="note">
+                    <div class="form-check m-0">
+                        <input class="form-check-input" type="checkbox" id="ack_ai_policy"
+                               name="ack_ai_policy"{% if application.ack_ai_policy %} checked{% endif %}>
+                        <label class="form-check-label" for="ack_ai_policy">
+                            My creative writing for the trial — room descriptions,
+                            quest dialogue, lore — will be my own original work,
+                            not pasted AI output.
+                        </label>
+                    </div>
+                </div>
+                <div class="ac-note" role="note">
+                    <div class="form-check m-0">
+                        <input class="form-check-input" type="checkbox" id="ack_commitment"
+                               name="ack_commitment"{% if application.ack_commitment %} checked{% endif %}>
+                        <label class="form-check-label" for="ack_commitment">
+                            I can commit the time for a ~4-week guided project,
+                            and if life gets in the way I'll communicate rather
+                            than go quiet.
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="ac-note ac-note--danger" id="form-error" hidden role="alert">
+            {% bi "exclamation-triangle" %}
+            <span id="form-error-text"></span>
+        </div>
+
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+            <button class="ac-cta ac-cta--accent" type="submit" id="form-submit">
+                {% bi "send" %} {% if application %}Resubmit application{% else %}Submit application{% endif %}
+            </button>
+            <a class="ac-btn" href="{% url 'trials' %}">Back to the trial page</a>
+        </div>
+    </form>
+
+</div>
+
+<script>
+    const form = document.getElementById("trial-form")
+    const errorBox = document.getElementById("form-error")
+    const errorText = document.getElementById("form-error-text")
+    const submitBtn = document.getElementById("form-submit")
+
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault()
+        errorBox.hidden = true
+        submitBtn.disabled = true
+        const track = form.querySelector('input[name="track"]:checked')
+        const payload = {
+            character_name: document.getElementById("character_name").value,
+            track: track ? track.value : "",
+            proposal: document.getElementById("proposal").value,
+            experience: document.getElementById("experience").value,
+            ack_ai_policy: document.getElementById("ack_ai_policy").checked,
+            ack_commitment: document.getElementById("ack_commitment").checked,
+        }
+        const resp = await fetch("{% url 'trial_apply_submit' %}", {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": "{{ csrf_token }}",
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+        }).catch(() => null)
+        const data = resp ? await resp.json().catch(() => null) : null
+        if (data && data.ok) {
+            window.location.assign(data.redirect || "{% url 'trial_application' %}")
+            return
+        }
+        errorText.textContent = (data && data.message) || "Submission failed — please try again."  // textContent: no HTML injection
+        errorBox.hidden = false
+        submitBtn.disabled = false
+    })
+</script>
+{% endblock content %}

--- a/apps/trials/templates/trial_review_dashboard.html
+++ b/apps/trials/templates/trial_review_dashboard.html
@@ -1,0 +1,151 @@
+{% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Trial Review{% endblock meta_title %}
+{% block meta_description %}Staff review queue for {{ WEBSITE_TITLE }} Immortal Trial applications.{% endblock meta_description %}
+{% block meta_url %}{% url 'trial_review' %}#review{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Trial Review{% endblock title %}
+{% block scripts %}let focusTo = 'review'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Trial Review" "stars" urlname="trial_review" anchor="review" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac ac--wide">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "stars" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title"><span id="review">Trial Review</span></h2>
+            <p class="ac-hero__sub">
+                Immortal Trial applications — the seven-day review clock is a
+                promise to applicants.
+            </p>
+        </div>
+        <div class="ac-hero__status">
+{% if counts.overdue %}
+            <span class="ac-pill ac-pill--status ac-pill--danger ac-pill--live" title="Applications past the seven-day review window">
+                {{ counts.overdue }} overdue
+            </span>
+{% elif counts.open %}
+            <span class="ac-pill ac-pill--status ac-pill--info" title="Applications awaiting a decision">
+                {{ counts.open }} in review
+            </span>
+{% else %}
+            <span class="ac-pill ac-pill--status ac-pill--ok" title="No applications waiting">
+                queue clear
+            </span>
+{% endif %}
+        </div>
+    </header>
+
+    <!-- Stat tiles -->
+    <div class="ac-tiles">
+        <a class="ac-tile ac-tile--accent{% if current.show == 'open' %} ac-tile--active{% endif %}"
+           href="{% url 'trial_review' %}?show=open">
+            <span class="ac-tile__n">{{ counts.open }}</span>
+            <span class="ac-tile__label">Open</span>
+        </a>
+        <a class="ac-tile {% if counts.overdue %}ac-tile--danger{% else %}ac-tile--muted{% endif %}{% if current.show == 'submitted' %} ac-tile--active{% endif %}"
+           href="{% url 'trial_review' %}?show=submitted">
+            <span class="ac-tile__n">{{ counts.overdue }}</span>
+            <span class="ac-tile__label">Overdue</span>
+        </a>
+        <a class="ac-tile {% if counts.needs_revision %}ac-tile--warn{% else %}ac-tile--muted{% endif %}{% if current.show == 'needs_revision' %} ac-tile--active{% endif %}"
+           href="{% url 'trial_review' %}?show=needs_revision">
+            <span class="ac-tile__n">{{ counts.needs_revision }}</span>
+            <span class="ac-tile__label">Needs Revision</span>
+        </a>
+        <a class="ac-tile {% if counts.accepted %}ac-tile--info{% else %}ac-tile--muted{% endif %}{% if current.show == 'decided' %} ac-tile--active{% endif %}"
+           href="{% url 'trial_review' %}?show=decided">
+            <span class="ac-tile__n">{{ counts.accepted }}</span>
+            <span class="ac-tile__label">Accepted</span>
+        </a>
+    </div>
+
+    <!-- Filters -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "funnel" %} Filters</div>
+        <div class="ac-filter mb-2" role="group" aria-label="Status filter">
+{% for key, label in show_filters %}
+            <a class="ac-chip{% if current.show == key %} ac-chip--active{% endif %}"
+               href="{% querystring show=key page=None %}">{{ label }}</a>
+{% endfor %}
+            <span class="ac-filter__sep" aria-hidden="true"></span>
+            <a class="ac-chip{% if not current.track %} ac-chip--active{% endif %}"
+               href="{% querystring track=None page=None %}">All tracks</a>
+{% for value, label in tracks %}
+            <a class="ac-chip{% if current.track == value %} ac-chip--active{% endif %}"
+               href="{% querystring track=value page=None %}">{{ label }}</a>
+{% endfor %}
+        </div>
+        <form class="d-flex flex-wrap gap-2 align-items-center" method="get" role="search">
+            <input type="hidden" name="show" value="{{ current.show }}">
+{% if current.track %}
+            <input type="hidden" name="track" value="{{ current.track }}">
+{% endif %}
+            <input class="ac-field ac-field--inline flex-grow-1" style="min-width: 12rem;" type="search"
+                   name="q" value="{{ current.q }}" placeholder="Search character, proposal, #id" aria-label="Search">
+            <button class="ac-btn" type="submit">{% bi "search" %} Search</button>
+        </form>
+    </div>
+
+    <!-- Applications -->
+{% if applications %}
+    <div class="ac-rows">
+{% for application in applications %}
+        <div class="ac-row" id="row-{{ application.pk }}">
+            <span class="ac-row__icon" title="{{ application.get_track_display }}">
+                {% bi application.track_icon label=application.get_track_display %}
+            </span>
+            <div class="ac-row__main">
+                <div class="ac-row__title">
+                    <a class="ac-row__link" href="{% url 'trial_review_detail' application.pk %}">
+                        {{ application.character_name }} — {{ application.summary }}
+                    </a>
+                </div>
+                <div class="ac-row__meta">
+                    <span class="mono">#{{ application.pk }}</span>
+                    <span>{{ application.account.account_name }}</span>
+                    <span title="{{ application.submitted_at }}">{{ application.submitted_at|naturaltime }}</span>
+{% if application.revision_count %}
+                    <span title="Resubmitted {{ application.revision_count }} time{{ application.revision_count|pluralize }}">{% bi "arrow-counterclockwise" %} rev {{ application.revision_count }}</span>
+{% endif %}
+{% if application.num_comments %}
+                    <span title="{{ application.num_comments }} timeline entr{{ application.num_comments|pluralize:'y,ies' }}">{% bi "chat-left-text" %} {{ application.num_comments }}</span>
+{% endif %}
+                </div>
+            </div>
+            <div class="ac-row__side">
+                <span class="ac-pill ac-pill--status ac-pill--{{ application.status_pill }}">{{ application.status_label }}</span>
+{% if application.is_submitted %}
+                <span class="ac-pill ac-pill--{% if application.is_overdue %}danger{% else %}muted{% endif %}" title="{{ application.due_at }}">{{ application.due_label }}</span>
+{% endif %}
+                <a class="ac-btn" href="{% url 'trial_review_detail' application.pk %}">Open</a>
+            </div>
+        </div>
+{% endfor %}
+    </div>
+
+{% if is_paginated %}
+    <nav class="ac-pager" aria-label="Application pages">
+{% if page_obj.has_previous %}
+        <a class="ac-btn" href="{% querystring page=page_obj.previous_page_number %}">{% bi "chevron-left" %} Prev</a>
+{% endif %}
+        <span class="ac-pager__info">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+{% if page_obj.has_next %}
+        <a class="ac-btn" href="{% querystring page=page_obj.next_page_number %}">Next {% bi "chevron-right" %}</a>
+{% endif %}
+    </nav>
+{% endif %}
+
+{% else %}
+    <div class="ac-empty">
+        {% bi "inbox" %}
+        <span>No applications match the current filter.</span>
+    </div>
+{% endif %}
+
+</div>
+{% endblock content %}

--- a/apps/trials/templates/trial_review_detail.html
+++ b/apps/trials/templates/trial_review_detail.html
@@ -42,10 +42,10 @@
             <div class="ac-panel">
                 <div class="ac-panel__h">{% bi "file-earmark-text" %} Application</div>
                 <div class="ac-label">Project proposal</div>
-                <pre class="ac-quote">{{ application.proposal }}</pre>
+                <pre class="ac-quote">{{ application.proposal|urlize }}</pre>
 {% if application.experience %}
                 <div class="ac-label mt-2">Experience</div>
-                <pre class="ac-quote">{{ application.experience }}</pre>
+                <pre class="ac-quote">{{ application.experience|urlize }}</pre>
 {% endif %}
             </div>
 
@@ -67,7 +67,7 @@
 {% endif %}
                                 <span class="ac-tl__time" title="{{ comment.created_at }}">{{ comment.created_at|naturaltime }}</span>
                             </div>
-                            <div class="ac-tl__text">{{ comment.body }}</div>
+                            <div class="ac-tl__text">{{ comment.body|urlize }}</div>
                         </div>
                     </div>
 {% empty %}

--- a/apps/trials/templates/trial_review_detail.html
+++ b/apps/trials/templates/trial_review_detail.html
@@ -1,0 +1,234 @@
+{% extends "layout.html" %}
+{% load humanize %}
+{% load ishar %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Trial Application #{{ application.pk }}{% endblock meta_title %}
+{% block meta_description %}Immortal Trial application #{{ application.pk }}.{% endblock meta_description %}
+{% block meta_url %}{% url 'trial_review_detail' application.pk %}{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Trial Application #{{ application.pk }}{% endblock title %}
+{% block scripts %}let focusTo = 'application'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Portal" "person-gear" urlname="portal" anchor="portal" %}
+    {% crumb "Trial Review" "stars" urlname="trial_review" anchor="review" %}
+    <li class="breadcrumb-item active h2" aria-current="page" title="Application #{{ application.pk }}">
+        <span id="application">#{{ application.pk }}</span>
+    </li>
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac ac--wide">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi application.track_icon %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title">#{{ application.pk }} · {{ application.character_name }}</h2>
+            <p class="ac-hero__sub">
+                {{ application.get_track_display }} track ·
+                submitted {{ application.submitted_at|naturaltime }}
+{% if application.revision_count %} · revision {{ application.revision_count }}{% endif %}
+            </p>
+        </div>
+        <div class="ac-hero__status d-flex flex-wrap gap-1 justify-content-end">
+            <span class="ac-pill ac-pill--status ac-pill--{{ application.status_pill }}" id="status-badge">{{ application.status_label }}</span>
+{% if application.is_submitted %}
+            <span class="ac-pill ac-pill--{% if application.is_overdue %}danger{% else %}muted{% endif %}" title="{{ application.due_at }}">{{ application.due_label }}</span>
+{% endif %}
+        </div>
+    </header>
+
+    <div class="row g-3">
+
+        {# ---- Left: application + timeline -------------------------------- #}
+        <div class="col-lg-8 d-flex flex-column gap-3">
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "file-earmark-text" %} Application</div>
+                <div class="ac-label">Project proposal</div>
+                <pre class="ac-quote">{{ application.proposal }}</pre>
+{% if application.experience %}
+                <div class="ac-label mt-2">Experience</div>
+                <pre class="ac-quote">{{ application.experience }}</pre>
+{% endif %}
+            </div>
+
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "chat-left-text" %} Timeline</div>
+                <div class="ac-timeline">
+{% for comment in timeline %}
+                    <div class="ac-tl{% if comment.is_system %} ac-tl--system{% endif %}{% if comment.is_internal %} ac-tl--internal{% endif %}">
+                        <span class="ac-tl__icon" title="{{ comment.get_kind_display }}">
+                            {% bi comment.kind_icon label=comment.get_kind_display %}
+                        </span>
+                        <div class="ac-tl__body">
+                            <div class="ac-tl__head">
+                                <span class="ac-tl__author{% if comment.kind == 'staff' %} ac-tl__author--staff{% endif %}">{{ comment.author }}</span>
+{% if comment.is_internal %}
+                                <span class="ac-pill ac-pill--warn" title="Staff only — the applicant never sees this">internal</span>
+{% elif comment.kind == 'staff' %}
+                                <span class="ac-pill ac-pill--info">staff</span>
+{% endif %}
+                                <span class="ac-tl__time" title="{{ comment.created_at }}">{{ comment.created_at|naturaltime }}</span>
+                            </div>
+                            <div class="ac-tl__text">{{ comment.body }}</div>
+                        </div>
+                    </div>
+{% empty %}
+                    <div class="ac-empty">
+                        {% bi "chat-left" %}
+                        <span>No comments yet.</span>
+                    </div>
+{% endfor %}
+                </div>
+            </div>
+        </div>
+
+        {# ---- Right: metadata + actions ----------------------------------- #}
+        <div class="col-lg-4 d-flex flex-column gap-3">
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "card-list" %} Details</div>
+                <dl class="ac-kv">
+                    <dt>Account</dt><dd>{{ application.account.account_name }}</dd>
+                    <dt>Character</dt><dd>{{ application.character_name }}</dd>
+                    <dt>Track</dt><dd>{{ application.get_track_display }}</dd>
+                    <dt>Submitted</dt><dd title="{{ application.submitted_at }}">{{ application.submitted_at|naturaltime }}</dd>
+                    <dt>Review due</dt><dd title="{{ application.due_at }}">{{ application.due_at|naturaltime }}</dd>
+{% if application.revision_count %}
+                    <dt>Revisions</dt><dd>{{ application.revision_count }}</dd>
+{% endif %}
+{% if application.decided_by %}
+                    <dt>Decided by</dt><dd>{{ application.decided_by }}</dd>
+                    <dt>Decided</dt><dd title="{{ application.decided_at }}">{{ application.decided_at|naturaltime }}</dd>
+{% endif %}
+{% if application.rejection_reason %}
+                    <dt>Reason</dt><dd>{{ application.rejection_reason }}</dd>
+{% endif %}
+{% if prior_applications %}
+                    <dt>Prior</dt>
+                    <dd>{% for prior in prior_applications %}<a href="{% url 'trial_review_detail' prior.pk %}" title="{{ prior.status_label }}">#{{ prior.pk }}</a> {% endfor %}</dd>
+{% endif %}
+                </dl>
+            </div>
+
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "person-check" %} Eligibility</div>
+                <dl class="ac-kv">
+                    <dt>Seasons played</dt>
+                    <dd>{{ eligibility.seasons_played }} {% if eligibility.meets_seasons %}{% bi "check-lg" css="text-success" label="meets" %}{% else %}{% bi "x-lg" css="text-warning" label="below" %}{% endif %}</dd>
+                    <dt>Best remorts</dt>
+                    <dd>{{ eligibility.best_remorts }} {% if eligibility.meets_remorts %}{% bi "check-lg" css="text-success" label="meets" %}{% else %}{% bi "x-lg" css="text-warning" label="below" %}{% endif %}</dd>
+                </dl>
+{% if eligibility.eligible %}
+                <span class="ac-pill ac-pill--ok">meets the guideline</span>
+{% else %}
+                <span class="ac-pill ac-pill--warn" title="A guideline, not a gate — staff judgment applies">below the guideline</span>
+{% endif %}
+            </div>
+
+            <div class="ac-panel">
+                <div class="ac-panel__h">{% bi "lightning-charge" %} Actions</div>
+                <div class="d-grid gap-2" id="action-panel">
+                    <div id="action-msg" class="d-none" role="status"></div>
+
+{% if application.is_open %}
+                    <div>
+                        <label class="ac-label" for="note">Note / reason</label>
+                        <input class="ac-field" id="note"
+                               placeholder="required for Needs Revision & Reject">
+                    </div>
+                    <div class="d-flex flex-wrap gap-1">
+                        <button class="ac-btn ac-btn--warn flex-fill" data-action="needs_revision"
+                                title="Send back for revision — the note is shown to the applicant">
+                            Needs&nbsp;Revision
+                        </button>
+                        <button class="ac-btn ac-btn--danger flex-fill" data-action="reject"
+                                title="Reject — the reason is shown to the applicant">
+                            Reject
+                        </button>
+                    </div>
+                    <button class="ac-btn ac-btn--ok" data-action="accept"
+                            data-confirm="Accept this application?{% if not application.account.is_immortal %} This grants the account Immortal (Trial) rank in the game.{% endif %}">
+                        {% bi "stars" %} Accept
+                    </button>
+{% if not application.account.is_immortal %}
+                    <div class="ac-note" role="note">
+                        {% bi "info-circle" %}
+                        <span>Accepting grants <code>{{ application.account.account_name }}</code>
+                        Immortal (Trial) rank in the game.</span>
+                    </div>
+{% endif %}
+{% else %}
+                    <div class="ac-note" role="note">
+                        {% bi "check2-circle" %}
+                        <span>Decided — the timeline above is the record.</span>
+                    </div>
+{% endif %}
+
+                    <hr class="border-secondary my-1">
+                    <div>
+                        <label class="ac-label" for="comment-text">Comment</label>
+                        <textarea class="ac-field" id="comment-text" rows="3"
+                                  placeholder="Feedback for the applicant, or an internal note…"></textarea>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="comment-internal">
+                        <label class="form-check-label" for="comment-internal"
+                               title="Internal notes never reach the applicant or Discord">
+                            Internal only
+                        </label>
+                    </div>
+                    <button class="ac-btn ac-btn--accent" data-action="comment">
+                        {% bi "chat-left-text" %} Add Comment
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<script>
+    const APPLICATION_ID = {{ application.pk }}
+    const msg = document.getElementById("action-msg")
+
+    function showMsg(text, ok) {
+        msg.textContent = text
+        msg.className = `ac-note ${ok ? "ac-note--ok" : "ac-note--danger"}`
+    }
+
+    async function postAction(action) {
+        const body = new URLSearchParams()
+        const note = document.getElementById("note")
+        const commentText = document.getElementById("comment-text")
+        const internal = document.getElementById("comment-internal")
+        if (note) {
+            body.append("note", note.value)
+            body.append("reason", note.value)
+        }
+        if (action === "comment" && commentText) {
+            body.append("text", commentText.value)
+            if (internal && internal.checked) body.append("internal", "1")
+        }
+
+        const resp = await fetch(`/trials/review/${APPLICATION_ID}/${action}/`, {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": "{{ csrf_token }}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: body.toString(),
+        })
+        const data = await resp.json().catch(() => ({ok: false, message: "Server error."}))
+        showMsg(data.message || (data.ok ? "Done." : "Failed."), data.ok)
+        if (data.ok) {
+            // Reload to reflect the new timeline entry and status.
+            setTimeout(() => window.location.reload(), 500)
+        }
+    }
+
+    document.querySelectorAll("#action-panel [data-action]").forEach((el) => {
+        el.addEventListener("click", () => {
+            el.blur()
+            if (el.dataset.confirm && !confirm(el.dataset.confirm)) return
+            postAction(el.dataset.action)
+        })
+    })
+</script>
+{% endblock content %}

--- a/apps/trials/templates/trials.html
+++ b/apps/trials/templates/trials.html
@@ -1,0 +1,173 @@
+{% extends "layout.html" %}
+{% load ishar %}
+{% block meta_title %}{{ WEBSITE_TITLE }} Immortal Trial{% endblock meta_title %}
+{% block meta_description %}Apply to join the {{ WEBSITE_TITLE }} staff: the Immortal Trial process, tracks, and expectations.{% endblock meta_description %}
+{% block meta_url %}{% url 'trials' %}#trials{% endblock meta_url %}
+{% block title %}{{ WEBSITE_TITLE }} Immortal Trial{% endblock title %}
+{% block scripts %}let focusTo = 'trials'{% endblock scripts %}
+{% block breadcrumbs %}
+    {% crumb "Immortal Trial" "stars" urlname="trials" anchor="trials" active=True %}
+{% endblock breadcrumbs %}
+{% block content %}
+<div class="ac">
+
+    <!-- Hero -->
+    <header class="ac-hero">
+        <span class="ac-hero__badge">{% bi "stars" %}</span>
+        <div class="ac-hero__text">
+            <h2 class="ac-hero__title"><span id="trials">The Immortal Trial</span></h2>
+            <p class="ac-hero__sub">
+                How mortals join the staff: a small, guided project that earns
+                the trust to build {{ WEBSITE_TITLE }}'s world.
+            </p>
+        </div>
+{% if application %}
+        <div class="ac-hero__status">
+            <a class="ac-pill ac-pill--status ac-pill--{{ application.status_pill }} text-decoration-none"
+               href="{% url 'trial_application' %}">{{ application.status_label }}</a>
+        </div>
+{% endif %}
+    </header>
+
+    <!-- What it is -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "signpost-split" %} How it works</div>
+        <p>
+            Ishar is a passion project — nobody here is paid, so everyone's
+            free time matters. The trial isn't there to stifle creativity;
+            it makes sure work gets finished, fits the larger game, and that
+            we can collaborate without burning each other out.
+        </p>
+        <p class="mb-0">
+            You start as an <strong>Immortal (Trial)</strong> with a small,
+            guided project scoped and approved by senior staff — it should
+            complete in about <strong>four weeks</strong>, with leeway for
+            active communication. Deliver it well, take feedback on board, and
+            you progress to a larger <strong>Proven</strong> project, then to
+            <strong>Artisan</strong>: earned autonomy to propose and build
+            passion projects of your own.
+        </p>
+    </div>
+
+    <!-- Tracks -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "signpost" %} Pick a track</div>
+        <div class="ac-grid">
+            <div class="ac-link" role="listitem">
+                <span class="ac-link__icon">{% bi "map" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Zoner</span>
+                    <span class="ac-link__note d-block">
+                        Zone design, writing, lore. Trial: a 3–10 room
+                        mini-zone in an underdeveloped area, a quest line
+                        using existing mechanics, and an in-game lore book.
+                    </span>
+                </span>
+            </div>
+            <div class="ac-link" role="listitem">
+                <span class="ac-link__icon">{% bi "code-slash" %}</span>
+                <span class="ac-link__body">
+                    <span class="ac-link__name">Coder</span>
+                    <span class="ac-link__note d-block">
+                        Code features, scripting, bug fixes. Trial: fix a
+                        small bug, or add / tweak a quality-of-life command.
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Expectations -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "check2-square" %} What we expect</div>
+        <div class="d-flex flex-column gap-2">
+            <div class="ac-note" role="note">
+                {% bi "pencil" %}
+                <span><strong>Original work.</strong> During the trial, all creative
+                writing — room descriptions, quest dialogue, lore — must be your
+                own. Blatantly copy-pasted AI text is rejected outright; learn
+                the craft before leaning on the tool.</span>
+            </div>
+            <div class="ac-note" role="note">
+                {% bi "chat-dots" %}
+                <span><strong>Stay in communication.</strong> Missed deadlines
+                happen — silence doesn't work. If life gets in the way, say so.</span>
+            </div>
+            <div class="ac-note" role="note">
+                {% bi "bullseye" %}
+                <span><strong>Respect the scope.</strong> The failure modes are
+                few and known: expanding scope beyond the agreed project,
+                ignoring guidance, refusing feedback, or going quiet.</span>
+            </div>
+            <div class="ac-note" role="note">
+                {% bi "heart" %}
+                <span><strong>Stay a player.</strong> The best builders keep a
+                pulse on the mortal game — what players enjoy, where the
+                friction is, what's missing.</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Eligibility -->
+    <div class="ac-panel">
+        <div class="ac-panel__h">{% bi "person-check" %} Eligibility</div>
+        <p{% if not user.is_authenticated %} class="mb-0"{% endif %}>
+            To apply you should have been an active player for at least
+            <strong>one full season</strong> and reached
+            <strong>two remorts</strong> on your mortal character. This is a
+            guideline, not a gate — staff review every application on its
+            merits.
+        </p>
+{% if user.is_authenticated and eligibility %}
+        <div class="ac-tiles">
+            <div class="ac-tile {% if eligibility.meets_seasons %}ac-tile--accent{% else %}ac-tile--warn{% endif %}">
+                <span class="ac-tile__n">{{ eligibility.seasons_played }}</span>
+                <span class="ac-tile__label">Season{{ eligibility.seasons_played|pluralize }} played</span>
+            </div>
+            <div class="ac-tile {% if eligibility.meets_remorts %}ac-tile--accent{% else %}ac-tile--warn{% endif %}">
+                <span class="ac-tile__n">{{ eligibility.best_remorts }}</span>
+                <span class="ac-tile__label">Best remorts</span>
+            </div>
+        </div>
+        <p class="mb-0 mt-2">
+{% if eligibility.eligible %}
+            <span class="ac-pill ac-pill--ok">meets the guideline</span>
+{% else %}
+            <span class="ac-pill ac-pill--warn">below the guideline</span>
+            — you can still apply; tell us why in your proposal.
+{% endif %}
+        </p>
+{% endif %}
+    </div>
+
+    <!-- Call to action -->
+    <div class="ac-panel">
+{% if not user.is_authenticated %}
+        <p>Ready to apply? Log in with your game account first.</p>
+        <a class="ac-cta ac-cta--accent" href="{% url 'login' %}?next={% url 'trial_apply' %}">
+            {% bi "box-arrow-in-right" %} Log in to apply
+        </a>
+{% elif application and application.is_submitted %}
+        <p>Your application is in — staff aim to review within seven days.</p>
+        <a class="ac-cta ac-cta--accent" href="{% url 'trial_application' %}">
+            {% bi "envelope-paper" %} View your application
+        </a>
+{% elif application and application.is_needs_revision %}
+        <p>Staff sent your application back with feedback — revise and resubmit when ready.</p>
+        <a class="ac-cta ac-cta--accent" href="{% url 'trial_apply' %}">
+            {% bi "pencil-square" %} Revise your application
+        </a>
+{% else %}
+        <p>Bring creativity and follow-through, and you'll earn the freedom to
+           tell the stories and build the worlds you're here for.</p>
+        <a class="ac-cta ac-cta--accent" href="{% url 'trial_apply' %}">
+            {% bi "stars" %} Apply for the Immortal Trial
+        </a>
+{% if application %}
+        <a class="ac-btn ms-2" href="{% url 'trial_application' %}">Past application</a>
+{% endif %}
+{% endif %}
+    </div>
+
+</div>
+{% endblock content %}

--- a/apps/trials/urls.py
+++ b/apps/trials/urls.py
@@ -1,0 +1,36 @@
+from django.urls import path
+
+from .views import (
+    TrialApplicantActionView,
+    TrialApplicationView,
+    TrialApplySubmitView,
+    TrialApplyView,
+    TrialInfoView,
+    TrialReviewActionView,
+    TrialReviewDashboardView,
+    TrialReviewDetailView,
+)
+
+
+urlpatterns = [
+    path("", TrialInfoView.as_view(), name="trials"),
+    path("apply/", TrialApplyView.as_view(), name="trial_apply"),
+    path("apply/submit/", TrialApplySubmitView.as_view(), name="trial_apply_submit"),
+    path("application/", TrialApplicationView.as_view(), name="trial_application"),
+    path(
+        "application/<str:action>/",
+        TrialApplicantActionView.as_view(),
+        name="trial_applicant_action",
+    ),
+    path("review/", TrialReviewDashboardView.as_view(), name="trial_review"),
+    path(
+        "review/<int:pk>/",
+        TrialReviewDetailView.as_view(),
+        name="trial_review_detail",
+    ),
+    path(
+        "review/<int:pk>/<str:action>/",
+        TrialReviewActionView.as_view(),
+        name="trial_review_action",
+    ),
+]

--- a/apps/trials/views/__init__.py
+++ b/apps/trials/views/__init__.py
@@ -1,0 +1,18 @@
+from .actions import TrialReviewActionView
+from .application import TrialApplicantActionView, TrialApplicationView
+from .apply import TrialApplySubmitView, TrialApplyView
+from .dashboard import TrialReviewDashboardView
+from .detail import TrialReviewDetailView
+from .info import TrialInfoView
+
+
+__all__ = (
+    "TrialApplicantActionView",
+    "TrialApplicationView",
+    "TrialApplySubmitView",
+    "TrialApplyView",
+    "TrialInfoView",
+    "TrialReviewActionView",
+    "TrialReviewDashboardView",
+    "TrialReviewDetailView",
+)

--- a/apps/trials/views/actions.py
+++ b/apps/trials/views/actions.py
@@ -1,0 +1,82 @@
+"""
+Staff action endpoint — one POST per review verb, returned as JSON for the
+detail page's buttons. The whole surface is Eternal-gated; the policy names
+Eternal, Forger, and God as trial reviewers, so no verb needs a higher gate.
+"""
+import json
+import logging
+
+from django.core.exceptions import ValidationError
+from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.generic.base import View
+
+from apps.core.views.mixins import EternalRequiredMixin, NeverCacheMixin
+
+from .. import services
+from ..models import TrialApplication
+
+log = logging.getLogger(__name__)
+
+
+def _run(action, application, actor, data):
+    """Route a verb to its service call. Raises ValidationError on bad input."""
+    if action == "comment":
+        return services.staff_comment(
+            application, actor, data.get("text", ""),
+            internal=bool(data.get("internal")),
+        )
+    if action == "needs_revision":
+        return services.send_back(application, actor, data.get("note", ""))
+    if action == "accept":
+        return services.accept(application, actor)
+    if action == "reject":
+        return services.reject(application, actor, data.get("reason", ""))
+    raise Http404(f"Unknown trial action: {action}")
+
+
+class TrialReviewActionView(EternalRequiredMixin, NeverCacheMixin, View):
+    """Handle a single staff action against one application."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        action = kwargs.get("action")
+        application = get_object_or_404(TrialApplication, pk=kwargs.get("pk"))
+        actor = services.staff_name(request.user)
+
+        # Accept both form-encoded and JSON bodies.
+        if request.content_type and "application/json" in request.content_type:
+            try:
+                data = json.loads(request.body or b"{}")
+            except json.JSONDecodeError:
+                return JsonResponse(
+                    {"ok": False, "message": "Malformed JSON."}, status=400
+                )
+        else:
+            data = request.POST
+
+        try:
+            message = _run(action, application, actor, data)
+        except ValidationError as exc:
+            return JsonResponse(
+                {"ok": False, "message": "; ".join(exc.messages)}, status=400
+            )
+        except Http404:
+            raise
+        except Exception:  # pragma: no cover - surface a clean error, log detail
+            log.exception("trials: action %s on #%s failed", action, application.pk)
+            return JsonResponse(
+                {"ok": False, "message": "The action could not be completed."},
+                status=500,
+            )
+
+        application.refresh_from_db()
+        return JsonResponse({
+            "ok": True,
+            "message": message,
+            "status": application.status,
+            "status_label": application.status_label,
+            "status_css": application.status_css,
+            "status_pill": application.status_pill,
+        })

--- a/apps/trials/views/application.py
+++ b/apps/trials/views/application.py
@@ -1,0 +1,105 @@
+"""
+The applicant's own view of their application: status, the applicant-facing
+timeline, and the reply/withdraw actions. The application is always resolved
+from the session account — no ID travels from the client, so there is no
+cross-account surface at all.
+"""
+import json
+import logging
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ValidationError
+from django.http import Http404, JsonResponse
+from django.views.generic.base import View
+from django.views.generic.detail import DetailView
+
+from apps.core.views.mixins import NeverCacheMixin
+
+from .. import services
+from ..models import OPEN_STATUSES, TrialApplication
+
+log = logging.getLogger(__name__)
+
+
+class TrialApplicationView(LoginRequiredMixin, NeverCacheMixin, DetailView):
+    """Status page for the account's latest application."""
+
+    context_object_name = "application"
+    http_method_names = ("get",)
+    template_name = "trial_application.html"
+
+    def get_object(self, queryset=None):
+        application = (
+            TrialApplication.objects.filter(account=self.request.user)
+            .order_by("-id")
+            .first()
+        )
+        if application is None:
+            raise Http404
+        return application
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["timeline"] = self.object.comments.filter(is_internal=False)
+        return context
+
+
+class TrialApplicantActionView(LoginRequiredMixin, NeverCacheMixin, View):
+    """Applicant actions (reply, withdraw) against their own open application."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        action = kwargs.get("action")
+        application = (
+            TrialApplication.objects.filter(
+                account=request.user, status__in=OPEN_STATUSES
+            )
+            .order_by("-id")
+            .first()
+        )
+        if application is None:
+            raise Http404
+
+        if request.content_type and "application/json" in request.content_type:
+            try:
+                data = json.loads(request.body or b"{}")
+            except json.JSONDecodeError:
+                return JsonResponse(
+                    {"ok": False, "message": "Malformed JSON."}, status=400
+                )
+        else:
+            data = request.POST
+
+        try:
+            if action == "reply":
+                message = services.applicant_reply(
+                    application, request.user, data.get("text", "")
+                )
+            elif action == "withdraw":
+                message = services.withdraw(application, request.user)
+            else:
+                raise Http404(f"Unknown applicant action: {action}")
+        except ValidationError as exc:
+            return JsonResponse(
+                {"ok": False, "message": "; ".join(exc.messages)}, status=400
+            )
+        except Http404:
+            raise
+        except Exception:  # pragma: no cover - surface a clean error, log detail
+            log.exception("trials: applicant action %s on #%s failed",
+                          action, application.pk)
+            return JsonResponse(
+                {"ok": False, "message": "The action could not be completed."},
+                status=500,
+            )
+
+        application.refresh_from_db()
+        return JsonResponse({
+            "ok": True,
+            "message": message,
+            "status": application.status,
+            "status_label": application.status_label,
+            "status_css": application.status_css,
+            "status_pill": application.status_pill,
+        })

--- a/apps/trials/views/apply.py
+++ b/apps/trials/views/apply.py
@@ -1,0 +1,95 @@
+"""
+The application form (first submission and revision) and its JSON submit
+endpoint. One endpoint covers both: if the account's open application is
+awaiting revision, the POST is a resubmit; otherwise it creates a new one.
+"""
+import json
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ValidationError
+from django.http import JsonResponse
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.views.generic.base import TemplateView, View
+
+from apps.core.views.mixins import NeverCacheMixin
+
+from .. import eligibility, services
+from ..models import OPEN_STATUSES, TrialApplication, TrialStatus, TrialTrack
+
+
+def _open_application(account):
+    return (
+        TrialApplication.objects.filter(account=account, status__in=OPEN_STATUSES)
+        .order_by("-id")
+        .first()
+    )
+
+
+class TrialApplyView(LoginRequiredMixin, NeverCacheMixin, TemplateView):
+    """The application form — empty, or prefilled for a revision."""
+
+    http_method_names = ("get",)
+    template_name = "trial_apply.html"
+
+    def get(self, request, *args, **kwargs):
+        application = _open_application(request.user)
+        # An application under review isn't editable — show its status instead.
+        if application and application.status == TrialStatus.SUBMITTED:
+            return redirect("trial_application")
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        user = self.request.user
+        application = _open_application(user)
+        revision_note = None
+        if application:
+            revision_note = (
+                application.comments.filter(
+                    is_internal=False, body__startswith="Needs revision:"
+                )
+                .order_by("-id")
+                .values_list("body", flat=True)
+                .first()
+            )
+        context.update({
+            "application": application,
+            "revision_note": revision_note,
+            "eligibility": eligibility.check(user),
+            "tracks": TrialTrack.choices,
+            "character_names": list(
+                user.players.values_list("name", flat=True).order_by("name")
+            ),
+            "caps": {
+                "character": services.CHARACTER_MAX,
+                "proposal": services.PROPOSAL_MAX,
+                "experience": services.EXPERIENCE_MAX,
+            },
+        })
+        return context
+
+
+class TrialApplySubmitView(LoginRequiredMixin, NeverCacheMixin, View):
+    """JSON submission endpoint — submit or resubmit."""
+
+    http_method_names = ("post",)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            data = json.loads(request.body or b"{}")
+        except json.JSONDecodeError:
+            return JsonResponse(
+                {"ok": False, "message": "Malformed submission."}, status=400
+            )
+        application = _open_application(request.user)
+        try:
+            if application and application.status == TrialStatus.NEEDS_REVISION:
+                services.resubmit(application, request.user, data)
+            else:
+                services.submit(request.user, data)
+        except ValidationError as exc:
+            return JsonResponse(
+                {"ok": False, "message": "; ".join(exc.messages)}, status=400
+            )
+        return JsonResponse({"ok": True, "redirect": reverse("trial_application")})

--- a/apps/trials/views/dashboard.py
+++ b/apps/trials/views/dashboard.py
@@ -1,0 +1,88 @@
+"""
+Trial review dashboard — the Eternal+ queue of applications, overdue first.
+"""
+from django.db.models import Count, Q
+from django.utils import timezone
+from django.views.generic.list import ListView
+
+from apps.core.views.mixins import EternalRequiredMixin, NeverCacheMixin
+
+from ..models import OPEN_STATUSES, TrialApplication, TrialStatus, TrialTrack
+
+
+def _overdue_q():
+    return Q(status=TrialStatus.SUBMITTED, due_at__lt=timezone.now())
+
+
+# Which application subsets the "show" filter exposes.
+SHOW_FILTERS = {
+    "open": Q(status__in=OPEN_STATUSES),
+    "submitted": Q(status=TrialStatus.SUBMITTED),
+    "needs_revision": Q(status=TrialStatus.NEEDS_REVISION),
+    "decided": Q(status__in=(
+        TrialStatus.ACCEPTED, TrialStatus.REJECTED, TrialStatus.WITHDRAWN,
+    )),
+    "all": Q(),
+}
+
+
+class TrialReviewDashboardView(EternalRequiredMixin, NeverCacheMixin, ListView):
+    """Staff-facing list of trial applications with filters and counts."""
+
+    context_object_name = "applications"
+    http_method_names = ("get",)
+    model = TrialApplication
+    paginate_by = 25
+    template_name = "trial_review_dashboard.html"
+
+    def get_queryset(self):
+        params = self.request.GET
+        qs = TrialApplication.objects.select_related("account").annotate(
+            num_comments=Count("comment"),
+        )
+
+        show = params.get("show", "open")
+        qs = qs.filter(SHOW_FILTERS.get(show, SHOW_FILTERS["open"]))
+
+        track = params.get("track")
+        if track in TrialTrack.values:
+            qs = qs.filter(track=track)
+
+        query = (params.get("q") or "").strip()
+        if query:
+            search = (
+                Q(character_name__icontains=query)
+                | Q(proposal__icontains=query)
+            )
+            if query.lstrip("#").isdigit():
+                search |= Q(pk=int(query.lstrip("#")))
+            qs = qs.filter(search)
+
+        # Default model ordering (due_at, -id) floats overdue reviews to the
+        # top of the open queue; decided views read best newest-first.
+        if show in ("decided", "all"):
+            return qs.order_by("-id")
+        return qs
+
+    def get_context_data(self, *, object_list=None, **kwargs):
+        context = super().get_context_data(object_list=object_list, **kwargs)
+        # One round trip for all four tiles instead of four COUNT queries.
+        counts = TrialApplication.objects.aggregate(
+            open=Count("pk", filter=SHOW_FILTERS["open"]),
+            overdue=Count("pk", filter=_overdue_q()),
+            needs_revision=Count("pk", filter=SHOW_FILTERS["needs_revision"]),
+            accepted=Count("pk", filter=Q(status=TrialStatus.ACCEPTED)),
+        )
+        context.update({
+            "tracks": TrialTrack.choices,
+            "show_filters": [
+                (key, key.replace("_", " ").title()) for key in SHOW_FILTERS
+            ],
+            "current": {
+                "show": self.request.GET.get("show", "open"),
+                "track": self.request.GET.get("track", ""),
+                "q": self.request.GET.get("q", ""),
+            },
+            "counts": counts,
+        })
+        return context

--- a/apps/trials/views/detail.py
+++ b/apps/trials/views/detail.py
@@ -1,0 +1,34 @@
+"""
+Trial application detail — the full application, complete timeline (internal
+notes included), live eligibility, and the staff action panel.
+"""
+from django.views.generic.detail import DetailView
+
+from apps.core.views.mixins import EternalRequiredMixin, NeverCacheMixin
+
+from .. import eligibility
+from ..models import TrialApplication
+
+
+class TrialReviewDetailView(EternalRequiredMixin, NeverCacheMixin, DetailView):
+    """Single application with its timeline and available staff actions."""
+
+    context_object_name = "application"
+    http_method_names = ("get",)
+    model = TrialApplication
+    template_name = "trial_review_detail.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("account")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["timeline"] = self.object.comments.all()
+        context["eligibility"] = eligibility.check(self.object.account)
+        # A re-applicant's history is context reviewers need.
+        context["prior_applications"] = (
+            TrialApplication.objects.filter(account=self.object.account)
+            .exclude(pk=self.object.pk)
+            .order_by("-id")
+        )
+        return context

--- a/apps/trials/views/info.py
+++ b/apps/trials/views/info.py
@@ -1,0 +1,26 @@
+"""
+Public Immortal Trial page — the policy summary that recruits, plus a
+state-aware call to action for logged-in players.
+"""
+from django.views.generic.base import TemplateView
+
+from .. import eligibility
+from ..models import TrialApplication
+
+
+class TrialInfoView(TemplateView):
+    """What the trial is, what it expects, and how to apply."""
+
+    template_name = "trials.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        user = self.request.user
+        if user.is_authenticated:
+            context["eligibility"] = eligibility.check(user)
+            context["application"] = (
+                TrialApplication.objects.filter(account=user)
+                .order_by("-id")
+                .first()
+            )
+        return context

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -262,8 +262,10 @@ patches. Status: **formalized** (supersedes Bootstrap `.pagination`).
 Stacked entries: round source-icon tile, head line (author — `--staff` renders
 info-blue — pills, right-aligned time), pre-wrapped text. `--system` entries
 recede (deepest surface, dashed border, dim italic text) so human conversation
-stays foreground.
-Used: feedback detail. Status: **formalized.**
+stays foreground. `--internal` marks staff-only entries in a mixed-audience
+timeline (warn left edge — always paired with a warn "internal" pill in the
+head so the marker isn't color-alone).
+Used: feedback detail, trial review detail. Status: **formalized.**
 
 ### `.ac-quote` — verbatim text block
 Monospace `pre` on the deepest surface with a strong left edge — for captured

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -2444,3 +2444,53 @@ game-side de-level restores it live via the same `Admin.Caps` trigger.
 
 **Notes.** Proofs refreshed in `docs/design/admin-hud/` (desktop re-tier,
 player regression eyeballed, 390px dock + who sheet).
+
+## 2026-07-29 — Immortal Trials: application flow, mixed-audience timeline, and the first game-owned column write
+
+**Problem.** The Immortal Trial policy (how mortals join the staff) lived
+only in a PDF. There was no way to apply, no review queue, no record of
+decisions — and no notification when someone did apply.
+
+**Decision.** A new `apps/trials` app, deliberately assembled from the two
+proven halves: the surveys pattern for the player-facing submission (site-
+owned `managed = True` tables, Account FK with `db_constraint=False`, fetch +
+`JsonResponse` POST with validation in `services.py`) and the feedback
+pattern for staff triage (Eternal-gated dashboard/detail, verb services in
+`transaction.atomic()` that mutate state + append a system timeline comment +
+enqueue a transactional-outbox row). Specific calls:
+
+1. **Five states, no draft.** `submitted ⇄ needs_revision`, terminal
+   `accepted / rejected / withdrawn`. "Submitted" *is* under review — the
+   7-day clock (`due_at`, stored) starts at submit and restarts on resubmit.
+   The clock is **display-only** (countdown/overdue pills, overdue-first
+   ordering); no scheduler, no auto-transitions.
+2. **One open application per account**, enforced in services with a DB
+   backstop: MariaDB has no conditional unique constraints, so a nullable
+   `open_slot` column mirrors `account_id` while open (unique; NULLed on
+   terminal transitions, and NULLs never collide).
+3. **A new site-owned outbox** (`trial_sync_queue`), not rows in
+   `feedback_sync_queue` — that table is game/daemon-owned and its action
+   enum is a frozen wire contract. Same column shape so the daemon reuses
+   its drain loop; the model docstring is the contract's source of truth
+   (Discord staff-channel embeds; daemon worker tracked in ishar-mud).
+   Notification is Discord-only: the repo has no email infrastructure and
+   account emails are unverified login credentials.
+4. **Mixed-audience timeline.** One comment model with `kind`
+   (staff/applicant/system) + `is_internal`. The applicant view filters
+   internal entries; internal comments are **never enqueued** to the outbox
+   (the daemon posts where applicants can read). New `.ac-tl--internal`
+   timeline variant (warn left edge + warn pill) marks them for staff.
+5. **Eligibility is a soft check.** Policy guideline (1 full season, 2
+   remorts) computed from `HistoricSeasonStat` + the leaderboard's hardcore
+   Coalesce, shown to both sides as "meets the guideline / below the
+   guideline" — never a gate.
+6. **Acceptance writes `immortal_level`** — the site's first write to a
+   game-owned `accounts` column. Invariant: a guarded single-column queryset
+   UPDATE (`0/None → IMMORTAL` only, never `account.save()`, never a
+   downgrade), atomic with the decision and its outbox row. In-game effect
+   depends on the engine's account reload semantics — verify on prod.
+
+**Notes.** `clean_text` (control/bidi stripping) promoted from feedback's
+private `_clean` to `apps/core/utils/text.py` for both apps. Public `/trials/`
+page carries the policy summary; portal cards + Portal dropdown entries wired
+for both surfaces with `TRIALS_PENDING` / `TRIAL_ATTENTION` badges.

--- a/settings.py
+++ b/settings.py
@@ -155,6 +155,7 @@ INSTALLED_APPS = [
     "apps.SeasonsConfig",
     "apps.SkillsConfig",
     "apps.SurveysConfig",
+    "apps.TrialsConfig",
 #    "daphne",
     "channels",
 ]
@@ -197,6 +198,7 @@ TEMPLATES = [
                 "apps.patchnotes.contexts.patch_notes_unread",
                 "apps.seasons.contexts.current_season",
                 "apps.surveys.contexts.surveys_open",
+                "apps.trials.contexts.trials_badges",
             ],
 #            "libraries": {
 #                "ishar": "apps.core.templatetags"

--- a/urls.py
+++ b/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
     path("season/", include("apps.seasons.urls"), name="season"),
     path("skills/", include("apps.skills.urls"), name="skills"),
     path("surveys/", include("apps.surveys.urls"), name="surveys"),
+    path("trials/", include("apps.trials.urls"), name="trials"),
     path("wiki/", RedirectView.as_view(url=settings.WIKI_URL), name="wiki"),
 ]
 


### PR DESCRIPTION
Implements the complete Immortal Trial intake and review workflow — the process by which mortals apply to join the staff. This is the first site-owned application surface that writes to a game-owned column (`immortal_level`), using a transactional outbox pattern to notify Discord.

## Summary

The Immortal Trial policy (how players earn Immortal rank and join the staff) previously existed only in a PDF with no intake mechanism. This change adds:

1. **Player-facing application flow** (`/trials/apply/`, `/trials/application/`) — submit a small ~4-week project pitch on one of two tracks (Zoner or Coder), with soft eligibility checks (1 season + 2 remorts) displayed as guidance, never enforced.

2. **Staff review queue** (`/trials/review/`) — Eternal-gated dashboard showing applications sorted by overdue status, with a detail view for each application and action buttons (comment, request revision, accept, reject, withdraw).

3. **Mixed-audience timeline** — applicant-facing comments and replies, plus internal staff-only notes, all on a single audit trail. Internal comments never enqueue to Discord.

4. **Transactional outbox** (`TrialSyncTask`) — each state change atomically enqueues a Discord side-effect intent for the host daemon to replay, ensuring delivery intent commits with the state change.

5. **Game-owned column write** — acceptance performs the site's first guarded write to a game-owned table: a single-column UPDATE granting `immortal_level = IMMORTAL`, never a downgrade, never a full-row save.

6. **One-open-application constraint** — enforced via a unique index on `open_slot` (mirrored `account_id` while open, NULLed on terminal transitions; MariaDB has no conditional unique constraints).

## Key Changes

- **New app `apps/trials`** with models for applications, comments, and sync tasks; services for all state transitions; views for applicant and staff surfaces; templates for the public policy page, application form, applicant status view, and staff review dashboard/detail.

- **Models** (`apps/trials/models/`):
  - `TrialApplication` — the intake record with status, timestamps, revision tracking, and decision attribution.
  - `TrialComment` — timeline entries (staff comments, applicant replies, system audit records) with internal-flag and kind (staff/applicant/system).
  - `TrialSyncTask` — outbox for Discord side-effects, with action type and payload.
  - Choice enums for status, track, comment kind, sync action, and sync status.

- **Services** (`apps/trials/services.py`) — all state mutations (submit, resubmit, staff comment, request revision, accept, reject, withdraw, applicant reply) in one place, each atomically updating state and enqueueing the Discord intent in the same transaction.

- **Eligibility check** (`apps/trials/eligibility.py`) — soft guidance (1 season + 2 remorts) computed from game-owned character data, displayed to applicant and reviewers, never enforced.

- **Views**:
  - `TrialInfoView` — public `/trials/` page with policy summary and state-aware call to action.
  - `TrialApplyView` / `TrialApplySubmitView` — form (empty or prefilled for revision) and JSON submit endpoint.
  - `TrialApplicationView` — applicant's own application status and applicant-facing timeline.
  - `TrialApplicantActionView` — applicant actions (reply, withdraw) against their own open application.
  - `TrialReviewDashboardView` — Eternal-gated list with filters (open, submitted, needs_revision, decided, all) and overdue highlighting.
  - `TrialReviewDetailView` — full application, complete timeline (internal notes included), live eligibility, and staff action panel.
  - `TrialReviewActionView` — staff action endpoint (comment, needs_revision, accept, reject) returning JSON for the detail page's buttons.

- **Templates** — public policy page, application form, applicant status view, staff review dashboard, and staff detail view

https://claude.ai/code/session_016wWcC3wjGs8WeU3fUu2dgk