### PR TITLE
Clients: add Savitar 2, hide seven dead clients

### DIFF
--- a/apps/clients/migrations/0009_savitar_and_dead_client_pruning.py
+++ b/apps/clients/migrations/0009_savitar_and_dead_client_pruning.py
@@ -1,0 +1,83 @@
+import sys
+
+from django.db import migrations
+from django.db.models import Q
+
+
+# Verified dead as of August 2026 — gone from their store, or unable to run on
+# any OS a player would connect from today:
+#   MUDRammer  — pulled from the App Store by its developer, March 2025
+#   Mukluk     — unpublished from Google Play, December 2024; broken on modern Android
+#   BlowTorch  — abandoned since 2015; delisted, and its target SDK is too old
+#                for Android 14+ to install
+#   MudWalker  — 32-bit; cannot launch on macOS 10.15+ (2019)
+#   zMUD       — unmaintained since ~2009; its successor CMUD is dead too
+#   yTin       — dead since ~2003
+#   Gosclient  — GNOME 1-era; project and site long gone
+DEAD_CLIENTS = (
+    "MUDRammer",
+    "Mukluk",
+    "BlowTorch",
+    "MudWalker",
+    "zMUD",
+    "yTin",
+    "Gosclient",
+)
+
+SAVITAR_NAME = "Savitar"
+SAVITAR_URL = "https://www.heynow.com/savitar/"
+
+
+def _macos_category(MUDClient, MUDClientCategory):
+    # Anchor on a known macOS client so this works whatever the category is
+    # named in the live table; hidden clients still anchor fine.
+    for name in ("Atlantis", "MudWalker"):
+        client = MUDClient.objects.filter(name__iexact=name).first()
+        if client:
+            return client.category
+    return MUDClientCategory.objects.filter(name__icontains="mac").first()
+
+
+def refresh_client_list(apps, schema_editor):
+    MUDClient = apps.get_model("clients", "MUDClient")
+    MUDClientCategory = apps.get_model("clients", "MUDClientCategory")
+
+    dead = Q()
+    for name in DEAD_CLIENTS:
+        dead |= Q(name__iexact=name)
+    MUDClient.objects.filter(dead).update(is_visible=False)
+
+    category = _macos_category(MUDClient, MUDClientCategory)
+    if category is None:
+        print(
+            "WARN: no macOS client category found — add Savitar "
+            f"({SAVITAR_URL}) by hand in the admin.",
+            file=sys.stderr,
+        )
+        return
+    MUDClient.objects.get_or_create(
+        name=SAVITAR_NAME,
+        defaults={"category": category, "url": SAVITAR_URL},
+    )
+
+
+def restore_client_list(apps, schema_editor):
+    MUDClient = apps.get_model("clients", "MUDClient")
+
+    MUDClient.objects.filter(name__iexact=SAVITAR_NAME).delete()
+
+    dead = Q()
+    for name in DEAD_CLIENTS:
+        dead |= Q(name__iexact=name)
+    MUDClient.objects.filter(dead).update(is_visible=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0008_mudclient_featured"),
+    ]
+
+    operations = [
+        migrations.RunPython(refresh_client_list, restore_client_list),
+    ]


### PR DESCRIPTION
Closes #194

### Problem

The clients page recommends software players can no longer get: MUDRammer (pulled from the App Store 3/2025), Mukluk (unpublished from Google Play 12/2024), BlowTorch (abandoned 2015; Android 14+ refuses its target SDK), MudWalker (32-bit, dead since Catalina), zMUD (~2009), yTin (~2003), and Gosclient (GNOME 1-era). Every dead link erodes the "connect in five minutes" pitch for newcomers. Separately, Jay Koutavas (Heynow Software) asked for Savitar to be listed — verified real: a from-scratch Swift rewrite ([jkoutavas/Savitar2](https://github.com/jkoutavas/Savitar2), BSD-3, active as of this week) with signed/notarized builds for macOS 10.12+ including Apple Silicon, distributed from [heynow.com/savitar](https://www.heynow.com/savitar/).

### Solution

A data migration (`clients` 0009), since the list lives only in the shared DB — the entrypoint's `migrate` applies it on the next deploy. Dead clients are hidden via `is_visible`, not deleted, so the rows stay recoverable in the admin. The non-obvious part: the live table's exact contents (category names, spelling) aren't visible from a dev environment, so the migration anchors the macOS category through a known macOS client (Atlantis/MudWalker) instead of guessing a category name, falls back to a `mac` name match, and warns + no-ops if neither exists. All lookups are `iexact` and idempotent; unknown names are skipped, so a drifted live table degrades to "nothing happens" rather than an error. Reverse restores visibility and drops Savitar.

### Verification

- Full `clients` migration chain 0001→0009 applied cleanly against in-memory sqlite (Django 5.2).
- Data functions exercised directly against a simulated live table: forward (Savitar created in the anchored category, dead clients hidden, survivors untouched), rerun (idempotent, no duplicate row), reverse (visibility restored, Savitar removed), and no-anchor (warns on stderr, creates nothing).
- `py_compile` on the migration.
- **Not** run against the live MariaDB — final eyeball of `/clients` after deploy is the owner's on-prod check.

### Deploy notes

No schema change, no static assets — `docker-entrypoint.sh` runs `migrate` on container start, so the data change lands with the next normal deploy. If the log shows the no-macOS-category warning, add Savitar by hand in the admin.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LDvDcVXZKUZZFvodV9iRb

---
_Generated by [Claude Code](https://claude.ai/code/session_014LDvDcVXZKUZZFvodV9iRb)_