### PR TITLE
Connect: open test-server (staging) sessions, gated by the staging beta tier

### DIFF
--- a/apps/connect/consumers.py
+++ b/apps/connect/consumers.py
@@ -7,7 +7,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.conf import settings
 
-from . import tracker
+from . import testserver, tracker
 
 
 logger = logging.getLogger(__name__)
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 # ending the session (a quit — don't fight it with an auto-reconnect loop).
 # 4000-4999 is the private-use range of RFC 6455.
 CLOSE_BRIDGE_FAILURE = 4502
+# The test-server policy refused this connection (beta tier, or the feature
+# is unconfigured). Terminal — the browser must not retry with backoff.
+CLOSE_TEST_FORBIDDEN = 4403
 
 # NUL-prefixed websocket text frames are the bridge's out-of-band control
 # channel (the browser's terminal stream never legitimately starts with NUL).
@@ -100,24 +103,35 @@ class TelnetConsumer(AsyncWebsocketConsumer):
             if user is not None and user.is_authenticated
             else None
         )
+        query = self.scope.get("query_string", b"").decode(
+            "utf-8", errors="replace"
+        )
+        params = parse_qs(query)
+        # `?server=test` dials the staging game instead of prod. The page
+        # only offers the option when the beta policy allows it, but the ws
+        # URL is forgeable — the policy is re-checked below before dialing.
+        self._server = (
+            "test" if (params.get("server") or [""])[0] == "test" else "prod"
+        )
         # States: account id set = waiting for the account prompt;
         # None = guest, already sent, or minting failed — leave manual login.
         # _account_id survives the attempt (auto-select needs it later).
         self._account_id = account_id
         self._autologin_account_id = account_id
+        # Test auto-login resolves the account by email: the staging DB is a
+        # refreshed copy of prod, so the same account may carry a different
+        # account_id there.
+        self._account_email = getattr(user, "email", None)
         self._prompt_tail = ""
         # Auto character select (#178): `ws/connect?character=<name>` names
         # the character this session is for. Only honored after a successful
         # webauth (the game validates ownership too — this is UX, not the
-        # security boundary), and never for guests.
+        # security boundary), and never for guests. Test sessions skip it:
+        # staging's character roster is a snapshot that may not match prod's.
         self._autoselect_name = None
         self._webauth_sent = False
         self._select_tail = ""
-        if account_id is not None:
-            query = self.scope.get("query_string", b"").decode(
-                "utf-8", errors="replace"
-            )
-            params = parse_qs(query)
+        if account_id is not None and self._server == "prod":
             requested = (params.get("character") or [""])[0].strip()
             if 0 < len(requested) <= 15:
                 self._autoselect_name = requested
@@ -145,8 +159,22 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         # which would be indistinguishable from a network drop.
         await self.accept()
 
-        host = getattr(settings, "MUD_HOST", "localhost")
-        port = getattr(settings, "MUD_PORT", 23)
+        if self._server == "test":
+            try:
+                permitted = await database_sync_to_async(testserver.allowed)(
+                    user
+                )
+            except Exception as exc:
+                logger.warning("Test-server policy check failed: %s", exc)
+                permitted = False
+            if not permitted:
+                await self.close(code=CLOSE_TEST_FORBIDDEN)
+                return
+            host = settings.MUD_TEST_HOST
+            port = settings.MUD_TEST_PORT
+        else:
+            host = getattr(settings, "MUD_HOST", "localhost")
+            port = getattr(settings, "MUD_PORT", 23)
 
         try:
             self._reader, self._writer = await asyncio.wait_for(
@@ -237,6 +265,30 @@ class TelnetConsumer(AsyncWebsocketConsumer):
             true_level__gte=dj_settings.MIN_IMMORTAL_LEVEL,
         ).exists()
 
+    def _mint_test_token(self):
+        """Mint a staging auto-login token for this account's staging row.
+
+        The staging game consumes tokens from its own database only, and its
+        accounts table is a refreshed copy of prod — same email, possibly a
+        different account_id. No staging row for the email just raises, and
+        the caller degrades to the manual prompt.
+        """
+        from apps.accounts.models import Account
+
+        from .models import WebLoginToken
+
+        staging_id = (
+            Account.objects.using("staging")
+            .filter(email=self._account_email)
+            .values_list("account_id", flat=True)
+            .first()
+        )
+        if staging_id is None:
+            raise LookupError(
+                f"no staging account for {self._account_email!r}"
+            )
+        return WebLoginToken.mint(staging_id, using="staging")
+
     def _cache_naws(self, frame):
         """Remember the window size from a browser NAWS subnegotiation.
 
@@ -285,13 +337,18 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         from .models import WebLoginToken
 
         try:
-            token = await database_sync_to_async(WebLoginToken.mint)(
-                account_id
-            )
+            if self._server == "test":
+                token = await database_sync_to_async(self._mint_test_token)()
+            else:
+                token = await database_sync_to_async(WebLoginToken.mint)(
+                    account_id
+                )
         except Exception as exc:
-            # E.g. the game-side migration hasn't run yet. Manual login works.
+            # E.g. the game-side migration hasn't run yet, or (test) the
+            # staging copy has no row for this email. Manual login works.
             logger.warning(
-                "Auto-login mint failed for account %s: %s", account_id, exc
+                "Auto-login mint failed for account %s (%s): %s",
+                account_id, self._server, exc,
             )
             return
 

--- a/apps/connect/consumers.py
+++ b/apps/connect/consumers.py
@@ -160,6 +160,8 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         await self.accept()
 
         if self._server == "test":
+            # Advisory-tier re-check (shares the policy's 60s state cache);
+            # the staging game's own login gates are the authority.
             try:
                 permitted = await database_sync_to_async(testserver.allowed)(
                     user
@@ -277,6 +279,8 @@ class TelnetConsumer(AsyncWebsocketConsumer):
 
         from .models import WebLoginToken
 
+        if not self._account_email:
+            raise LookupError("no email on the authenticated account")
         staging_id = (
             Account.objects.using("staging")
             .filter(email=self._account_email)
@@ -345,11 +349,21 @@ class TelnetConsumer(AsyncWebsocketConsumer):
                 )
         except Exception as exc:
             # E.g. the game-side migration hasn't run yet, or (test) the
-            # staging copy has no row for this email. Manual login works.
+            # staging copy has no row for this email. Manual login works —
+            # but on the test server that's a surprise worth explaining:
+            # the account may postdate the last staging refresh, and an old
+            # refresh can even hold a previous password.
             logger.warning(
                 "Auto-login mint failed for account %s (%s): %s",
                 account_id, self._server, exc,
             )
+            if self._server == "test":
+                await self.send(text_data=(
+                    "\r\n\x1b[90m--- Auto-login isn't available on the test"
+                    " server right now - log in with your email and"
+                    " password. Accounts newer than the last test refresh"
+                    " may not exist here yet. ---\x1b[0m\r\n"
+                ))
             return
 
         if self._writer and not self._writer.is_closing():

--- a/apps/connect/consumers.py
+++ b/apps/connect/consumers.py
@@ -268,29 +268,20 @@ class TelnetConsumer(AsyncWebsocketConsumer):
         ).exists()
 
     def _mint_test_token(self):
-        """Mint a staging auto-login token for this account's staging row.
+        """Mint a staging auto-login token, seeding the account if needed.
 
-        The staging game consumes tokens from its own database only, and its
-        accounts table is a refreshed copy of prod — same email, possibly a
-        different account_id. No staging row for the email just raises, and
-        the caller degrades to the manual prompt.
+        The staging game consumes tokens from its own database only, so the
+        account row must exist there too. sync_account() guarantees it: the
+        first test connect copies the prod account (with no characters),
+        later ones refresh the login identity so the current password and
+        beta/ban flags always apply. Any failure raises, and the caller
+        degrades to the manual prompt.
         """
