### PR TITLE
Fix trial apply form truncating input to 4 characters

### DIFF
--- a/apps/trials/templates/trial_apply.html
+++ b/apps/trials/templates/trial_apply.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% load ishar %}
+{% load l10n %}
 {% block meta_title %}{{ WEBSITE_TITLE }} Trial Application{% endblock meta_title %}
 {% block meta_description %}Apply for the {{ WEBSITE_TITLE }} Immortal Trial.{% endblock meta_description %}
 {% block meta_url %}{% url 'trial_apply' %}#apply{% endblock meta_url %}
@@ -46,7 +47,7 @@
             <div class="ac-panel__h">{% bi "person" %} Who you are</div>
             <label class="ac-label" for="character_name">Character name</label>
             <input class="ac-field" id="character_name" name="character_name"
-                   maxlength="{{ caps.character }}" list="character-names" required
+                   maxlength="{{ caps.character|unlocalize }}" list="character-names" required
                    value="{{ application.character_name|default:'' }}"
                    placeholder="The mortal you're known by">
             <datalist id="character-names">
@@ -84,13 +85,13 @@
                 quality-of-life command.
             </label>
             <textarea class="ac-field" id="proposal" name="proposal" rows="8"
-                      maxlength="{{ caps.proposal }}" required
+                      maxlength="{{ caps.proposal|unlocalize }}" required
                       placeholder="The project, why it fits the game, and roughly how you'd spend the four weeks…">{{ application.proposal|default:'' }}</textarea>
             <label class="ac-label mt-3" for="experience">
                 Relevant experience <span class="text-secondary">(optional)</span>
             </label>
             <textarea class="ac-field" id="experience" name="experience" rows="4"
-                      maxlength="{{ caps.experience }}"
+                      maxlength="{{ caps.experience|unlocalize }}"
                       placeholder="Building, writing, or coding you've done — here or elsewhere">{{ application.experience|default:'' }}</textarea>
         </div>
 


### PR DESCRIPTION
Relates to #187

### Problem

The first live applicant could only type four characters into the trial application's proposal and experience fields — his application stored as "BROK" / "CODE" and he had to file the real proposal as thread replies. `settings.py` enables `USE_THOUSAND_SEPARATOR`, so the template rendered `maxlength="4,000"`; HTML's non-negative-integer parsing stops at the first non-digit, so every browser silently enforced **maxlength=4**. The reply box has no maxlength, which is why the workaround worked.

### Solution

Render the caps through `|unlocalize` (`{% load l10n %}`) in `trial_apply.html` so numeric HTML attributes are never thousand-grouped. The lesson worth keeping: with `USE_THOUSAND_SEPARATOR` on, any integer interpolated into an HTML attribute needs `unlocalize` — a repo-wide grep confirms this was the only templated `maxlength`. Server-side caps (4,000 chars) were always correct; only browser input was blocked.

### Verification

- Rendered the form through the real template engine with `USE_THOUSAND_SEPARATOR=True` (matching prod): before the fix the attribute renders `4,000`; after, the three attributes assert as `64` / `4000` / `4000`.
- Template compile pass on all trials templates.
- Not run against the live DB — one-attribute template change; the live repro is the applicant's truncated submission.

### Deploy notes

After deploy, send the affected application back with **Needs Revision** so the applicant can paste his full proposal — the form unlocks for editing and his thread replies stay on the timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wWcC3wjGs8WeU3fUu2dgk

---
_Generated by [Claude Code](https://claude.ai/code/session_016wWcC3wjGs8WeU3fUu2dgk)_