-        from apps.accounts.models import Account
-
         from .models import WebLoginToken
 
         if not self._account_email:
             raise LookupError("no email on the authenticated account")
-        staging_id = (
-            Account.objects.using("staging")
-            .filter(email=self._account_email)
-            .values_list("account_id", flat=True)
-            .first()
-        )
-        if staging_id is None:
-            raise LookupError(
-                f"no staging account for {self._account_email!r}"
-            )
+        staging_id = testserver.sync_account(self._account_email)
         return WebLoginToken.mint(staging_id, using="staging")
 
     def _cache_naws(self, frame):
@@ -349,10 +340,10 @@ class TelnetConsumer(AsyncWebsocketConsumer):
                 )
         except Exception as exc:
             # E.g. the game-side migration hasn't run yet, or (test) the
-            # staging copy has no row for this email. Manual login works —
-            # but on the test server that's a surprise worth explaining:
-            # the account may postdate the last staging refresh, and an old
-            # refresh can even hold a previous password.
+            # account sync/mint against the staging DB failed. Manual login
+            # works — but on the test server that's a surprise worth
+            # explaining, and with the sync down the staging copy of the
+            # password may be stale too.
             logger.warning(
                 "Auto-login mint failed for account %s (%s): %s",
                 account_id, self._server, exc,
@@ -361,8 +352,7 @@ class TelnetConsumer(AsyncWebsocketConsumer):
                 await self.send(text_data=(
                     "\r\n\x1b[90m--- Auto-login isn't available on the test"
                     " server right now - log in with your email and"
-                    " password. Accounts newer than the last test refresh"
-                    " may not exist here yet. ---\x1b[0m\r\n"
+                    " password. ---\x1b[0m\r\n"
                 ))
             return
 

--- a/apps/connect/models/token.py
+++ b/apps/connect/models/token.py
@@ -21,7 +21,7 @@ The flow, and the two rules that make it safe:
 import hashlib
 import secrets
 
-from django.db import connection, models
+from django.db import connections, models
 
 from apps.core.models.unsigned import UnsignedAutoField
 
@@ -71,18 +71,21 @@ class WebLoginToken(models.Model):
         return f"Web login token for account {self.account_id}"
 
     @classmethod
-    def mint(cls, account_id: int) -> str:
+    def mint(cls, account_id: int, using: str = "default") -> str:
         """Mint a token for *account_id* and return the plaintext.
 
         The row stores only the SHA-256; ``expires_at`` is computed **in the
         database** (``NOW() + INTERVAL 90 SECOND``) so the same clock that
         checks the TTL game-side also sets it — no Django/MariaDB timezone or
-        clock-skew coupling. Raises on any DB error (e.g. the game migration
-        has not run yet); the caller degrades to manual login.
+        clock-skew coupling. *using* selects which game's table gets the row —
+        each game only ever consumes tokens from its own database, so a
+        test-server session mints into the ``staging`` alias. Raises on any DB
+        error (e.g. the game migration has not run yet); the caller degrades
+        to manual login.
         """
         token = secrets.token_urlsafe(32)
         token_hash = hashlib.sha256(token.encode("ascii")).hexdigest()
-        with connection.cursor() as cursor:
+        with connections[using].cursor() as cursor:
             cursor.execute(
                 "INSERT INTO web_login_token (token_hash, account_id, expires_at)"
                 " VALUES (%s, %s, NOW() + INTERVAL %s SECOND)",

--- a/apps/connect/static/css/hud.css
+++ b/apps/connect/static/css/hud.css
@@ -524,6 +524,10 @@ button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 .sess-tab--lone .sess-tab__btn { padding-right: 9px; }
 .sess-tab--active { border-color: var(--ac-accent); background: var(--ac-wash); }
 .sess-tab--immortal .sess-tab__name { color: var(--ac-immortal); }
+/* Test-server sessions read amber-and-dashed so nobody mistakes staging for
+   the live game (dashed keeps it distinct from the amber active border). */
+.sess-tab--test { border-style: dashed; border-color: var(--ac-warn); background: var(--ac-warn-wash); }
+.sess-tab--test .sess-tab__name { color: var(--ac-warn); }
 .sess-tab__btn {
     display: inline-flex; align-items: center; gap: 5px;
     padding: 2px 2px 2px 8px; margin: 0; border: 0; background: none;
@@ -564,6 +568,8 @@ button.v-tgt:hover { border-color: rgba(214, 75, 75, .8); }
 .sess-pick__dot { width: .5rem; height: .5rem; border-radius: 50%; flex: none; background: var(--ac-dim); }
 .sess-pick__dot.is-online { background: var(--ac-ok); }
 .sess-pick--immortal .sess-pick__name { color: var(--ac-immortal); }
+.sess-pick--test .sess-pick__name { color: var(--ac-warn); }
+.sess-pick--test .sess-pick__dot { background: var(--ac-warn); }
 .sess-pick__name { font-weight: 700; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sess-pick__meta { font-size: .7rem; color: var(--ac-dim); white-space: nowrap; }
 .sess-note { padding: 6px 10px; font-size: .7rem; color: var(--ac-dim); }

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -528,6 +528,10 @@
     var isMobile = ("ontouchstart" in window) && window.innerWidth < 768;
     var isDemo = new URLSearchParams(location.search).has("demo");
     var isAuthed = {{ user.is_authenticated|yesno:"true,false" }};
+    // Whether this visitor may open a test-server session (the beta-tier
+    // policy in apps/connect/testserver.py; the bridge re-checks it
+    // server-side before dialing, so this only shapes the UI).
+    var TEST_ALLOWED = {{ test_server_allowed|yesno:"true,false" }};
 
     // --- ANSI color theme (all 16 standard colors) ---
     var mudTheme = {
@@ -721,6 +725,7 @@
     var MAX_SESSIONS = 3;
     var BACKOFF_MS = [1000, 2000, 5000, 10000];
     var CLOSE_BRIDGE_FAILURE = 4502;  // matches apps/connect/consumers.py
+    var CLOSE_TEST_FORBIDDEN = 4403;  // test-server policy refusal — terminal
     var SCROLLBACK_MAX = 512 * 1024;
     var CHAT_MAX = 200;               // mirrors hud.js CHAT_MAX
 
@@ -774,8 +779,10 @@
     function createSession(opts) {
         var sess = {
             slot: opts.slot,
+            server: opts.server === "test" ? "test" : "prod",
             charName: opts.character || null,
-            displayName: opts.character || null,
+            displayName: opts.character
+                || (opts.server === "test" ? "Test" : null),
             isImmortal: !!opts.isImmortal,
             echo: false,
             state: "connecting",
@@ -947,7 +954,10 @@
 
             var protocol = location.protocol === "https:" ? "wss:" : "ws:";
             var url = protocol + "//" + location.host + "/ws/connect";
-            if (sess.charName) url += "?character=" + encodeURIComponent(sess.charName);
+            var qs = [];
+            if (sess.charName) qs.push("character=" + encodeURIComponent(sess.charName));
+            if (sess.server === "test") qs.push("server=test");
+            if (qs.length) url += "?" + qs.join("&");
 
             sess.state = "connecting";
             sess.reconnectVisible = false;
@@ -1022,6 +1032,17 @@
                 // restart the backoff ladder instead of climbing it forever.
                 if (sess.openedAt && Date.now() - sess.openedAt > 30000) sess.reconnectAttempt = 0;
                 sess.openedAt = 0;
+                if (event.code === CLOSE_TEST_FORBIDDEN) {
+                    // The bridge refused a test-server session (beta tier
+                    // changed, or the feature is off). Terminal — a retry
+                    // would refuse identically.
+                    sess.quitClean = true;
+                    sess.state = "dead";
+                    sess.reconnectVisible = true;
+                    if (isFocused(sess)) syncFocusUi(); else renderSessionTabs();
+                    sess.term.writeln("\r\n\x1b[1;33m--- The test server is not open to your account right now. ---\x1b[0m");
+                    return;
+                }
                 if (event.code === 1000) {
                     // The game ended the session (e.g. quit) — don't fight a
                     // deliberate exit with an auto-reconnect loop.
@@ -1156,6 +1177,7 @@
             if (lone) tab.classList.add("sess-tab--lone");
             if (isFocused(s)) tab.classList.add("sess-tab--active");
             if (s.isImmortal) tab.classList.add("sess-tab--immortal");
+            if (s.server === "test") tab.classList.add("sess-tab--test");
             if (s.bell) tab.classList.add("sess-tab--bell");
 
             var btn = document.createElement("button");
@@ -1242,7 +1264,7 @@
             sessionStorage.setItem(ROSTER_KEY, JSON.stringify({
                 focused: focusedSession ? focusedSession.slot : null,
                 list: sessions.map(function(s) {
-                    return { slot: s.slot, character: s.charName, isImmortal: s.isImmortal };
+                    return { slot: s.slot, character: s.charName, isImmortal: s.isImmortal, server: s.server };
                 })
             }));
         } catch (e) {}
@@ -1268,7 +1290,8 @@
             var sess = createSession({
                 slot: slot,
                 character: opts && opts.character,
-                isImmortal: opts && opts.isImmortal
+                isImmortal: opts && opts.isImmortal,
+                server: opts && opts.server
             });
             if (!focusedSession) Sessions.focus(sess);
             if (!isDemo) sess.connect();
@@ -1814,6 +1837,13 @@
             ]
         }
     ];
+    // The test-server command only exists for visitors the beta policy
+    // admits — an unlisted binding is fine here because the command itself
+    // would just refuse.
+    if (TEST_ALLOWED) {
+        KEYS_CLIENT[0].rows.splice(1, 0,
+            { cmd: "/test", desc: "Open a session on the test server (staging)" });
+    }
     function keyGroups() {
         var hud = (window.IsharHUD && window.IsharHUD.keyHelp) ? window.IsharHUD.keyHelp() : [];
         return KEYS_TERMINAL.concat(hud, KEYS_CLIENT);
@@ -1854,6 +1884,24 @@
             case "clear":
                 if (focusedSession) focusedSession.term.clear();
                 break;
+            case "test": {
+                if (!TEST_ALLOWED) {
+                    sysln("The test server is not open to your account right now.");
+                    break;
+                }
+                var testOpen = null;
+                sessions.forEach(function(s) {
+                    if (s.server === "test") testOpen = s;
+                });
+                if (testOpen) {
+                    Sessions.focus(testOpen);
+                    break;
+                }
+                var testSess = Sessions.create({ server: "test" });
+                if (testSess) Sessions.focus(testSess);
+                else sysln("Session limit reached — close one first.");
+                break;
+            }
             case "aliases":
                 listAliases();
                 break;
@@ -2482,6 +2530,7 @@
         var chars = (payload && payload.characters) || [];
         if (!chars.length) {
             sessionPopNote("No characters on this account yet.");
+            appendTestPick();
             return;
         }
         chars.forEach(function(c) {
@@ -2516,11 +2565,47 @@
             });
             sessionPop.appendChild(b);
         });
+        appendTestPick();
         if (payload.multiplay_limit != null) {
             sessionPopNote("Season limit: " + payload.multiplay_limit
                 + " at once" + (payload.immortal_account ? " (immortals exempt)" : "")
                 + ". The game has the final say.");
         }
+    }
+
+    // The test-server entry rides the same picker (also /test — guests in an
+    // open beta have no "+" button). One test session at a time.
+    function appendTestPick() {
+        if (!TEST_ALLOWED) return;
+        var open = sessions.some(function(s) { return s.server === "test"; });
+        var b = document.createElement("button");
+        b.type = "button";
+        b.className = "sess-pick sess-pick--test";
+
+        var dot = document.createElement("span");
+        dot.className = "sess-pick__dot";
+        b.appendChild(dot);
+
+        var name = document.createElement("span");
+        name.className = "sess-pick__name";
+        name.textContent = "Test server";
+        b.appendChild(name);
+
+        var meta = document.createElement("span");
+        meta.className = "sess-pick__meta";
+        meta.textContent = "staging";
+        b.appendChild(meta);
+
+        if (open) {
+            b.disabled = true;
+            b.title = "Already open in a session";
+        }
+        b.addEventListener("click", function() {
+            closeSessionPop();
+            var s = Sessions.create({ server: "test" });
+            if (s) Sessions.focus(s);
+        });
+        sessionPop.appendChild(b);
     }
 
     if (sessionAddBtn) {
@@ -2665,7 +2750,8 @@
     if (roster) {
         roster.list.slice(0, MAX_SESSIONS).forEach(function(r) {
             var s = Sessions.create({
-                slot: r.slot, character: r.character, isImmortal: r.isImmortal
+                slot: r.slot, character: r.character, isImmortal: r.isImmortal,
+                server: r.server
             });
             if (s && r.slot === roster.focused) Sessions.focus(s);
         });

--- a/apps/connect/templates/connect.html
+++ b/apps/connect/templates/connect.html
@@ -532,6 +532,7 @@
     // policy in apps/connect/testserver.py; the bridge re-checks it
     // server-side before dialing, so this only shapes the UI).
     var TEST_ALLOWED = {{ test_server_allowed|yesno:"true,false" }};
+    var TEST_TIER = "{{ test_server_tier|escapejs }}";  // open | closed | staff
 
     // --- ANSI color theme (all 16 standard colors) ---
     var mudTheme = {
@@ -750,9 +751,15 @@
         if (pkg === "Char.Status") {
             try {
                 var st = JSON.parse(body);
-                if (st && st.name && sess.displayName !== String(st.name)) {
-                    sess.displayName = String(st.name);
-                    renderSessionTabs();
+                // Test sessions keep the marker in the label: amber alone
+                // can't distinguish the same character on prod vs staging.
+                if (st && st.name) {
+                    var want = (sess.server === "test" ? "Test · " : "")
+                        + String(st.name);
+                    if (sess.displayName !== want) {
+                        sess.displayName = want;
+                        renderSessionTabs();
+                    }
                 }
             } catch (e) {}
         }
@@ -1040,7 +1047,7 @@
                     sess.state = "dead";
                     sess.reconnectVisible = true;
                     if (isFocused(sess)) syncFocusUi(); else renderSessionTabs();
-                    sess.term.writeln("\r\n\x1b[1;33m--- The test server is not open to your account right now. ---\x1b[0m");
+                    sess.term.writeln("\r\n\x1b[1;33m--- The test server is not open to your account right now. If a beta just opened or closed, reload the page. ---\x1b[0m");
                     return;
                 }
                 if (event.code === 1000) {
@@ -1886,7 +1893,9 @@
                 break;
             case "test": {
                 if (!TEST_ALLOWED) {
-                    sysln("The test server is not open to your account right now.");
+                    sysln(TEST_TIER === "closed" && !isAuthed
+                        ? "A closed beta is running — log in to check your test-server access."
+                        : "The test server is not open to your account right now.");
                     break;
                 }
                 var testOpen = null;
@@ -2574,10 +2583,12 @@
     }
 
     // The test-server entry rides the same picker (also /test — guests in an
-    // open beta have no "+" button). One test session at a time.
+    // open beta have no "+" button). One test session at a time: picking it
+    // again just focuses the open one, like /test.
     function appendTestPick() {
         if (!TEST_ALLOWED) return;
-        var open = sessions.some(function(s) { return s.server === "test"; });
+        var open = null;
+        sessions.forEach(function(s) { if (s.server === "test") open = s; });
         var b = document.createElement("button");
         b.type = "button";
         b.className = "sess-pick sess-pick--test";
@@ -2593,15 +2604,14 @@
 
         var meta = document.createElement("span");
         meta.className = "sess-pick__meta";
-        meta.textContent = "staging";
+        meta.textContent = open ? "open — switch"
+            : (TEST_TIER === "open" ? "open beta"
+                : TEST_TIER === "closed" ? "closed beta" : "staff");
         b.appendChild(meta);
 
-        if (open) {
-            b.disabled = true;
-            b.title = "Already open in a session";
-        }
         b.addEventListener("click", function() {
             closeSessionPop();
+            if (open) { Sessions.focus(open); return; }
             var s = Sessions.create({ server: "test" });
             if (s) Sessions.focus(s);
         });
@@ -2758,6 +2768,14 @@
         first = focusedSession;
     }
     if (!first) first = Sessions.create({});
+
+    // Test-server access is invisible unless announced — the picker is behind
+    // "+" (and guests have no "+" at all), so say it once at load.
+    if (TEST_ALLOWED && !isDemo) {
+        sysln(TEST_TIER === "open"
+            ? "An open beta is running on the test server — /test (or the + menu) opens a session there."
+            : "You have test-server access — /test (or the + menu) opens a staging session.");
+    }
 
     // Demo mode (/connect?demo=1): populate the HUD with sample data for design
     // review without a GMCP-enabled server. Skips the live connection.

--- a/apps/connect/testserver.py
+++ b/apps/connect/testserver.py
@@ -13,22 +13,25 @@ Tiers:
 * **Closed beta** — accounts flagged ``beta_tester``, plus staff.
 * **Beta off** (or the staging DB unreachable) — staff only. Failing closed
   costs nothing: the game refuses non-staff logins in those states anyway.
+
+"Staff" here is Artisan+ (``is_artisan``), matching the game gate's
+``IMM_ARTISAN`` floor exactly — the two policies must not drift.
 """
 import logging
 
 from django.conf import settings
 from django.core.cache import cache
 
+from apps.seasons.models.season import GameState
+
 
 logger = logging.getLogger(__name__)
 
-# seasons.game_state values (ishar-mud src/include/constants.h, game_state_t).
-GAME_STATE_OPEN_BETA = 3
-GAME_STATE_CLOSED_BETA = 4
-
 # The staging DB is an internet hop that backs both page renders and every
 # websocket connect — cache the state briefly, including "unreachable" so a
-# down box doesn't cost a 3s connect timeout per request.
+# down box doesn't cost a connect timeout per request. The cache means the
+# policy trails `admin beta` by up to 60s; that's advisory-tier only, since
+# the game re-gates every login itself.
 _CACHE_KEY = "connect.test_server.game_state"
 _CACHE_SECONDS = 60
 _UNREACHABLE = "unreachable"
@@ -53,6 +56,10 @@ def staging_game_state():
             .values_list("game_state", flat=True)
             .first()
         )
+        if state is None:
+            # Reachable but no active season — a mis-refreshed staging DB,
+            # not a down box. Same fail-closed result, different fix.
+            logger.warning("Staging DB reachable but no active season row")
     except Exception as exc:
         logger.warning("Staging game_state lookup failed: %s", exc)
         state = None
@@ -62,15 +69,25 @@ def staging_game_state():
     return state
 
 
+def tier() -> str:
+    """The current access tier: ``open``, ``closed``, or ``staff``."""
+    state = staging_game_state()
+    if state == GameState.OPEN_BETA:
+        return "open"
+    if state == GameState.CLOSED_BETA:
+        return "closed"
+    return "staff"
+
+
 def allowed(user) -> bool:
     """Whether this user may open a test-server session right now."""
     if not enabled():
         return False
-    state = staging_game_state()
-    if state == GAME_STATE_OPEN_BETA:
+    current = tier()
+    if current == "open":
         return True
     if not getattr(user, "is_authenticated", False):
         return False
-    if user.is_eternal():
+    if user.is_artisan():
         return True
-    return state == GAME_STATE_CLOSED_BETA and bool(user.beta_tester)
+    return current == "closed" and bool(user.beta_tester)

--- a/apps/connect/testserver.py
+++ b/apps/connect/testserver.py
@@ -1,0 +1,76 @@
+"""Test-server (staging) access policy for ``/connect``.
+
+The staging game is the authority on who may actually log in — its login
+gates admit beta testers during closed beta and staff only while beta is
+off (ishar-mud, ``server.c``). This module mirrors that policy web-side so
+the page can offer, hide, or refuse the test option *before* dialing, keyed
+off the staging season's persisted ``game_state`` (set in-game with
+``admin beta <open|closed|off>``, saved by ``save_season()``).
+
+Tiers:
+
+* **Open beta** — everyone, guests included.
+* **Closed beta** — accounts flagged ``beta_tester``, plus staff.
+* **Beta off** (or the staging DB unreachable) — staff only. Failing closed
+  costs nothing: the game refuses non-staff logins in those states anyway.
+"""
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+
+logger = logging.getLogger(__name__)
+
+# seasons.game_state values (ishar-mud src/include/constants.h, game_state_t).
+GAME_STATE_OPEN_BETA = 3
+GAME_STATE_CLOSED_BETA = 4
+
+# The staging DB is an internet hop that backs both page renders and every
+# websocket connect — cache the state briefly, including "unreachable" so a
+# down box doesn't cost a 3s connect timeout per request.
+_CACHE_KEY = "connect.test_server.game_state"
+_CACHE_SECONDS = 60
+_UNREACHABLE = "unreachable"
+
+
+def enabled() -> bool:
+    return bool(settings.MUD_TEST_HOST)
+
+
+def staging_game_state():
+    """The staging game's active-season ``game_state``; None if unreachable."""
+    cached = cache.get(_CACHE_KEY)
+    if cached is not None:
+        return None if cached == _UNREACHABLE else cached
+
+    from apps.seasons.models.season import Season
+
+    try:
+        state = (
+            Season.objects.using("staging")
+            .filter(is_active=1)
+            .values_list("game_state", flat=True)
+            .first()
+        )
+    except Exception as exc:
+        logger.warning("Staging game_state lookup failed: %s", exc)
+        state = None
+    cache.set(
+        _CACHE_KEY, _UNREACHABLE if state is None else state, _CACHE_SECONDS
+    )
+    return state
+
+
+def allowed(user) -> bool:
+    """Whether this user may open a test-server session right now."""
+    if not enabled():
+        return False
+    state = staging_game_state()
+    if state == GAME_STATE_OPEN_BETA:
+        return True
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if user.is_eternal():
+        return True
+    return state == GAME_STATE_CLOSED_BETA and bool(user.beta_tester)

--- a/apps/connect/testserver.py
+++ b/apps/connect/testserver.py
@@ -91,3 +91,46 @@ def allowed(user) -> bool:
     if user.is_artisan():
         return True
     return current == "closed" and bool(user.beta_tester)
+
+
+# Login-identity columns refreshed on every test connect. The rest of the
+# row is seeded once and then belongs to staging — gameplay writes stay
+# local, and players/characters are never synced.
+_IDENTITY_FIELDS = ("password", "beta_tester", "immortal_level", "banned_until")
+
+
+def sync_account(email: str) -> int:
+    """Seed or refresh this prod account on staging; return its staging id.
+
+    The unified-account model: one login identity everywhere, separate
+    character sets. The first test connect copies the whole prod accounts
+    row (fresh characters; the referrer id is nulled — it points into
+    prod's id space); after that only the identity columns track prod, so
+    a password change or beta revocation reaches staging the next time the
+    player web-connects. Raises on any failure — including a unique-key
+    collision with a stale staging row after a prod email change, which
+    needs a re-dump or admin cleanup — and the caller degrades to manual
+    login.
+    """
+    from apps.accounts.models import Account
+
+    prod = Account.objects.get(email=email)
+    staging_id = (
+        Account.objects.using("staging")
+        .filter(email=email)
+        .values_list("account_id", flat=True)
+        .first()
+    )
+    if staging_id is not None:
+        Account.objects.using("staging").filter(account_id=staging_id).update(
+            **{f: getattr(prod, f) for f in _IDENTITY_FIELDS}
+        )
+        return staging_id
+
+    values = {
+        f.attname: getattr(prod, f.attname)
+        for f in Account._meta.concrete_fields
+        if not f.primary_key
+    }
+    values["referrer_account_id"] = None
+    return Account.objects.using("staging").create(**values).account_id

--- a/apps/connect/views/connect.py
+++ b/apps/connect/views/connect.py
@@ -2,6 +2,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic.base import TemplateView
 
+from apps.connect import testserver
 from apps.connect.skill_icons import SKILL_ICONS
 
 
@@ -21,4 +22,6 @@ class ConnectView(TemplateView):
         # name). Rendered via {{ ...|json_script }} so it reaches the page as
         # safely-escaped JSON, then handed to IsharHUD.init({skillIcons}).
         ctx["skill_icons"] = SKILL_ICONS
+        # Advisory only — the websocket consumer re-checks before dialing.
+        ctx["test_server_allowed"] = testserver.allowed(self.request.user)
         return ctx

--- a/apps/connect/views/connect.py
+++ b/apps/connect/views/connect.py
@@ -23,5 +23,7 @@ class ConnectView(TemplateView):
         # safely-escaped JSON, then handed to IsharHUD.init({skillIcons}).
         ctx["skill_icons"] = SKILL_ICONS
         # Advisory only — the websocket consumer re-checks before dialing.
+        # The tier shapes client-side copy (announcement, refusal hints).
         ctx["test_server_allowed"] = testserver.allowed(self.request.user)
+        ctx["test_server_tier"] = testserver.tier()
         return ctx

--- a/apps/seasons/models/season.py
+++ b/apps/seasons/models/season.py
@@ -8,6 +8,17 @@ from django.utils.timezone import now
 from .enigma import SeasonalEnigma
 
 
+class GameState(models.IntegerChoices):
+    """The game's ``game_state_t`` (ishar-mud ``src/include/constants.h``) —
+    the one web-side anchor for ``seasons.game_state`` values."""
+
+    NORMAL = 0, "Normal"
+    SEASON_CYCLE = 1, "Season cycle"
+    MAINTENANCE = 2, "Maintenance"
+    OPEN_BETA = 3, "Open beta"
+    CLOSED_BETA = 4, "Closed beta"
+
+
 class Season(models.Model):
     """Ishar season."""
 

--- a/apps/seasons/views/console.py
+++ b/apps/seasons/views/console.py
@@ -19,17 +19,14 @@ from apps.core.utils import webadmin
 from apps.core.utils.staff import staff_name
 from apps.core.views.mixins import GodRequiredMixin, NeverCacheMixin
 
+from ..models.season import GameState
 from ..utils.current import get_current_season
 
 
-# `seasons.game_state` values — the game's enum game_state_t (constants.h).
-GAME_STATES = {
-    0: "Normal",
-    1: "Season cycle (awaiting start)",
-    2: "Maintenance",
-    3: "Open beta",
-    4: "Closed beta",
-}
+# Console display labels over the shared GameState anchor; the cycle state
+# gets an operator-facing hint the generic label lacks.
+GAME_STATES = {s.value: s.label for s in GameState}
+GAME_STATES[GameState.SEASON_CYCLE] = "Season cycle (awaiting start)"
 
 # The automatic season-end countdown events (game-fired; display only here).
 SEASON_END_LADDER = (
@@ -54,8 +51,10 @@ class SeasonConsoleView(GodRequiredMixin, NeverCacheMixin, TemplateView):
         context["game_state_label"] = GAME_STATES.get(
             season.game_state, f"Unknown ({season.game_state})"
         )
-        context["game_state_normal"] = season.game_state == 0
-        context["game_state_mid_cycle"] = season.game_state == 1
+        context["game_state_normal"] = season.game_state == GameState.NORMAL
+        context["game_state_mid_cycle"] = (
+            season.game_state == GameState.SEASON_CYCLE
+        )
         context["season_end_ladder"] = [
             {
                 "days": days,

--- a/settings.example.py
+++ b/settings.example.py
@@ -57,15 +57,6 @@ CACHE_MIDDLEWARE_KEY_PREFIX = f"{DJANGO_CACHE_KEY}_"
 
 # Database(s).
 DATABASES = {
-    # Staging.
-    "staging.isharmud.com": {
-        "ENGINE": "apps.core.backends",
-        "NAME": "ishar_test",
-        "USER": "ishar_test",
-        "PASSWORD": "secret",
-        "HOST": "127.0.0.1",
-        "PORT": 3306
-    },
     # Production
     "isharmud.com": {
         "ENGINE": "apps.core.backends",
@@ -74,9 +65,20 @@ DATABASES = {
         "PASSWORD": "secret",
         "HOST": "127.0.0.1",
         "PORT": 3306
-    }
+    },
+    # The staging game's own MariaDB (test-server bridge). An empty password
+    # just disables the bridge readers gracefully.
+    "staging": {
+        "ENGINE": "apps.core.backends",
+        "NAME": "ishar_test",
+        "USER": "ishar",
+        "PASSWORD": "",
+        "HOST": "staging.isharmud.com",
+        "PORT": 3306,
+        "OPTIONS": {"connect_timeout": 3},
+    },
 }
-DATABASES["default"] = DATABASES[ALLOWED_HOSTS[0]]
+DATABASES["default"] = DATABASES.get(ALLOWED_HOSTS[0], DATABASES["isharmud.com"])
 
 # Default primary key field type.
 DEFAULT_AUTO_FIELD = "apps.core.models.unsigned.UnsignedAutoField"
@@ -254,6 +256,8 @@ HELPTAB = Path(MUD_HOME, "lib/Misc/helptab")
 # MUD connection.
 MUD_HOST = "isharmud.com"
 MUD_PORT = 23
+MUD_TEST_HOST = "staging.isharmud.com"
+MUD_TEST_PORT = 23
 
 # Alignments.
 ALIGNMENTS = {

--- a/settings.example.py
+++ b/settings.example.py
@@ -58,7 +58,7 @@ CACHE_MIDDLEWARE_KEY_PREFIX = f"{DJANGO_CACHE_KEY}_"
 # Database(s).
 DATABASES = {
     # Production
-    "isharmud.com": {
+    "default": {
         "ENGINE": "apps.core.backends",
         "NAME": "ishar",
         "USER": "ishar",
@@ -71,14 +71,13 @@ DATABASES = {
     "staging": {
         "ENGINE": "apps.core.backends",
         "NAME": "ishar_test",
-        "USER": "ishar",
+        "USER": "web_bridge",
         "PASSWORD": "",
         "HOST": "staging.isharmud.com",
         "PORT": 3306,
-        "OPTIONS": {"connect_timeout": 3},
+        "OPTIONS": {"connect_timeout": 3, "read_timeout": 5},
     },
 }
-DATABASES["default"] = DATABASES.get(ALLOWED_HOSTS[0], DATABASES["isharmud.com"])
 
 # Default primary key field type.
 DEFAULT_AUTO_FIELD = "apps.core.models.unsigned.UnsignedAutoField"

--- a/settings.py
+++ b/settings.py
@@ -62,12 +62,13 @@ CACHE_MIDDLEWARE_ALIAS =  DJANGO_CACHE_KEY
 CACHE_MIDDLEWARE_SECONDS = 300
 CACHE_MIDDLEWARE_KEY_PREFIX = f"{DJANGO_CACHE_KEY}_"
 
-# Database(s).
+# Database(s). Fully env-driven — the old hostname-keyed selection is gone
+# (staging has no website; there is one site and it talks to prod).
 DATABASES = {
     # Production. In a container these come from the env (the compose file
     # passes DB_HOST=ishar-db, DB_PASSWORD=<app pw>, etc.); the literals are
     # the non-container defaults.
-    "isharmud.com": {
+    "default": {
         "ENGINE": "apps.core.backends",
         "NAME":     getenv("DB_NAME", "ishar"),
         "USER":     getenv("DB_USER", "ishar"),
@@ -75,24 +76,25 @@ DATABASES = {
         "HOST":     getenv("DB_HOST", "127.0.0.1"),
         "PORT": int(getenv("DB_PORT", 3306))
     },
-    # The staging game's own MariaDB, on the staging box (test-server bridge).
-    # Only the /connect test-server path uses it: the access policy reads the
-    # staging season's game_state, and the telnet consumer mints
-    # web_login_token rows there so auto-login works on staging too. This is
-    # an internet hop that may be down — every reader degrades (policy fails
-    # closed to staff, auto-login falls back to the manual prompt), hence the
-    # short connect_timeout.
+    # The staging game's own MariaDB, on the staging box (test-server bridge,
+    # ishar-mud docs/web_bridge_contracts.md Contract 4). Only the /connect
+    # test-server path uses it: the access policy reads the staging season's
+    # game_state, and the telnet consumer mints web_login_token rows there so
+    # auto-login works on staging too. web_bridge is a least-privilege user
+    # (SELECT seasons/accounts, INSERT web_login_token — grants in the
+    # contract doc). This is an internet hop that may be down — every reader
+    # degrades (policy fails closed to staff, auto-login falls back to the
+    # manual prompt), hence the short timeouts.
     "staging": {
         "ENGINE": "apps.core.backends",
         "NAME":     getenv("TEST_DB_NAME", "ishar_test"),
-        "USER":     getenv("TEST_DB_USER", "ishar"),
+        "USER":     getenv("TEST_DB_USER", "web_bridge"),
         "PASSWORD": getenv("TEST_DB_PASSWORD", ""),
         "HOST":     getenv("TEST_DB_HOST", "staging.isharmud.com"),
         "PORT": int(getenv("TEST_DB_PORT", 3306)),
-        "OPTIONS": {"connect_timeout": 3},
+        "OPTIONS": {"connect_timeout": 3, "read_timeout": 5},
     },
 }
-DATABASES["default"] = DATABASES.get(ALLOWED_HOSTS[0], DATABASES["isharmud.com"])
 
 # Default primary key field type.
 DEFAULT_AUTO_FIELD = "apps.core.models.unsigned.UnsignedAutoField"

--- a/settings.py
+++ b/settings.py
@@ -64,15 +64,6 @@ CACHE_MIDDLEWARE_KEY_PREFIX = f"{DJANGO_CACHE_KEY}_"
 
 # Database(s).
 DATABASES = {
-    # Staging.
-    "staging.isharmud.com": {
-        "ENGINE": "apps.core.backends",
-        "NAME": "ishar_test",
-        "USER": "ishar_test",
-        "PASSWORD": "secret",
-        "HOST": "127.0.0.1",
-        "PORT": 3306
-    },
     # Production. In a container these come from the env (the compose file
     # passes DB_HOST=ishar-db, DB_PASSWORD=<app pw>, etc.); the literals are
     # the non-container defaults.
@@ -83,9 +74,25 @@ DATABASES = {
         "PASSWORD": getenv("DB_PASSWORD", "secret"),
         "HOST":     getenv("DB_HOST", "127.0.0.1"),
         "PORT": int(getenv("DB_PORT", 3306))
-    }
+    },
+    # The staging game's own MariaDB, on the staging box (test-server bridge).
+    # Only the /connect test-server path uses it: the access policy reads the
+    # staging season's game_state, and the telnet consumer mints
+    # web_login_token rows there so auto-login works on staging too. This is
+    # an internet hop that may be down — every reader degrades (policy fails
+    # closed to staff, auto-login falls back to the manual prompt), hence the
+    # short connect_timeout.
+    "staging": {
+        "ENGINE": "apps.core.backends",
+        "NAME":     getenv("TEST_DB_NAME", "ishar_test"),
+        "USER":     getenv("TEST_DB_USER", "ishar"),
+        "PASSWORD": getenv("TEST_DB_PASSWORD", ""),
+        "HOST":     getenv("TEST_DB_HOST", "staging.isharmud.com"),
+        "PORT": int(getenv("TEST_DB_PORT", 3306)),
+        "OPTIONS": {"connect_timeout": 3},
+    },
 }
-DATABASES["default"] = DATABASES[ALLOWED_HOSTS[0]]
+DATABASES["default"] = DATABASES.get(ALLOWED_HOSTS[0], DATABASES["isharmud.com"])
 
 # Default primary key field type.
 DEFAULT_AUTO_FIELD = "apps.core.models.unsigned.UnsignedAutoField"
@@ -274,6 +281,12 @@ HELPTAB = Path(MUD_HOME, "lib/Misc/helptab")
 # Docker network instead of looping out through the public hostname.
 MUD_HOST = getenv("MUD_HOST", "isharmud.com")
 MUD_PORT = int(getenv("MUD_PORT", 23))
+
+# Test server (the staging box's game). Who may open a test session is decided
+# by apps.connect.testserver from the staging season's beta state. An empty
+# MUD_TEST_HOST removes the test option from /connect entirely.
+MUD_TEST_HOST = getenv("MUD_TEST_HOST", "staging.isharmud.com")
+MUD_TEST_PORT = int(getenv("MUD_TEST_PORT", 23))
 
 # Web deploy button (#1754). The God-gated deploy page (/portal/deploy/) POSTs
 # to an endpoint that talks to the host deploy agent over this bind-mounted unix


### PR DESCRIPTION
Closes #192

### Problem

The web connector is the primary way people reach Ishar — several of the ~11 players drive it from phones — but it can only dial prod. Beta testing on `staging.isharmud.com` therefore means asking testers to install a telnet client, which mostly means they won't. `/connect` needs to open sessions on the test server, offered to exactly whoever the current beta tier admits: everyone in open beta, `beta_tester` accounts plus staff in closed beta, staff only otherwise.

### Solution

Sessions gain a server axis. A test session is opened from the "+" picker's **Test server** entry or the `/test` command (guests in an open beta have no "+" button), rides the same websocket bridge with `?server=test`, and renders as an amber **dashed** tab whose "Test ·" label survives GMCP renames — the same character on prod and staging can never look identical. Anyone the policy admits gets a one-line announcement at page load, since an entry behind "+" is otherwise invisible.

The policy (`apps/connect/testserver.py`) reads the staging season's persisted `game_state` — the exact field `admin beta` sets — over a new optional `staging` DB alias, cached 60 s and failing closed to staff-only. It's deliberately advisory: the consumer re-checks before dialing (refusals close with 4403, terminal, no reconnect loop), but the staging game's own login gates are the authority (isharmud/ishar-mud#1899), so a forged URL only ever reaches a login prompt that refuses. The staff floor is Artisan+, mirroring the game's `IMM_ARTISAN` exactly.

The one subtle mechanism: **unified login identity, separate character sets**. Each game consumes `web_login_token` rows only from its own DB, so before minting a staging token the consumer runs `sync_account()`: a first test connect copies the prod accounts row onto staging (fresh seasonal state, no characters — players are never synced; referrer nulled since its id points into prod's id space), and every later connect refreshes only the login-identity columns (`password`, `beta_tester`, `immortal_level`, `banned_until`). Auto-login therefore always works with the player's *current* password, revocations reach the staging gate on the next web connect, and staging-earned account state is never clobbered. Truly sharing one accounts table was rejected: the game writes account currencies during play, so staging sessions (with test-env free leveling active) would mutate real prod essence. Staging heartbeating its state into prod was likewise rejected — it hands the lower-trust box prod write credentials (rationale in ishar-mud `docs/web_bridge_contracts.md` Contract 4).

Housekeeping in the path of the change: `game_state` values now have one web-side anchor (`GameState` IntegerChoices on the seasons model, replacing the season console's hand-copied map), and `DATABASES` drops the dead hostname-keyed selection — there is one site and it talks to prod.

### Test coverage

No test suite exists in this repo. Verified: `py_compile` on all changed Python, `manage.py check` under the real settings, a field-map assertion that every copied `Account` field maps to a real `accounts` column (the unmapped `season_*` columns are NOT NULL DEFAULT 0, so seeded accounts start with fresh seasonal state), template compile under stub settings, `node --check` on the extracted page script, and headless-Chromium screenshots of the picker/tab states (rendered from the real `hud.css`; shared in the working session — this environment can't attach images to the PR). Not verified live (no DB or game reachable from the sandbox): the staging dial, account seed, token consume, and closed-beta flow end-to-end — owner's on-staging test.

### Deploy notes

Game/staging side first (isharmud/ishar-mud#1899), then this. To enable: create the least-privilege `web_bridge` user on the staging MariaDB — `SELECT` on `seasons`, `SELECT, INSERT, UPDATE` on `accounts` (the identity seed/refresh), `INSERT` on `web_login_token`; exact grants in Contract 4 — and set `TEST_DB_PASSWORD` in the prod env. Confirm the staging telnet port (`MUD_TEST_PORT` defaults to 23, but the test compose publishes `${ISHAR_PORT:-9999}`). Everything unset degrades cleanly: staff-only access, manual login. With the sync live, staging re-dumps are only needed for world/character resets, not roster changes. `hud.css` changes are force-added per the `static/` rule, so collectstatic picks them up on deploy.

### Review summary

Exploit, code-quality, architecture, and player-experience passes ran (full findings on #192). Addressed: Artisan/Eternal floor mismatch with the game gate; guest discoverability in open beta (announcement line); silent auto-login degradation (explained in-terminal); empty-email mint guard; `read_timeout` on the staging alias; picker now focuses an open test session like `/test` instead of a disabled button; the staging-refresh drift finding is now largely closed by the account sync (remaining gap: telnet-only players who never web-connect). Deferred: a topbar-level guest affordance beyond the announcement, and passing richer tier detail into refusals. Known edge: a prod **email change** strands the old staging row (unique `account_name` collision on re-seed) — needs a re-dump or admin cleanup; auto-login degrades to manual until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RthQuEUJJnqVce4Frm8UU